### PR TITLE
gapstone: Bump capstone from 4.0.2 to 5.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Please check [bpfsnoop.com](https://bpfsnoop.com) for more details.
 
 - [cilium/ebpf](https://github.com/cilium/ebpf) for interacting with bpf subsystem.
 - [daludaluking/addr2line](https://github.com/daludaluking/addr2line) for translating addresses to file and line number by parsing debug info from vmlinux.
-- [knightsc/gapstone](https://github.com/knightsc/gapstone) for disassembling machine native instructions.
+- [bpfsnoop/gapstone](https://github.com/bpfsnoop/gapstone) for disassembling machine native instructions.
 - [jschwinger233/elibpcap](github.com/jschwinger233/elibpcap) for injecting pcap-filter expressions to bpf stubs.
 
 ## License

--- a/go.mod
+++ b/go.mod
@@ -1,19 +1,19 @@
 module github.com/bpfsnoop/bpfsnoop
 
-go 1.23.4
+go 1.24
 
-toolchain go1.24.0
+toolchain go1.24.1
 
 require (
 	github.com/Asphaltt/addr2line v0.1.2
 	github.com/Asphaltt/mybtf v0.0.0-20250315135407-f9d09086616b
+	github.com/bpfsnoop/gapstone v0.0.0-20250326151126-f4ba393504da
 	github.com/cilium/ebpf v0.17.4-0.20250310175843-23a70a77897a
 	github.com/fatih/color v1.18.0
 	github.com/gobwas/glob v0.2.3
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jschwinger233/elibpcap v1.0.0
 	github.com/klauspost/compress v1.17.11
-	github.com/knightsc/gapstone v4.0.1+incompatible
 	github.com/leonhwangprojects/bice v0.1.1
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
@@ -33,5 +33,3 @@ require (
 	github.com/ianlancetaylor/demangle v0.0.0-20240912202439-0a2b6291aafd // indirect
 	golang.org/x/sys v0.30.0
 )
-
-replace github.com/knightsc/gapstone v4.0.1+incompatible => github.com/Asphaltt/gapstone v0.0.0-20241029140935-c5412a26abf7

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 github.com/Asphaltt/addr2line v0.1.2 h1:GPZflkxPeF+7EKXt9ty8GDwBhd7tVxQilUkCHI/4Ujg=
 github.com/Asphaltt/addr2line v0.1.2/go.mod h1:02z/FcEJ9rsH1i7It81L6xHtjSoBOrKbDtTGlptzfP0=
-github.com/Asphaltt/gapstone v0.0.0-20241029140935-c5412a26abf7 h1:z1Ohf61MSfgVMxAs2Z4nWZ4p+a12K/u41JJurdIxdBU=
-github.com/Asphaltt/gapstone v0.0.0-20241029140935-c5412a26abf7/go.mod h1:1K5hEzsMBLTPdRJKEHqBFJ8Zt2VRqDhomcQ11KH0WW4=
 github.com/Asphaltt/mybtf v0.0.0-20250315135407-f9d09086616b h1:LRS0ckDlNnX2Bux8k0HqLVf/2PqvvykoB8HSxXf7XjA=
 github.com/Asphaltt/mybtf v0.0.0-20250315135407-f9d09086616b/go.mod h1:ZxswciFofS8TXGsc2j5CWCY8O3XwKEysCnU7hoI1fnI=
+github.com/bpfsnoop/gapstone v0.0.0-20250326151126-f4ba393504da h1:jMqMpXXLc7sZrIUOatcnO6cmlV1MuLZPtDMmaXksu6I=
+github.com/bpfsnoop/gapstone v0.0.0-20250326151126-f4ba393504da/go.mod h1:z8pjvjRs6upeW3rOvXbyAua+ngoozVZg6HwTdRsALoM=
 github.com/cilium/ebpf v0.17.4-0.20250310175843-23a70a77897a h1:Gwqct80mVVFXishYmIJKmnkSxSUsPIkoEHpLagVHIjU=
 github.com/cilium/ebpf v0.17.4-0.20250310175843-23a70a77897a/go.mod h1:z4P4PotUQMhVXjjIj1zZUD7KogbAIS/o6WtXnM8QG9U=
 github.com/cloudflare/cbpfc v0.0.0-20230809125630-31aa294050ff h1:SLLG1soGN/PYTXkYWiR1PAxWlP1URBvgZPYymC5+0WI=

--- a/internal/bpfsnoop/disasm.go
+++ b/internal/bpfsnoop/disasm.go
@@ -13,8 +13,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bpfsnoop/gapstone"
 	"github.com/fatih/color"
-	"github.com/knightsc/gapstone"
 
 	"github.com/bpfsnoop/bpfsnoop/internal/assert"
 )

--- a/internal/bpfsnoop/dump.go
+++ b/internal/bpfsnoop/dump.go
@@ -10,10 +10,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bpfsnoop/gapstone"
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/btf"
 	"github.com/fatih/color"
-	"github.com/knightsc/gapstone"
 
 	"github.com/bpfsnoop/bpfsnoop/internal/assert"
 )

--- a/main.go
+++ b/main.go
@@ -14,8 +14,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/bpfsnoop/gapstone"
 	"github.com/cilium/ebpf/ringbuf"
-	"github.com/knightsc/gapstone"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/unix"
 


### PR DESCRIPTION
In [bpfsnoop/gapstone](https://github.com/bpfsnoop/gapstone), I update it to support capstone 5.0.6.

Afterwards, use [bpfsnoop/gapstone](https://github.com/bpfsnoop/gapstone) as disasm engine library.