### PR TITLE
tp: Trace tracepoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,19 @@ $(LIBPCAP_OBJ):
 $(VMLINUX_OBJ):
 	$(CMD_BPFTOOL) btf dump file /sys/kernel/btf/vmlinux format c > $(VMLINUX_OBJ)
 
-$(BPF_OBJ): $(BPF_SRC) $(VMLINUX_OBJ)
-	$(GOGEN)
+$(FEAT_BPF_OBJ): $(FEAT_BPF_SRC) $(VMLINUX_OBJ)
+	$(BPF2GO) feat bpf/feature.c -- $(BPF2GO_EXTRA_FLAGS)
 
-$(BPFSNOOP_OBJ): $(BPF_OBJ) $(BPFSNOOP_SRC) $(LIBCAPSTONE_OBJ) $(LIBPCAP_OBJ)
+$(TRACEABLE_BPF_OBJ): $(TRACEABLE_BPF_SRC) $(VMLINUX_OBJ)
+	$(BPF2GO) traceable bpf/traceable.c -- $(BPF2GO_EXTRA_FLAGS)
+
+$(TRACEPOINT_BPF_OBJ): $(TRACEPOINT_BPF_SRC) $(VMLINUX_OBJ)
+	$(BPF2GO) tracepoint bpf/tracepoint.c -- $(BPF2GO_EXTRA_FLAGS)
+
+$(BPFSNOOP_BPF_OBJ): $(BPFSNOOP_BPF_SRC) $(VMLINUX_OBJ)
+	$(BPF2GO) bpfsnoop bpf/bpfsnoop.c -- $(BPF2GO_EXTRA_FLAGS)
+
+$(BPFSNOOP_OBJ): $(BPF_OBJS) $(BPFSNOOP_SRC) $(LIBCAPSTONE_OBJ) $(LIBPCAP_OBJ)
 	$(GOBUILD_CGO_CFLAGS) $(GOBUILD_CGO_LDFLAGS) $(GOBUILD)
 
 .PHONY: local_release
@@ -34,7 +43,7 @@ local_release: $(BPFSNOOP_OBJ)
 
 .PHONY: clean
 clean:
-	rm -f $(BPF_OBJ)
+	rm -f $(BPF_OBJS)
 	rm -f $(BPFSNOOP_OBJ)
 	rm -rf $(DIR_BIN)/*
 	@touch $(DIR_BIN)/.gitkeep

--- a/bpf/bpfsnoop.c
+++ b/bpf/bpfsnoop.c
@@ -16,6 +16,8 @@ volatile const __u32 PID = -1;
 
 __u32 ready SEC(".data.ready") = 0;
 
+volatile const __u64 FUNC_IP = 0;
+
 #define MAX_STACK_DEPTH 50
 struct {
     __uint(type, BPF_MAP_TYPE_STACK_TRACE);
@@ -59,17 +61,17 @@ gen_session_id(void)
 }
 
 static __always_inline int
-emit_bpfsnoop_event(void *ctx)
+emit_bpfsnoop_event(void *ctx, volatile __u64 *args, const bool use_args)
 {
     struct bpfsnoop_lbr_data *lbr;
     struct bpfsnoop_str_data *str;
     struct bpfsnoop_pkt_data *pkt;
     struct bpfsnoop_arg_data *arg;
     struct event *evt;
+    __u64 retval = 0;
     __u64 session_id;
     size_t event_sz;
     __u32 cpu, pid;
-    __u64 retval;
 
     if (!ready)
         return BPF_OK;
@@ -95,26 +97,36 @@ emit_bpfsnoop_event(void *ctx)
         return BPF_OK;
 
     session_id = gen_session_id();
-    if (!filter(ctx, session_id))
+    if (!filter(use_args ? (void *) args : ctx, session_id))
         return BPF_OK;
 
     evt->session_id = session_id;
-    bpf_get_func_ret(ctx, (void *) &retval); /* required 5.17 kernel. */
-    evt->func_ret = retval;
-    evt->func_ip = bpf_get_func_ip(ctx); /* required 5.17 kernel. */
+    if (!use_args) {
+        bpf_get_func_ret(ctx, (void *) &retval); /* required 5.17 kernel. */
+        evt->func_ret = retval;
+    }
+    evt->func_ip = FUNC_IP ? FUNC_IP : bpf_get_func_ip(ctx); /* required 5.17 kernel. */
     evt->cpu = cpu;
     evt->pid = pid;
     bpf_get_current_comm(evt->comm, sizeof(evt->comm));
     evt->func_stack_id = -1;
     if (cfg->output_stack)
         evt->func_stack_id = bpf_get_stackid(ctx, &bpfsnoop_stacks, BPF_F_FAST_STACK_CMP);
-    output_fn_data(evt, ctx, (void *) retval, str);
     if (cfg->output_lbr)
         output_lbr_data(lbr, session_id);
-    if (cfg->output_pkt)
-        output_pkt_tuple(ctx, pkt, session_id);
-    if (cfg->output_arg)
-        output_arg_data(ctx, arg, session_id);
+    if (use_args) {
+        output_fn_data_vol(evt, str, args);
+        if (cfg->output_pkt)
+            output_pkt_tuple((void *) args, pkt, session_id);
+        if (cfg->output_arg)
+            output_arg_data((void *) args, arg, session_id);
+    } else {
+        output_fn_data(evt, ctx, (void *) retval, str);
+        if (cfg->output_pkt)
+            output_pkt_tuple(ctx, pkt, session_id);
+        if (cfg->output_arg)
+            output_arg_data(ctx, arg, session_id);
+    }
 
     event_sz  = offsetof(struct event, fn_data);
     event_sz += sizeof(struct bpfsnoop_fn_arg_data) * cfg->fn_args.nr_fn_args;
@@ -126,13 +138,28 @@ emit_bpfsnoop_event(void *ctx)
 SEC("fexit")
 int BPF_PROG(fexit_fn)
 {
-    return emit_bpfsnoop_event(ctx);
+    return emit_bpfsnoop_event(ctx, NULL, false);
 }
 
 SEC("fentry")
 int BPF_PROG(fentry_fn)
 {
-    return emit_bpfsnoop_event(ctx);
+    return emit_bpfsnoop_event(ctx, NULL, false);
+}
+
+static __noinline int
+handle_tp_event(void *ctx, volatile __u64 *args)
+{
+    return emit_bpfsnoop_event(ctx, args, true);
+}
+
+SEC("tp_btf")
+int BPF_PROG(tp_btf_fn)
+{
+    /* This function will be rewrote by Go totally. */
+    volatile __u64 args[MAX_FN_ARGS] = {};
+
+    return handle_tp_event(ctx, args);
 }
 
 char __license[] SEC("license") = "GPL";

--- a/bpf/bpfsnoop_str.h
+++ b/bpf/bpfsnoop_str.h
@@ -27,27 +27,34 @@ struct {
 static __always_inline void
 output_fn_data(struct event *event, void *ctx, void *retval, struct bpfsnoop_str_data *str)
 {
+    const volatile struct bpfsnoop_fn_arg_flags *arg_flags;
+    const volatile struct bpfsnoop_fn_args *arg_cfg;
     bool is_str, is_number_ptr, use_str = false;
+    struct bpfsnoop_fn_arg_data *arg_data;
     __u64 arg;
     __u32 i;
 
+    arg_cfg = &cfg->fn_args;
     for (i = 0; i < MAX_FN_ARGS; i++) {
         if (i >= cfg->fn_args.nr_fn_args)
             break;
 
         (void) bpf_get_func_arg(ctx, i, &arg); /* required 5.17 kernel. */
-        event->fn_data.args[i].raw_data = arg;
+
+        arg_data = &event->fn_data.args[i];
+        arg_data->raw_data = arg;
 
         if (!arg)
             continue;
 
-        is_str = cfg->fn_args.args[i].is_str;
-        is_number_ptr = cfg->fn_args.args[i].is_number_ptr;
+        arg_flags = &arg_cfg->args[i];
+        is_str = arg_flags->is_str;
+        is_number_ptr = arg_flags->is_number_ptr;
         if (is_str) {
             use_str = true;
             (void) bpf_probe_read_kernel_str(&str->arg, sizeof(str->arg), (void *) arg);
         } else if (is_number_ptr) {
-            (void) bpf_probe_read_kernel(&event->fn_data.args[i].ptr_data, sizeof(event->fn_data.args[i].ptr_data), (void *) arg);
+            (void) bpf_probe_read_kernel(&arg_data->ptr_data, sizeof(arg_data->ptr_data), (void *) arg);
         }
     }
 
@@ -64,6 +71,43 @@ static __noinline bool
 filter_fnarg(void *ctx)
 {
     return ctx != NULL;
+}
+
+static __always_inline void
+output_fn_data_vol(struct event *event, struct bpfsnoop_str_data *str, volatile __u64 *args)
+{
+    const volatile struct bpfsnoop_fn_arg_flags *arg_flags;
+    const volatile struct bpfsnoop_fn_args *arg_cfg;
+    bool is_str, is_number_ptr, use_str = false;
+    struct bpfsnoop_fn_arg_data *arg_data;
+    __u64 arg;
+    __u32 i;
+
+    arg_cfg = &cfg->fn_args;
+    for (i = 0; i < MAX_FN_ARGS; i++) {
+        if (i >= arg_cfg->nr_fn_args)
+            break;
+
+        arg = args[i];
+        arg_data = &event->fn_data.args[i];
+        arg_data->raw_data = arg;
+
+        if (!arg)
+            continue;
+
+        arg_flags = &arg_cfg->args[i];
+        is_str = arg_flags->is_str;
+        is_number_ptr = arg_flags->is_number_ptr;
+        if (is_str) {
+            use_str = true;
+            (void) bpf_probe_read_kernel_str(&str->arg, sizeof(str->arg), (void *) arg);
+        } else if (is_number_ptr) {
+            (void) bpf_probe_read_kernel(&arg_data->ptr_data, sizeof(arg_data->ptr_data), (void *) arg);
+        }
+    }
+
+    if (use_str)
+        (void) bpf_map_update_elem(&bpfsnoop_strs, &event->session_id, str, BPF_ANY);
 }
 
 #endif // __BPFSNOOP_STR_H_

--- a/bpf/tracepoint.c
+++ b/bpf/tracepoint.c
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0 OR Apache-2.0
+/* Copyright 2025 Leon Hwang */
+
+#include "vmlinux.h"
+#include "bpf_helpers.h"
+#include "bpf_core_read.h"
+
+#define TP_MAX 256
+
+volatile const u64 __start;
+volatile const u32 nr_tps SEC(".rodata.nr_tps");
+bool run SEC(".data.run");
+
+struct tp_info {
+    char name[64]; /* The longest tp name has over 40 chars. */
+    __u64 func_proto_symbol;
+    __u32 num_args;
+};
+
+struct tp_info tps[TP_MAX];
+
+static __noinline void
+probe_tp_info(struct bpf_raw_event_map *btp, int i)
+{
+    struct tp_info *tp = &tps[i];
+    const char *str;
+
+    str = BPF_CORE_READ(btp, tp, name);
+    bpf_probe_read_kernel_str(tp->name, sizeof(tp->name), str);
+    BPF_CORE_READ_INTO(&tp->func_proto_symbol, btp, bpf_func);
+    BPF_CORE_READ_INTO(&tp->num_args, btp, num_args);
+}
+
+SEC("fentry/__x64_sys_nanosleep")
+int probe(struct pt_regs *regs)
+{
+    struct bpf_raw_event_map *btp = (typeof(btp)) __start;
+
+    if (run)
+        return BPF_OK;
+    run = true;
+
+    for (int i = 0; i < TP_MAX; i++) {
+        if (i >= nr_tps)
+            break;
+
+        probe_tp_info(btp, i);
+        btp++;
+    }
+
+    return BPF_OK;
+}
+
+char __license[] SEC("license") = "GPL";

--- a/internal/bpfsnoop/bpf_get_func_arg.go
+++ b/internal/bpfsnoop/bpf_get_func_arg.go
@@ -14,3 +14,9 @@ func genGetFuncArg(index int, dst asm.Register) asm.Instructions {
 		asm.LoadMem(dst, asm.R10, -8, asm.DWord),
 	}
 }
+
+func genAccessArg(index int, dst asm.Register) asm.Instructions {
+	return asm.Instructions{
+		asm.LoadMem(dst, asm.R1, int16(index*8), asm.DWord),
+	}
+}

--- a/internal/bpfsnoop/bpf_kfuncs.go
+++ b/internal/bpfsnoop/bpf_kfuncs.go
@@ -112,5 +112,9 @@ func detectTraceables(spec *ebpf.CollectionSpec, kfuncs KFuncs, silent bool) (KF
 }
 
 func DetectTraceable(spec *ebpf.CollectionSpec, kfuncs KFuncs) (KFuncs, error) {
+	if len(kfuncs) == 0 {
+		return kfuncs, nil
+	}
+
 	return detectTraceables(spec, kfuncs, false)
 }

--- a/internal/bpfsnoop/bpf_tracepoints.go
+++ b/internal/bpfsnoop/bpf_tracepoints.go
@@ -1,0 +1,154 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package bpfsnoop
+
+import (
+	"errors"
+	"fmt"
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/btf"
+	"github.com/cilium/ebpf/link"
+
+	"github.com/bpfsnoop/bpfsnoop/internal/strx"
+)
+
+const tpMax = 256
+
+type tracepointInfo struct {
+	name   string
+	sym    uint64
+	nrArgs uint32
+
+	fn *btf.Func
+}
+
+type TpInfo struct {
+	Name   [64]byte
+	Sym    uint64
+	NrArgs uint32
+}
+
+func probeTracepointInfos(spec *ebpf.CollectionSpec, start uint64, cnt uint32) (map[string]tracepointInfo, error) {
+	spec = spec.Copy()
+
+	if err := spec.Variables["__start"].Set(start); err != nil {
+		return nil, fmt.Errorf("failed to set __start: %w", err)
+	}
+	if err := spec.Variables["nr_tps"].Set(cnt); err != nil {
+		return nil, fmt.Errorf("failed to set nr_tps: %w", err)
+	}
+
+	coll, err := ebpf.NewCollectionWithOptions(spec, ebpf.CollectionOptions{
+		Programs: ebpf.ProgramOptions{
+			LogDisabled: true,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create bpf collection: %w", err)
+	}
+	defer coll.Close()
+
+	prog := coll.Programs["probe"]
+	l, err := link.AttachTracing(link.TracingOptions{
+		Program:    prog,
+		AttachType: ebpf.AttachTraceFEntry,
+	})
+	defer l.Close()
+
+	nanosleep()
+
+	var run bool
+	if err := coll.Variables["run"].Get(&run); err != nil {
+		return nil, fmt.Errorf("failed to get run: %w", err)
+	}
+	if !run {
+		return nil, errors.New("probing tracepoint infos was not triggered")
+	}
+
+	var tps [tpMax]TpInfo
+	if err := coll.Variables["tps"].Get(ptr2bytes(unsafe.Pointer(&tps), (64+8+8)*tpMax)); err != nil {
+		return nil, fmt.Errorf("failed to get tps: %w", err)
+	}
+
+	infos := make(map[string]tracepointInfo, cnt)
+	for _, tp := range tps[:] {
+		if tp.Sym == 0 {
+			continue
+		}
+
+		infos[strx.NullTerminated(tp.Name[:])] = tracepointInfo{
+			sym:    tp.Sym,
+			nrArgs: tp.NrArgs,
+		}
+	}
+
+	return infos, nil
+}
+
+func ProbeTracepoints(spec *ebpf.CollectionSpec, ksyms *Kallsyms) (map[string]tracepointInfo, error) {
+	if ksyms.bpfRawTpStart == 0 || ksyms.bpfRawTpStop == 0 || ksyms.bpfRawTpStart >= ksyms.bpfRawTpStop {
+		return nil, fmt.Errorf("invalid %s(%d) and %s(%d)", bpfRawTpStart, ksyms.bpfRawTpStart, bpfRawTpStop, ksyms.bpfRawTpStop)
+	}
+
+	kernelSpec, err := btf.LoadKernelSpec()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load kernel btf: %w", err)
+	}
+
+	bpfRawTp, err := kernelSpec.AnyTypeByName("bpf_raw_event_map")
+	if err != nil {
+		return nil, fmt.Errorf("failed to find bpf_raw_event_map btf: %w", err)
+	}
+	size, err := btf.Sizeof(bpfRawTp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get size of struct bpf_raw_event_map: %w", err)
+	}
+	if size == 0 {
+		return nil, errors.New("size of struct bpf_raw_event_map must not be 0")
+	}
+
+	start := ksyms.bpfRawTpStart
+	total := (ksyms.bpfRawTpStop - ksyms.bpfRawTpStart) / uint64(size)
+
+	tps := make(map[string]tracepointInfo)
+	for total > 0 {
+		cnt := min(total, tpMax)
+
+		infos, err := probeTracepointInfos(spec, start, uint32(cnt))
+		if err != nil {
+			return nil, fmt.Errorf("failed to probe tracepoint infos: %w", err)
+		}
+
+		for name, info := range infos {
+			i := info
+			i.name = name
+
+			ksym, ok := ksyms.a2s[info.sym]
+			if !ok {
+				return nil, fmt.Errorf("%d is not found in kallsyms", info.sym)
+			}
+
+			t, err := kernelSpec.AnyTypeByName(ksym.name)
+			if err != nil {
+				return nil, fmt.Errorf("%s is not found in kernel btf", ksym.name)
+			}
+
+			fn, ok := t.(*btf.Func)
+			if !ok {
+				return nil, fmt.Errorf("%s is not a func in kernel btf", ksym.name)
+			}
+
+			i.fn = fn
+
+			tps[name] = i
+		}
+
+		total -= cnt
+		start += uint64(size) * cnt
+	}
+
+	return tps, nil
+}

--- a/internal/bpfsnoop/bpf_tracing_tracepoint.go
+++ b/internal/bpfsnoop/bpf_tracing_tracepoint.go
@@ -1,0 +1,71 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package bpfsnoop
+
+import (
+	"slices"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
+)
+
+const (
+	handleTpEventStub = "handle_tp_event"
+)
+
+func (t *bpfTracing) injectTpBtfFn(prog *ebpf.ProgramSpec, fp *btf.FuncProto, tpName string) error {
+	// The original insns are:
+	//  ; int BPF_PROG(tp_btf_fn)
+	//    0: MovImm dst: r2 imm: 0
+	//  ; volatile __u64 args[MAX_FN_ARGS] = {};
+	//    1: StXMemDW dst: rfp src: r2 off: -8 imm: 0
+	//    2: StXMemDW dst: rfp src: r2 off: -16 imm: 0
+	//    3: StXMemDW dst: rfp src: r2 off: -24 imm: 0
+	//    4: StXMemDW dst: rfp src: r2 off: -32 imm: 0
+	//    5: StXMemDW dst: rfp src: r2 off: -40 imm: 0
+	//    6: StXMemDW dst: rfp src: r2 off: -48 imm: 0
+	//    7: StXMemDW dst: rfp src: r2 off: -56 imm: 0
+	//    8: StXMemDW dst: rfp src: r2 off: -64 imm: 0
+	//    9: StXMemDW dst: rfp src: r2 off: -72 imm: 0
+	//   10: StXMemDW dst: rfp src: r2 off: -80 imm: 0
+	//   11: StXMemDW dst: rfp src: r2 off: -88 imm: 0
+	//   12: StXMemDW dst: rfp src: r2 off: -96 imm: 0
+	//   13: MovReg dst: r2 src: rfp
+	//   14: AddImm dst: r2 imm: -96
+	//  ; return handle_tp_event(ctx, args);
+	//   15: Call -1 <handle_tp_event>
+	//  ; int BPF_PROG(tp_btf_fn)
+	//   16: MovImm dst: r0 imm: 0
+	//   17: Exit
+
+	var insns asm.Instructions
+	insns = slices.Clone(prog.Instructions[:13])
+
+	// Store args on stack
+
+	// NOTE: Because "func 'xdp_redirect_err' arg2 type UNKNOWN is not a struct".
+	// for i := 0; i < len(fp.Params); i++ {
+	// 	argReg := asm.R0
+	// 	insns = append(insns,
+	// 		asm.LoadMem(argReg, asm.R1, int16(8*i), asm.DWord),
+	// 		asm.StoreMem(asm.RFP, int16(-8*(MAX_BPF_FUNC_ARGS-i)), argReg, asm.DWord),
+	// 	)
+	// }
+
+	// copy memory by `bpf_probe_read_kernel` helper.
+	insns = append(insns,
+		asm.Mov.Reg(asm.R6, asm.R1),
+		asm.Mov.Reg(asm.R3, asm.R1),
+		asm.Mov.Imm(asm.R2, int32(8*len(fp.Params))),
+		asm.Mov.Reg(asm.R1, asm.RFP),
+		asm.Add.Imm(asm.R1, -8*MAX_BPF_FUNC_ARGS),
+		asm.FnProbeReadKernel.Call(),
+		asm.Mov.Reg(asm.R1, asm.R6),
+	)
+
+	prog.Instructions = append(insns, prog.Instructions[13:]...)
+
+	return nil
+}

--- a/internal/bpfsnoop/bpfsnoop.go
+++ b/internal/bpfsnoop/bpfsnoop.go
@@ -193,6 +193,11 @@ func Run(reader *ringbuf.Reader, progs *bpfProgs, addr2line *Addr2Line, ksyms *K
 				funcArgs = fn.Args
 				funcParams = fn.Prms
 				isRetStr = fn.IsRetStr
+
+				if fn.IsTp {
+					targetName = fn.Func.Name + "[tp]"
+					printRetval = false
+				}
 			}
 		}
 

--- a/internal/bpfsnoop/flags.go
+++ b/internal/bpfsnoop/flags.go
@@ -38,6 +38,7 @@ var (
 type Flags struct {
 	progs  []string
 	kfuncs []string
+	ktps   []string
 
 	outputFile string
 
@@ -52,7 +53,8 @@ func ParseFlags() (*Flags, error) {
 
 	f := flag.NewFlagSet("bpfsnoop", flag.ExitOnError)
 	f.StringSliceVarP(&flags.progs, "prog", "p", nil, "bpf prog info for bpfsnoop in format PROG[,PROG,..], PROG: PROGID[:<prog function name>], PROGID: <prog ID> or 'i/id:<prog ID>' or 'p/pinned:<pinned file>' or 't/tag:<prog tag>' or 'n/name:<prog full name>' or 'pid:<pid>'; all bpf progs will be traced if '*' is specified")
-	f.StringSliceVarP(&flags.kfuncs, "kfunc", "k", nil, "filter kernel functions by shell wildcards way")
+	f.StringSliceVarP(&flags.kfuncs, "kfunc", "k", nil, "filter kernel functions")
+	f.StringSliceVarP(&flags.ktps, "tracepoint", "t", nil, "filter kernel tracepoints")
 	f.BoolVar(&kfuncAllKmods, "kfunc-all-kmods", false, "filter functions in all kernel modules")
 	f.StringSliceVar(&kfuncKmods, "kfunc-kmods", nil, "filter functions in specified kernel modules")
 	f.StringVarP(&flags.outputFile, "output", "o", "", "output file for the result, default is stdout")
@@ -93,6 +95,10 @@ func (f *Flags) ParseProgs() ([]ProgFlag, error) {
 
 func (f *Flags) Kfuncs() []string {
 	return f.kfuncs
+}
+
+func (f *Flags) Ktps() []string {
+	return f.ktps
 }
 
 func (f *Flags) OutputFile() string {

--- a/internal/bpfsnoop/kernel_btf.go
+++ b/internal/bpfsnoop/kernel_btf.go
@@ -1,0 +1,53 @@
+// Copyright 2024 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package bpfsnoop
+
+import (
+	"fmt"
+	"os"
+	"slices"
+
+	"github.com/cilium/ebpf/btf"
+)
+
+func iterateKernelBtfs(iter func(*btf.Spec)) error {
+	if kfuncAllKmods {
+		files, err := os.ReadDir("/sys/kernel/btf")
+		if err != nil {
+			return fmt.Errorf("failed to read /sys/kernel/btf: %w", err)
+		}
+
+		for _, file := range files {
+			kmodBtf, err := btf.LoadKernelModuleSpec(file.Name())
+			if err != nil {
+				return fmt.Errorf("failed to load kernel module BTF: %w", err)
+			}
+
+			iter(kmodBtf)
+		}
+	} else if len(kfuncKmods) != 0 {
+		kmods := slices.Clone(kfuncKmods)
+		kmods = append(kmods, "vmlinux")
+		slices.Sort(kmods)
+		kmods = slices.Compact(kmods)
+
+		for _, kmod := range kmods {
+			kmodBtf, err := btf.LoadKernelModuleSpec(kmod)
+			if err != nil {
+				return fmt.Errorf("failed to load kernel module BTF: %w", err)
+			}
+
+			iter(kmodBtf)
+		}
+	} else {
+		kernelBtf, err := btf.LoadKernelSpec()
+		if err != nil {
+			return fmt.Errorf("failed to load kernel BTF: %w", err)
+		}
+
+		iter(kernelBtf)
+	}
+
+	return nil
+}

--- a/internal/bpfsnoop/kernel_functions.go
+++ b/internal/bpfsnoop/kernel_functions.go
@@ -4,8 +4,6 @@
 package bpfsnoop
 
 import (
-	"fmt"
-	"os"
 	"slices"
 
 	"github.com/Asphaltt/mybtf"
@@ -54,9 +52,10 @@ type KFunc struct {
 	Args     []funcArgumentOutput
 	Prms     []FuncParamFlags
 	IsRetStr bool
+	IsTp     bool
 }
 
-func (k KFunc) Name() string {
+func (k *KFunc) Name() string {
 	return k.Func.Name
 }
 
@@ -65,116 +64,87 @@ func isValistParam(p btf.FuncParam) bool {
 	return p.Name == "" && isVoid
 }
 
+func matchKernelFunc(matches []*kfuncMatch, fn *btf.Func, maxArgs int, ksyms *Kallsyms, findManyArgs, silent bool) (*KFunc, bool) {
+	if len(matches) == 0 {
+		return nil, false
+	}
+
+	funcProto := fn.Type.(*btf.FuncProto)
+	if !matchKfunc(fn.Name, funcProto, matches) {
+		return nil, false
+	}
+
+	if isValist := len(funcProto.Params) != 0 && isValistParam(funcProto.Params[len(funcProto.Params)-1]); isValist {
+		verboseLogIf(!silent, "Skip function %s with variable args", fn.Name)
+		return nil, false
+	}
+
+	if _, isStruct := mybtf.UnderlyingType(funcProto.Return).(*btf.Struct); isStruct {
+		verboseLogIf(!silent, "Skip function %s with struct return type", fn.Name)
+		return nil, false
+	}
+
+	ksym, ok := ksyms.n2s[fn.Name]
+	if !ok {
+		verboseLogIf(!silent, "Failed to find ksym for %s", fn.Name)
+		return nil, false
+	}
+	if ksym.duped {
+		verboseLogIf(!silent, "Skip multiple-addrs ksym %s", fn.Name)
+		return nil, false
+	}
+
+	params, err := getFuncParams(fn)
+	if err != nil {
+		verboseLogIf(!silent, "Failed to get params for %s: %v", fn.Name, err)
+		return nil, false
+	}
+
+	if findManyArgs {
+		if MAX_BPF_FUNC_ARGS_PREV < len(funcProto.Params) && len(funcProto.Params) <= MAX_BPF_FUNC_ARGS {
+			kf := KFunc{Ksym: ksym, Func: fn}
+			kf.Prms = params
+			kf.IsRetStr = mybtf.IsConstCharPtr(funcProto.Return)
+			return &kf, true
+		}
+		return nil, false
+	}
+
+	if len(funcProto.Params) <= maxArgs {
+		kf := KFunc{Ksym: ksym, Func: fn}
+		kf.Prms = params
+		kf.IsRetStr = mybtf.IsConstCharPtr(funcProto.Return)
+		return &kf, true
+	}
+
+	verboseLogIf(!silent, "Skip function %s with %d args because of limit %d args\n",
+		fn.Name, len(funcProto.Params), maxArgs)
+
+	return nil, false
+}
+
 type KFuncs map[uintptr]*KFunc
 
 func findKernelFuncs(funcs []string, ksyms *Kallsyms, maxArgs int, findManyArgs, silent bool) (KFuncs, error) {
-	matches, err := kfuncFlags2matches(funcs)
+	matchFuncs, err := kfuncFlags2matches(funcs)
 	if err != nil {
 		return KFuncs{}, err
 	}
 
 	kfuncs := make(KFuncs, len(funcs))
-
-	iterBtfSpec := func(spec *btf.Spec) {
+	err = iterateKernelBtfs(func(spec *btf.Spec) {
 		iter := spec.Iterate()
 		for iter.Next() {
-			fn, ok := iter.Type.(*btf.Func)
-			if !ok {
-				continue
-			}
-
-			funcProto := fn.Type.(*btf.FuncProto)
-			if !matchKfunc(fn.Name, funcProto, matches) {
-				continue
-			}
-
-			if isValist := len(funcProto.Params) != 0 && isValistParam(funcProto.Params[len(funcProto.Params)-1]); isValist {
-				verboseLogIf(!silent, "Skip function %s with variable args", fn.Name)
-				continue
-			}
-
-			if _, isStruct := mybtf.UnderlyingType(funcProto.Return).(*btf.Struct); isStruct {
-				verboseLogIf(!silent, "Skip function %s with struct return type", fn.Name)
-				continue
-			}
-
-			ksym, ok := ksyms.n2s[fn.Name]
-			if !ok {
-				verboseLogIf(!silent, "Failed to find ksym for %s", fn.Name)
-				continue
-			}
-			if ksym.duped {
-				verboseLogIf(!silent, "Skip multiple-addrs ksym %s", fn.Name)
-				continue
-			}
-
-			params, err := getFuncParams(fn)
-			if err != nil {
-				verboseLogIf(!silent, "Failed to get params for %s: %v", fn.Name, err)
-				continue
-			}
-
-			if findManyArgs {
-				if MAX_BPF_FUNC_ARGS_PREV < len(funcProto.Params) && len(funcProto.Params) <= MAX_BPF_FUNC_ARGS {
-					kf := KFunc{Ksym: ksym, Func: fn}
-					kf.Prms = params
-					kf.IsRetStr = mybtf.IsConstCharPtr(funcProto.Return)
-					kfuncs[uintptr(ksym.addr)] = &kf
+			if fn, ok := iter.Type.(*btf.Func); ok {
+				kf, ok := matchKernelFunc(matchFuncs, fn, maxArgs, ksyms, findManyArgs, silent)
+				if ok {
+					kfuncs[uintptr(kf.Ksym.addr)] = kf
 				}
-				continue
-			}
-
-			if len(funcProto.Params) <= maxArgs {
-				kf := KFunc{Ksym: ksym, Func: fn}
-				kf.Prms = params
-				kf.IsRetStr = mybtf.IsConstCharPtr(funcProto.Return)
-				kfuncs[uintptr(ksym.addr)] = &kf
-			} else {
-				verboseLogIf(!silent, "Skip function %s with %d args because of limit %d args\n",
-					fn.Name, len(funcProto.Params), maxArgs)
 			}
 		}
-	}
-
-	if kfuncAllKmods {
-		files, err := os.ReadDir("/sys/kernel/btf")
-		if err != nil {
-			return nil, fmt.Errorf("failed to read /sys/kernel/btf: %w", err)
-		}
-
-		for _, file := range files {
-			kmodBtf, err := btf.LoadKernelModuleSpec(file.Name())
-			if err != nil {
-				return nil, fmt.Errorf("failed to load kernel module BTF: %w", err)
-			}
-
-			iterBtfSpec(kmodBtf)
-		}
-	} else if len(kfuncKmods) != 0 {
-		kmods := slices.Clone(kfuncKmods)
-		kmods = append(kmods, "vmlinux")
-		slices.Sort(kmods)
-		kmods = slices.Compact(kmods)
-
-		for _, kmod := range kmods {
-			kmodBtf, err := btf.LoadKernelModuleSpec(kmod)
-			if err != nil {
-				return nil, fmt.Errorf("failed to load kernel module BTF: %w", err)
-			}
-
-			iterBtfSpec(kmodBtf)
-		}
-	} else {
-		kernelBtf, err := btf.LoadKernelSpec()
-		if err != nil {
-			return nil, fmt.Errorf("failed to load kernel BTF: %w", err)
-		}
-
-		iterBtfSpec(kernelBtf)
-	}
-
-	if len(kfuncs) == 0 {
-		return nil, fmt.Errorf("no functions found for %v", funcs)
+	})
+	if err != nil {
+		return kfuncs, err
 	}
 
 	return kfuncs, nil

--- a/internal/bpfsnoop/kernel_functions_max_arg.go
+++ b/internal/bpfsnoop/kernel_functions_max_arg.go
@@ -26,6 +26,7 @@ func DetectSupportedMaxArg(traceableSpec, spec *ebpf.CollectionSpec, ksyms *Kall
 	}
 
 	spec = spec.Copy()
+	delete(spec.Programs, TracingTpBtfProgName())
 	reusedMaps := PrepareBPFMaps(spec)
 	defer CloseBPFMaps(reusedMaps)
 

--- a/internal/bpfsnoop/kernel_tracepoints.go
+++ b/internal/bpfsnoop/kernel_tracepoints.go
@@ -1,0 +1,93 @@
+// Copyright 2024 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package bpfsnoop
+
+import (
+	rand "math/rand/v2"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/btf"
+
+	"github.com/bpfsnoop/bpfsnoop/internal/btfx"
+)
+
+type Tracepoints map[string]*KFunc
+
+func findKernelTracepoints(tps []string, spec *ebpf.CollectionSpec, ksyms *Kallsyms, silent bool) (Tracepoints, error) {
+	matches, err := kfuncFlags2matches(tps)
+	if err != nil {
+		return Tracepoints{}, err
+	}
+
+	tpInfos, err := ProbeTracepoints(spec, ksyms)
+	if err != nil {
+		return Tracepoints{}, err
+	}
+
+	ktps := make(Tracepoints, len(tps))
+	for tpName, tp := range tpInfos {
+		fn := *tp.fn
+		fp := *tp.fn.Type.(*btf.FuncProto)
+		fp.Params = fp.Params[1:] // skip 'void *__data'
+		fn.Type = &fp
+
+		if len(fp.Params) < int(tp.nrArgs) {
+			verboseLogIf(!silent, "%s has %d params, which is required %d params for tracepoint %s",
+				tp.fn.Name, len(fp.Params), tp.nrArgs, tpName)
+			continue
+		}
+
+		if len(fp.Params) > MAX_BPF_FUNC_ARGS {
+			verboseLogIf(!silent, "%s has %d params, which is more than %d params for tp_btf %s",
+				tp.fn.Name, len(fp.Params), MAX_BPF_FUNC_ARGS, tpName)
+			continue
+		}
+
+		ok := matchKfunc(tpName, &fp, matches)
+		if !ok {
+			continue
+		}
+
+		params, err := getFuncParams(&fn)
+		if err != nil {
+			verboseLogIf(!silent, "Failed to prepare params info for tracepoint %s: %w", tpName, err)
+			continue
+		}
+
+		fn.Name = tpName
+		ktps[tpName] = &KFunc{
+			Ksym:     &KsymEntry{name: tpName},
+			Func:     &fn,
+			Prms:     params,
+			IsRetStr: btfx.IsStr(fp.Return),
+			IsTp:     true,
+		}
+	}
+
+	return ktps, nil
+}
+
+func FindKernelTracepoints(tps []string, spec *ebpf.CollectionSpec, ksyms *Kallsyms) (Tracepoints, error) {
+	if len(tps) == 0 {
+		return Tracepoints{}, nil
+	}
+
+	return findKernelTracepoints(tps, spec, ksyms, false)
+}
+
+func MergeTracepointsToKfuncs(tps Tracepoints, kfuncs KFuncs) {
+	for _, tp := range tps {
+		id := rand.Uint64()
+		for {
+			if _, ok := kfuncs[uintptr(id)]; !ok {
+				break
+			}
+
+			id = rand.Uint64()
+		}
+
+		tp.Ksym.addr = id
+		kfuncs[uintptr(id)] = tp
+	}
+}

--- a/internal/bpfsnoop/output_arg.go
+++ b/internal/bpfsnoop/output_arg.go
@@ -85,14 +85,18 @@ func prepareFuncArgOutput(exprs []string) argDataOutput {
 	return arg
 }
 
-func (arg *funcArgumentOutput) compile(idx int, t btf.Type, offset int, ctxStale bool) (int, error) {
+func (arg *funcArgumentOutput) compile(idx int, t btf.Type, offset int, ctxStale, getFuncArg bool) (int, error) {
 	var insns asm.Instructions
 	if ctxStale {
 		insns = append(insns,
 			asm.Mov.Reg(asm.R1, asm.R8), // R1 = ctx
 		)
 	}
-	insns = append(insns, genGetFuncArg(idx, asm.R3)...)
+	if getFuncArg {
+		insns = append(insns, genGetFuncArg(idx, asm.R3)...)
+	} else {
+		insns = append(insns, genAccessArg(idx, asm.R3)...)
+	}
 
 	res, err := bice.Access(bice.AccessOptions{
 		Insns:     insns,
@@ -185,7 +189,7 @@ func (arg *argDataOutput) correctArgType(t btf.Type) (btf.Type, error) {
 	return t, nil
 }
 
-func (arg *argDataOutput) matchParams(params []btf.FuncParam, checkArgType bool) ([]funcArgumentOutput, error) {
+func (arg *argDataOutput) matchParams(params []btf.FuncParam, checkArgType, getFuncArg bool) ([]funcArgumentOutput, error) {
 	args := make([]funcArgumentOutput, 0, maxOutputArgCnt)
 
 	ctxStale := false
@@ -209,7 +213,7 @@ func (arg *argDataOutput) matchParams(params []btf.FuncParam, checkArgType bool)
 			}
 
 			a := a
-			size, err := a.compile(i, t, offset, ctxStale)
+			size, err := a.compile(i, t, offset, ctxStale, getFuncArg)
 			if err != nil {
 				return nil, fmt.Errorf("failed to compile arg %s with expr %s: %w", p.Name, a.expr, err)
 			}

--- a/internal/btfx/types.go
+++ b/internal/btfx/types.go
@@ -64,6 +64,10 @@ func IsBool(t btf.Type) bool {
 	return ok && i.Name == "_Bool"
 }
 
+func IsStr(t btf.Type) bool {
+	return mybtf.IsConstCharPtr(t) || mybtf.IsCharArray(t)
+}
+
 func IsConst(t btf.Type) bool {
 	for {
 		switch v := t.(type) {

--- a/makefiles/variables.mk
+++ b/makefiles/variables.mk
@@ -18,10 +18,22 @@ GOBUILD := go build -v -trimpath
 GOBUILD_CGO_CFLAGS := CGO_CFLAGS='-O2 -I$(CURDIR)/lib/capstone/include -I$(CURDIR)/lib/libpcap'
 GOBUILD_CGO_LDFLAGS := CGO_LDFLAGS='-O2 -g -L$(CURDIR)/lib/capstone/build -lcapstone -L$(CURDIR)/lib/libpcap -lpcap -static'
 
-GOGEN := go generate
+BPF2GO := go run github.com/cilium/ebpf/cmd/bpf2go -cc clang -go-package main
+BPF2GO_EXTRA_FLAGS := -g -D__TARGET_ARCH_x86 -I./bpf -I./bpf/headers -I./lib/libbpf/src -Wno-address-of-packed-member -Wall
 
-BPF_OBJ := bpfsnoop_bpfel.o bpfsnoop_bpfeb.o feat_bpfel.o feat_bpfeb.o traceable_bpfel.o traceable_bpfeb.o
-BPF_SRC := $(wildcard bpf/*.c) $(wildcard bpf/*.h) $(wildcard bpf/headers/*.h)
+BPFSNOOP_BPF_OBJ := bpfsnoop_bpfel.o bpfsnoop_bpfeb.o
+BPFSNOOP_BPF_SRC := bpf/bpfsnoop.c $(wildcard bpf/*.h) $(wildcard bpf/headers/*.h)
+
+FEAT_BPF_OBJ := feat_bpfel.o feat_bpfeb.o
+FEAT_BPF_SRC := bpf/feature.c
+
+TRACEABLE_BPF_OBJ := traceable_bpfel.o traceable_bpfeb.o
+TRACEABLE_BPF_SRC := bpf/traceable.c
+
+TRACEPOINT_BPF_OBJ := tracepoint_bpfel.o tracepoint_bpfeb.o
+TRACEPOINT_BPF_SRC := bpf/tracepoint.c
+
+BPF_OBJS := $(BPFSNOOP_BPF_OBJ) $(FEAT_BPF_OBJ) $(TRACEABLE_BPF_OBJ) $(TRACEPOINT_BPF_OBJ)
 
 BPFSNOOP_OBJ := bpfsnoop
 BPFSNOOP_SRC := $(shell find internal -type f -name '*.go') main.go


### PR DESCRIPTION
Fixes #47 

It's to trace tracepoints with tp_btf. However, it's not easy to trace different tracepoint with one bpf program spec.

Above all, it's not easy to recognize the function prototype of tracepoint's BTF. In order to figure out it, `bpfsnoop` implement `--show-func-proto` for `-t` to print all tracepoint's BTF function prototype.

Next, prog type of tp_btf is tracing but tp_btf does not support `bpf_get_func_arg()` helper like fentry. Amazingly, `bpfsnoop` saves all arguments on stack, and then accesses the argument from the stack.

Another issue is "func 'xdp_redirect_err' arg2 type UNKNOWN is not a struct". It seems that there is a BUG in bpf verifier. Amazingly again, `bpfsnoop` uses `bpf_probe_read_kernel()` to copy all arguments from `ctx` to stack.

At the same time, like kernel functions, it filters kernel tracepoints by the same way, and injects the `--filter-arg`, `--output-arg`, `--filter-pkt` and `--output-pkt` by the same way.