### PR TITLE
bpfsnoop: Refactor handling events

### DIFF
--- a/internal/bpfsnoop/bpfsnoop.go
+++ b/internal/bpfsnoop/bpfsnoop.go
@@ -7,51 +7,19 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"slices"
 	"strings"
 	"unsafe"
 
 	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/btf"
 	"github.com/cilium/ebpf/ringbuf"
 	"github.com/fatih/color"
 
-	"github.com/bpfsnoop/bpfsnoop/internal/btfx"
 	"github.com/bpfsnoop/bpfsnoop/internal/strx"
 )
 
 const (
 	MAX_STACK_DEPTH = 50
 )
-
-type LbrEntry struct {
-	From  uintptr
-	To    uintptr
-	Flags uint64
-}
-
-type LbrData struct {
-	Entries [32]LbrEntry
-	NrBytes int64
-}
-
-type FnData struct {
-	Retval [2]uint64
-	Args   [MAX_BPF_FUNC_ARGS][2]uint64 // raw data + pointed data
-}
-
-type StrData struct {
-	Arg [32]byte
-	Ret [32]byte
-}
-
-func (s *StrData) arg() string {
-	return strx.NullTerminated(s.Arg[:])
-}
-
-func (s *StrData) ret() string {
-	return strx.NullTerminated(s.Ret[:])
-}
 
 type Event struct {
 	SessID  uint64
@@ -63,17 +31,20 @@ type Event struct {
 	Func    FnData
 }
 
-type FuncStack struct {
-	IPs [MAX_STACK_DEPTH]uint64
-}
-
 func ptr2bytes(p unsafe.Pointer, size int) []byte {
 	return unsafe.Slice((*byte)(p), size)
 }
 
-func Run(reader *ringbuf.Reader, progs *bpfProgs, addr2line *Addr2Line, ksyms *Kallsyms, kfuncs KFuncs, maps map[string]*ebpf.Map, w io.Writer) error {
+type Helpers struct {
+	Progs     *bpfProgs
+	Addr2line *Addr2Line
+	Ksyms     *Kallsyms
+	Kfuncs    KFuncs
+}
+
+func Run(reader *ringbuf.Reader, helpers *Helpers, maps map[string]*ebpf.Map, w io.Writer) error {
 	lbrStack := newLBRStack()
-	funcStack := make([]string, 0, MAX_STACK_DEPTH)
+	fnStack := newFnStack()
 
 	stacks := maps["bpfsnoop_stacks"]
 	lbrs := maps["bpfsnoop_lbrs"]
@@ -89,32 +60,12 @@ func Run(reader *ringbuf.Reader, progs *bpfProgs, addr2line *Addr2Line, ksyms *K
 	fg := NewFlameGraph()
 	defer fg.Save(outputFlameGraph)
 
-	outputFlameGraph := outputFlameGraph != ""
-	printRetval := mode == TracingModeExit
-	colorOutput := !noColorOutput
-	useLbr := outputLbr
-
-	funcParamColors := []*color.Color{
-		color.RGB(0x9d, 0x9d, 0x9d),
-		color.RGB(0x7a, 0x7a, 0x7a),
-		color.RGB(0x54, 0x54, 0x54),
-		color.RGB(0x9c, 0x91, 0x91),
-		color.RGB(0x7c, 0x74, 0x74),
-		color.RGB(0x5c, 0x54, 0x54),
-		color.RGB(0x9d, 0x9d, 0x9d),
-		color.RGB(0x7a, 0x7a, 0x7a),
-		color.RGB(0x54, 0x54, 0x54),
-		color.RGB(0x9c, 0x91, 0x91),
-		color.RGB(0x7c, 0x74, 0x74),
-		color.RGB(0x5c, 0x54, 0x54),
-	}
-
 	findSymbol := func(addr uint64) string {
-		if prog, ok := progs.funcs[uintptr(addr)]; ok {
+		if prog, ok := helpers.Progs.funcs[uintptr(addr)]; ok {
 			return prog.funcName + "[bpf]"
 		}
 
-		return ksyms.findSymbol(addr)
+		return helpers.Ksyms.findSymbol(addr)
 	}
 
 	var sb strings.Builder
@@ -138,163 +89,21 @@ func Run(reader *ringbuf.Reader, progs *bpfProgs, addr2line *Addr2Line, ksyms *K
 		}
 
 		event := (*Event)(unsafe.Pointer(&record.RawSample[0]))
-		if outputFuncStack && event.StackID >= 0 {
-			funcStack, err = getFuncStack(event, progs, addr2line, ksyms, stacks, outputFlameGraph, funcStack)
-			if err != nil {
-				return err
-			}
-		}
+		fnInfo := getFuncInfo(event, helpers)
 
-		if useLbr {
-			b := ptr2bytes(unsafe.Pointer(&lbrData), int(unsafe.Sizeof(lbrData)))
-			err := lbrs.LookupAndDelete(event.SessID, b)
-			if err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
-				return fmt.Errorf("failed to lookup lbr data: %w", err)
-			}
-		}
-
-		hasLbrEntries := useLbr && lbrData.NrBytes > 0 && lbrData.Entries[0] != (LbrEntry{})
-		hasLbrEntries = hasLbrEntries && getLbrStack(event.FuncIP, &lbrData, progs, addr2line, ksyms, lbrStack)
-
-		var targetName string
-		var funcProto *btf.Func
-		var funcArgs []funcArgumentOutput
-		var funcParams []FuncParamFlags
-		var retParam FuncParamFlags
-		var hasPktTuple bool
-
-		if progInfo, ok := progs.funcs[event.FuncIP]; ok {
-			targetName = progInfo.funcName + "[bpf]"
-			funcProto = progInfo.funcProto
-			funcArgs = progInfo.funcArgs
-			funcParams = progInfo.funcParams
-			retParam = progInfo.retParam
-			hasPktTuple = progInfo.pktOutput
-		} else {
-			ksym, ok := ksyms.find(event.FuncIP)
-			if ok {
-				targetName = ksym.name
-			} else {
-				targetName = fmt.Sprintf("0x%x", event.FuncIP)
-			}
-
-			fn, ok := kfuncs[event.FuncIP]
-			if ok {
-				funcProto = fn.Func
-				funcArgs = fn.Args
-				funcParams = fn.Prms
-				retParam = fn.Ret
-				hasPktTuple = fn.Pkt
-
-				if fn.IsTp {
-					targetName = fn.Func.Name + "[tp]"
-					printRetval = false
-				}
-			}
-		}
-
-		if hasPktTuple {
-			b := ptr2bytes(unsafe.Pointer(&pktData), int(unsafe.Sizeof(pktData)))
-			err := pkts.LookupAndDelete(event.SessID, b)
-			if err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
-				return fmt.Errorf("failed to lookup pkt data: %w", err)
-			}
-
-			hasPktTuple = !pktData.zero() && err == nil
-		}
-
-		hasArgOutput := len(funcArgs) != 0
-		if hasArgOutput {
-			b := ptr2bytes(unsafe.Pointer(&argData), int(unsafe.Sizeof(argData)))
-			err := args.LookupAndDelete(event.SessID, b)
-			if err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
-				return fmt.Errorf("failed to lookup arg data: %w", err)
-			}
-		}
-
-		useStrData := retParam.IsStr
-		if !useStrData {
-			for _, prm := range funcParams {
-				useStrData = useStrData || prm.IsStr
-			}
-		}
-		if useStrData {
-			b := ptr2bytes(unsafe.Pointer(&strData), int(unsafe.Sizeof(strData)))
-			err := strs.LookupAndDelete(event.SessID, b)
-			if err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
-				return fmt.Errorf("failed to lookup str data: %w", err)
-			}
-		}
-
-		if colorOutput {
-			targetName = color.New(color.FgYellow, color.Bold).Sprint(targetName)
-		}
-		fmt.Fprint(&sb, targetName, " ")
-
-		if colorOutput {
+		if !noColorOutput {
+			color.New(color.FgYellow, color.Bold).Fprint(&sb, fnInfo.name, " ")
 			color.New(color.FgBlue).Fprintf(&sb, "args")
 		} else {
-			fmt.Fprintf(&sb, "args")
-		}
-		fmt.Fprintf(&sb, "=(")
-		if funcProto != nil {
-			params := funcProto.Type.(*btf.FuncProto).Params
-			lastIdx, idx := len(params)-1, 0
-			s := strData.arg()
-			strUsed := false
-			for i, fnParam := range funcParams {
-				if fnParam.partOfPrevParam {
-					continue
-				}
-
-				if idx != 0 {
-					fmt.Fprint(&sb, ", ")
-				}
-
-				arg := event.Func.Args[i]
-
-				if strUsed {
-					s = ""
-				}
-				strUsed = strUsed || fnParam.IsStr
-
-				valNext := arg[0]
-				if i < lastIdx {
-					valNext = event.Func.Args[i+1][0]
-				}
-
-				fp := btfx.ReprFuncParam(&params[idx], i, fnParam.IsStr, fnParam.IsNumberPtr, arg[0], arg[1], valNext, s, findSymbol)
-				if colorOutput {
-					funcParamColors[i].Fprint(&sb, fp)
-				} else {
-					fmt.Fprintf(&sb, "%s", fp)
-				}
-
-				idx++
-			}
-		} else {
-			fmt.Fprintf(&sb, "..UNK..")
-		}
-		fmt.Fprintf(&sb, ")")
-
-		if printRetval {
-			retval := fmt.Sprintf("%d/%#x", event.Func.Retval[0], uint64(event.Func.Retval[0]))
-			if funcProto != nil {
-				rettyp := funcProto.Type.(*btf.FuncProto).Return
-				retval = btfx.ReprFuncReturn(rettyp, retParam.IsStr,
-					retParam.IsNumberPtr, event.Func.Retval[0], event.Func.Retval[1],
-					strData.ret(), findSymbol)
-			}
-			if colorOutput {
-				color.New(color.FgGreen).Fprintf(&sb, " retval")
-				fmt.Fprint(&sb, "=")
-				color.New(color.FgRed).Fprintf(&sb, "%s", retval)
-			} else {
-				fmt.Fprintf(&sb, " retval=%s", retval)
-			}
+			fmt.Fprint(&sb, fnInfo.name, " args")
 		}
 
-		if colorOutput {
+		err = outputFnArgs(&sb, fnInfo, helpers, &strData, strs, event, findSymbol)
+		if err != nil {
+			return fmt.Errorf("failed to output function data: %w", err)
+		}
+
+		if !noColorOutput {
 			color.New(color.FgCyan).Fprintf(&sb, " cpu=%d", event.CPU)
 			color.New(color.FgMagenta).Fprintf(&sb, " process=(%d:%s)", event.Pid, strx.NullTerminated(event.Comm[:]))
 		} else {
@@ -302,154 +111,32 @@ func Run(reader *ringbuf.Reader, progs *bpfProgs, addr2line *Addr2Line, ksyms *K
 		}
 		fmt.Fprintln(&sb)
 
-		if hasPktTuple {
-			fmt.Fprint(&sb, "Pkt tuple: ")
-			color.New(color.FgGreen).Fprintln(&sb, pktData.repr())
+		err = outputPktTuple(&sb, fnInfo, &pktData, pkts, event)
+		if err != nil {
+			return fmt.Errorf("failed to output packet tuple: %w", err)
 		}
 
-		if hasArgOutput {
-			fmt.Fprint(&sb, "Arg attrs: ")
-			argData.repr(&sb, funcArgs, ksyms)
+		err = outputFuncArgAttrs(&sb, fnInfo, &argData, args, event, findSymbol)
+		if err != nil {
+			return fmt.Errorf("failed to output function arguments: %w", err)
 		}
 
-		if hasLbrEntries {
-			fmt.Fprintln(&sb, "LBR stack:")
-			lbrStack.output(&sb)
+		err = lbrStack.outputStack(&sb, helpers, &lbrData, lbrs, event)
+		if err != nil {
+			return fmt.Errorf("failed to output LBR stack: %w", err)
 		}
-		hasFuncEntries := len(funcStack) > 0
-		if hasFuncEntries && !outputFlameGraph {
-			fmt.Fprintln(&sb, "Func stack:")
-			for _, entry := range funcStack {
-				fmt.Fprint(&sb, entry)
-			}
-		} else if hasFuncEntries && outputFlameGraph {
-			slices.Reverse(funcStack)
-			fg.AddStack(funcStack, 1)
+
+		err = fnStack.output(&sb, helpers, stacks, fg, event)
+		if err != nil {
+			return fmt.Errorf("failed to output function stack: %w", err)
 		}
+
 		fmt.Fprintln(w, sb.String())
 
 		sb.Reset()
 		lbrStack.reset()
-		funcStack = funcStack[:0]
+		fnStack.reset()
 	}
 
 	return ErrFinished
-}
-
-func getLbrStack(funcIP uintptr, lbrData *LbrData, progs *bpfProgs, addr2line *Addr2Line, ksyms *Kallsyms, stack *lbrStack) bool {
-	progInfo, isProg := progs.funcs[funcIP]
-
-	nrEntries := lbrData.NrBytes / int64(8*3)
-	entries := lbrData.Entries[:nrEntries]
-	if !verbose {
-		if !isProg {
-			for i := range entries {
-				if ksym, ok := ksyms.find(entries[i].From); ok && ksym.addr == uint64(funcIP) {
-					entries = entries[i:]
-					break
-				}
-			}
-		} else if mode == TracingModeExit {
-			for i := range entries {
-				if progInfo.contains(entries[i].From) || progInfo.contains(entries[i].To) {
-					entries = entries[i:]
-					break
-				}
-			}
-
-			for i := len(entries) - 1; i >= 0; i-- {
-				if progInfo.contains(entries[i].From) || progInfo.contains(entries[i].To) {
-					entries = entries[:i+1]
-					break
-				}
-			}
-		} else {
-			for i := range entries {
-				if progInfo.contains(entries[i].From) {
-					entries = entries[i:]
-					break
-				}
-			}
-		}
-
-		if len(entries) == 0 {
-			return false
-		}
-	}
-
-	lbrEntries := make([]branchEntry, 0, len(entries))
-	for _, entry := range entries {
-		from := getLineInfo(entry.From, progs, addr2line, ksyms)
-		to := getLineInfo(entry.To, progs, addr2line, ksyms)
-		lbrEntries = append(lbrEntries, branchEntry{from, to})
-	}
-
-	last := len(lbrEntries) - 1
-	stack.pushFirstEntry(lbrEntries[last])
-	for i := last - 1; i >= 0; i-- {
-		stack.pushEntry(lbrEntries[i])
-	}
-
-	return true
-}
-
-func getFuncStack(event *Event, progs *bpfProgs, addr2line *Addr2Line, ksym *Kallsyms, funcStacks *ebpf.Map, symbolOnly bool, stack []string) ([]string, error) {
-	id := uint32(event.StackID)
-
-	var data FuncStack
-	err := funcStacks.Lookup(id, &data)
-	if err != nil {
-		if errors.Is(err, ebpf.ErrKeyNotExist) {
-			return stack, nil
-		}
-		return stack, fmt.Errorf("failed to lookup func stack map: %w", err)
-	}
-	_ = funcStacks.Delete(id)
-
-	ips := data.IPs[:]
-	if !verbose {
-		ips = ips[3:] // Skip the first 3 entries as they are entries for fentry/fexit and its trampoline.
-	}
-	for _, ip := range ips {
-		if ip == 0 {
-			continue
-		}
-
-		li := getLineInfo(uintptr(ip), progs, addr2line, ksym)
-
-		if symbolOnly {
-			stack = append(stack, li.funcName)
-			continue
-		}
-
-		var sb strings.Builder
-		fmt.Fprint(&sb, "  ")
-		if noColorOutput {
-			if verbose {
-				fmt.Fprintf(&sb, "0x%x:", ip)
-			}
-			fmt.Fprintf(&sb, "%-50s", fmt.Sprintf("%s+%#x", li.funcName, li.offset))
-			if li.fileName != "" {
-				fmt.Fprintf(&sb, "\t; %s:%d", li.fileName, li.fileLine)
-			}
-		} else {
-			if verbose {
-				color.New(color.FgBlue).Fprintf(&sb, "%#x", ip)
-				fmt.Fprint(&sb, ":")
-			}
-
-			offset := fmt.Sprintf("+%#x", li.offset)
-			color.RGB(0xE1, 0xD5, 0x77 /* light yellow */).Fprint(&sb, li.funcName)
-			fmt.Fprintf(&sb, "%-*s", 50-len(li.funcName), offset)
-			if li.fileName != "" {
-				color.RGB(0x88, 0x88, 0x88 /* gray */).Fprintf(&sb, "\t; %s:%d", li.fileName, li.fileLine)
-			}
-		}
-
-		fmt.Fprintln(&sb)
-
-		stack = append(stack, sb.String())
-	}
-
-	return stack, nil
 }

--- a/internal/bpfsnoop/bpfsnoop_func.go
+++ b/internal/bpfsnoop/bpfsnoop_func.go
@@ -1,0 +1,59 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package bpfsnoop
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf/btf"
+)
+
+type funcInfo struct {
+	name     string
+	proto    *btf.Func
+	args     []funcArgumentOutput
+	params   []FuncParamFlags
+	retParam FuncParamFlags
+	pktTuple bool
+	isTp     bool
+}
+
+func getFuncInfo(event *Event, helpers *Helpers) *funcInfo {
+	var info funcInfo
+
+	if progInfo, ok := helpers.Progs.funcs[event.FuncIP]; ok {
+		info.name = progInfo.funcName + "[bpf]"
+		info.proto = progInfo.funcProto
+		info.args = progInfo.funcArgs
+		info.params = progInfo.funcParams
+		info.retParam = progInfo.retParam
+		info.pktTuple = progInfo.pktOutput
+		return &info
+	}
+
+	ksym, ok := helpers.Ksyms.find(event.FuncIP)
+	if ok {
+		info.name = ksym.name
+	} else {
+		info.name = fmt.Sprintf("0x%x", event.FuncIP)
+	}
+
+	fn, ok := helpers.Kfuncs[event.FuncIP]
+	if !ok {
+		return &info
+	}
+
+	info.proto = fn.Func
+	info.args = fn.Args
+	info.params = fn.Prms
+	info.retParam = fn.Ret
+	info.pktTuple = fn.Pkt
+
+	if fn.IsTp {
+		info.name = fn.Func.Name + "[tp]"
+		info.isTp = true
+	}
+
+	return &info
+}

--- a/internal/bpfsnoop/bpfsnoop_func_data.go
+++ b/internal/bpfsnoop/bpfsnoop_func_data.go
@@ -1,0 +1,150 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package bpfsnoop
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/btf"
+	"github.com/fatih/color"
+
+	"github.com/bpfsnoop/bpfsnoop/internal/btfx"
+	"github.com/bpfsnoop/bpfsnoop/internal/strx"
+)
+
+type StrData struct {
+	Arg [32]byte
+	Ret [32]byte
+}
+
+func (s *StrData) arg() string {
+	return strx.NullTerminated(s.Arg[:])
+}
+
+func (s *StrData) ret() string {
+	return strx.NullTerminated(s.Ret[:])
+}
+
+type FnData struct {
+	Retval [2]uint64
+	Args   [MAX_BPF_FUNC_ARGS][2]uint64 // raw data + pointed data
+}
+
+func outputFnRetval(sb *strings.Builder, s string, info *funcInfo, event *Event, f btfx.FindSymbol) {
+	var retval string
+	if info.proto != nil {
+		rettyp := info.proto.Type.(*btf.FuncProto).Return
+		retval = btfx.ReprFuncReturn(rettyp, info.retParam.IsStr,
+			info.retParam.IsNumberPtr, event.Func.Retval[0], event.Func.Retval[1],
+			s, f)
+	} else {
+		retval = fmt.Sprintf("%#x/%s", uint64(event.Func.Retval[0]), event.Func.Retval[0])
+	}
+
+	if !noColorOutput {
+		color.New(color.FgGreen).Fprintf(sb, " retval")
+		fmt.Fprint(sb, "=")
+		color.New(color.FgRed).Fprintf(sb, "%s", retval)
+	} else {
+		fmt.Fprintf(sb, " retval=%s", retval)
+	}
+}
+
+func outputFnArgs(sb *strings.Builder, info *funcInfo, helpers *Helpers, strData *StrData, strs *ebpf.Map, event *Event, f btfx.FindSymbol) error {
+	if info.proto == nil {
+		fmt.Fprint(sb, "args=(..UNK..)")
+		outputFnRetval(sb, "", info, event, f)
+		return nil
+	}
+
+	funcParamColors := []*color.Color{
+		color.RGB(0x9d, 0x9d, 0x9d),
+		color.RGB(0x7a, 0x7a, 0x7a),
+		color.RGB(0x54, 0x54, 0x54),
+		color.RGB(0x9c, 0x91, 0x91),
+		color.RGB(0x7c, 0x74, 0x74),
+		color.RGB(0x5c, 0x54, 0x54),
+		color.RGB(0x9d, 0x9d, 0x9d),
+		color.RGB(0x7a, 0x7a, 0x7a),
+		color.RGB(0x54, 0x54, 0x54),
+		color.RGB(0x9c, 0x91, 0x91),
+		color.RGB(0x7c, 0x74, 0x74),
+		color.RGB(0x5c, 0x54, 0x54),
+	}
+
+	hasStrData := info.retParam.IsStr
+	if !hasStrData {
+		for _, prm := range info.params {
+			hasStrData = hasStrData || prm.IsStr
+		}
+	}
+
+	var argStr, retStr string
+	var notFound bool
+
+	if hasStrData {
+		b := ptr2bytes(unsafe.Pointer(strData), int(unsafe.Sizeof(*strData)))
+		err := strs.LookupAndDelete(event.SessID, b)
+		if err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
+			return fmt.Errorf("failed to lookup str data: %w", err)
+		}
+
+		if err == nil {
+			argStr, retStr = strData.arg(), strData.ret()
+		} else {
+			retStr = fmt.Sprintf("%#16x", uint64(event.Func.Retval[0]))
+			notFound = true
+		}
+	}
+
+	fmt.Fprintf(sb, "=(")
+
+	params := info.proto.Type.(*btf.FuncProto).Params
+	lastIdx, idx := len(params)-1, 0
+	strUsed := false
+	for i, fnParam := range info.params {
+		if fnParam.partOfPrevParam {
+			continue
+		}
+
+		if idx != 0 {
+			fmt.Fprint(sb, ", ")
+		}
+
+		arg := event.Func.Args[i]
+
+		if strUsed {
+			argStr = ""
+		}
+		strUsed = strUsed || fnParam.IsStr
+		if fnParam.IsStr && notFound {
+			argStr = fmt.Sprintf("%#16x", arg[0])
+		}
+
+		valNext := arg[0]
+		if i < lastIdx {
+			valNext = event.Func.Args[i+1][0]
+		}
+
+		fp := btfx.ReprFuncParam(&params[idx], i, fnParam.IsStr, fnParam.IsNumberPtr, arg[0], arg[1], valNext, argStr, f)
+		if !noColorOutput {
+			funcParamColors[i].Fprint(sb, fp)
+		} else {
+			fmt.Fprintf(sb, "%s", fp)
+		}
+
+		idx++
+	}
+	fmt.Fprintf(sb, ")")
+
+	if mode == TracingModeExit && !info.isTp {
+		outputFnRetval(sb, retStr, info, event, f)
+	}
+
+	return nil
+}

--- a/internal/bpfsnoop/bpfsnoop_func_stack.go
+++ b/internal/bpfsnoop/bpfsnoop_func_stack.go
@@ -1,0 +1,119 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package bpfsnoop
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/cilium/ebpf"
+	"github.com/fatih/color"
+)
+
+type FuncStack struct {
+	IPs [MAX_STACK_DEPTH]uint64
+}
+
+type fnStack struct {
+	stack []string
+}
+
+func newFnStack() *fnStack {
+	return &fnStack{
+		stack: make([]string, 0, MAX_STACK_DEPTH),
+	}
+}
+
+func (s *fnStack) reset() {
+	s.stack = s.stack[:0]
+}
+
+func (s *fnStack) get(event *Event, helpers *Helpers, stacks *ebpf.Map, symbolOnly bool) error {
+	id := uint32(event.StackID)
+
+	var data FuncStack
+	err := stacks.Lookup(id, &data)
+	if err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return nil
+		}
+		return fmt.Errorf("failed to lookup func stack map: %w", err)
+	}
+	_ = stacks.Delete(id)
+
+	ips := data.IPs[:]
+	if !verbose {
+		ips = ips[3:] // Skip the first 3 entries as they are entries for fentry/fexit and its trampoline.
+	}
+	for _, ip := range ips {
+		if ip == 0 {
+			continue
+		}
+
+		li := getLineInfo(uintptr(ip), helpers.Progs, helpers.Addr2line, helpers.Ksyms)
+
+		if symbolOnly {
+			s.stack = append(s.stack, li.funcName)
+			continue
+		}
+
+		var sb strings.Builder
+		fmt.Fprint(&sb, "  ")
+		if noColorOutput {
+			if verbose {
+				fmt.Fprintf(&sb, "0x%x:", ip)
+			}
+			fmt.Fprintf(&sb, "%-50s", fmt.Sprintf("%s+%#x", li.funcName, li.offset))
+			if li.fileName != "" {
+				fmt.Fprintf(&sb, "\t; %s:%d", li.fileName, li.fileLine)
+			}
+		} else {
+			if verbose {
+				color.New(color.FgBlue).Fprintf(&sb, "%#x", ip)
+				fmt.Fprint(&sb, ":")
+			}
+
+			offset := fmt.Sprintf("+%#x", li.offset)
+			color.RGB(0xE1, 0xD5, 0x77 /* light yellow */).Fprint(&sb, li.funcName)
+			fmt.Fprintf(&sb, "%-*s", 50-len(li.funcName), offset)
+			if li.fileName != "" {
+				color.RGB(0x88, 0x88, 0x88 /* gray */).Fprintf(&sb, "\t; %s:%d", li.fileName, li.fileLine)
+			}
+		}
+
+		fmt.Fprintln(&sb)
+
+		s.stack = append(s.stack, sb.String())
+	}
+
+	return nil
+}
+
+func (s *fnStack) output(sb *strings.Builder, helpers *Helpers, stacks *ebpf.Map, fg *FlameGraph, event *Event) error {
+	if !outputFuncStack || event.StackID <= 0 {
+		return nil
+	}
+
+	err := s.get(event, helpers, stacks, outputFlameGraph != "")
+	if err != nil {
+		return fmt.Errorf("failed to get function stack: %w", err)
+	}
+	if len(s.stack) == 0 {
+		return nil
+	}
+
+	if outputFlameGraph == "" {
+		fmt.Fprintln(sb, "Func stack:")
+		for _, line := range s.stack {
+			fmt.Fprint(sb, line)
+		}
+	} else {
+		slices.Reverse(s.stack)
+		fg.AddStack(s.stack, 1)
+	}
+
+	return nil
+}

--- a/internal/bpfsnoop/bpfsnoop_lbr.go
+++ b/internal/bpfsnoop/bpfsnoop_lbr.go
@@ -1,0 +1,108 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package bpfsnoop
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+)
+
+type LbrEntry struct {
+	From  uintptr
+	To    uintptr
+	Flags uint64
+}
+
+type LbrData struct {
+	Entries [32]LbrEntry
+	NrBytes int64
+}
+
+func (s *lbrStack) get(funcIP uintptr, lbrData *LbrData, helpers *Helpers) bool {
+	progs, addr2line, ksyms := helpers.Progs, helpers.Addr2line, helpers.Ksyms
+	progInfo, isProg := progs.funcs[funcIP]
+
+	nrEntries := lbrData.NrBytes / int64(8*3)
+	entries := lbrData.Entries[:nrEntries]
+	if !verbose {
+		if !isProg {
+			for i := range entries {
+				if ksym, ok := ksyms.find(entries[i].From); ok && ksym.addr == uint64(funcIP) {
+					entries = entries[i:]
+					break
+				}
+			}
+		} else if mode == TracingModeExit {
+			for i := range entries {
+				if progInfo.contains(entries[i].From) || progInfo.contains(entries[i].To) {
+					entries = entries[i:]
+					break
+				}
+			}
+
+			for i := len(entries) - 1; i >= 0; i-- {
+				if progInfo.contains(entries[i].From) || progInfo.contains(entries[i].To) {
+					entries = entries[:i+1]
+					break
+				}
+			}
+		} else {
+			for i := range entries {
+				if progInfo.contains(entries[i].From) {
+					entries = entries[i:]
+					break
+				}
+			}
+		}
+
+		if len(entries) == 0 {
+			return false
+		}
+	}
+
+	lbrEntries := make([]branchEntry, 0, len(entries))
+	for _, entry := range entries {
+		from := getLineInfo(entry.From, progs, addr2line, ksyms)
+		to := getLineInfo(entry.To, progs, addr2line, ksyms)
+		lbrEntries = append(lbrEntries, branchEntry{from, to})
+	}
+
+	last := len(lbrEntries) - 1
+	s.pushFirstEntry(lbrEntries[last])
+	for i := last - 1; i >= 0; i-- {
+		s.pushEntry(lbrEntries[i])
+	}
+
+	return true
+}
+
+func (s *lbrStack) outputStack(sb *strings.Builder, helpers *Helpers, lbrData *LbrData, lbrs *ebpf.Map, ev *Event) error {
+	if !outputLbr {
+		return nil
+	}
+
+	b := ptr2bytes(unsafe.Pointer(lbrData), int(unsafe.Sizeof(*lbrData)))
+	err := lbrs.LookupAndDelete(ev.SessID, b)
+	if err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return nil
+		}
+		return fmt.Errorf("failed to lookup lbr data: %w", err)
+	}
+
+	hasLbrEntries := lbrData.NrBytes > 0 && lbrData.Entries[0] != (LbrEntry{})
+	hasLbrEntries = hasLbrEntries && s.get(ev.FuncIP, lbrData, helpers)
+	if !hasLbrEntries {
+		return nil
+	}
+
+	fmt.Fprintln(sb, "LBR stack:")
+	s.output(sb)
+
+	return nil
+}

--- a/internal/btfx/types.go
+++ b/internal/btfx/types.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cilium/ebpf/btf"
 )
 
-type findSymbol func(addr uint64) string
+type FindSymbol func(addr uint64) string
 
 func IsPointer(t btf.Type) bool {
 	t = mybtf.UnderlyingType(t)
@@ -207,7 +207,7 @@ func ReprEnumValue(t btf.Type, val uint64) string {
 	return fmt.Sprintf("%d", val)
 }
 
-func reprMember(sb *strings.Builder, m *btf.Member, data []byte, find findSymbol) {
+func reprMember(sb *strings.Builder, m *btf.Member, data []byte, find FindSymbol) {
 	if m.Name != "" {
 		fmt.Fprintf(sb, "%s=", m.Name)
 	}
@@ -218,7 +218,7 @@ func reprMember(sb *strings.Builder, m *btf.Member, data []byte, find findSymbol
 	}
 }
 
-func reprStructUnion(sb *strings.Builder, name string, members []btf.Member, data []byte, find findSymbol) {
+func reprStructUnion(sb *strings.Builder, name string, members []btf.Member, data []byte, find FindSymbol) {
 	fmt.Fprintf(sb, "%s{", name)
 	for i, m := range members {
 		if i > 0 {
@@ -229,7 +229,7 @@ func reprStructUnion(sb *strings.Builder, name string, members []btf.Member, dat
 	fmt.Fprint(sb, "}")
 }
 
-func ReprValue(t btf.Type, val, valNext uint64, find findSymbol) string {
+func ReprValue(t btf.Type, val, valNext uint64, find FindSymbol) string {
 	t = mybtf.UnderlyingType(t)
 
 	var sb strings.Builder
@@ -311,7 +311,7 @@ func ReprValue(t btf.Type, val, valNext uint64, find findSymbol) string {
 	return sb.String()
 }
 
-func reprValue(sb *strings.Builder, t btf.Type, isStr, isNumberPtr bool, data, data2, dataNext uint64, s string, f findSymbol) {
+func reprValue(sb *strings.Builder, t btf.Type, isStr, isNumberPtr bool, data, data2, dataNext uint64, s string, f FindSymbol) {
 	if isStr {
 		fmt.Fprintf(sb, "\"%s\"", s)
 	} else if isNumberPtr {
@@ -326,7 +326,7 @@ func reprValue(sb *strings.Builder, t btf.Type, isStr, isNumberPtr bool, data, d
 	}
 }
 
-func ReprValueType(name string, t btf.Type, isStr, isNumberPtr bool, data, data2, dataNext uint64, s string, f findSymbol) string {
+func ReprValueType(name string, t btf.Type, isStr, isNumberPtr bool, data, data2, dataNext uint64, s string, f FindSymbol) string {
 	var sb strings.Builder
 
 	fmt.Fprintf(&sb, "(%v)%s=", Repr(t), name)
@@ -336,11 +336,11 @@ func ReprValueType(name string, t btf.Type, isStr, isNumberPtr bool, data, data2
 	return sb.String()
 }
 
-func ReprFuncParam(param *btf.FuncParam, i int, isStr, isNumberPtr bool, data, data2, dataNext uint64, s string, f findSymbol) string {
+func ReprFuncParam(param *btf.FuncParam, i int, isStr, isNumberPtr bool, data, data2, dataNext uint64, s string, f FindSymbol) string {
 	return ReprValueType(param.Name, param.Type, isStr, isNumberPtr, data, data2, dataNext, s, f)
 }
 
-func ReprFuncReturn(typ btf.Type, isStr, isNumberPtr bool, data, data2 uint64, s string, f findSymbol) string {
+func ReprFuncReturn(typ btf.Type, isStr, isNumberPtr bool, data, data2 uint64, s string, f FindSymbol) string {
 	typ = mybtf.UnderlyingType(typ)
 	if _, ok := typ.(*btf.Void); ok {
 		return "(void)"

--- a/main.go
+++ b/main.go
@@ -208,7 +208,13 @@ func main() {
 	})
 
 	errg.Go(func() error {
-		return bpfsnoop.Run(reader, bpfProgs, addr2line, kallsyms, kfuncs, reusedMaps, w)
+		helpers := bpfsnoop.Helpers{
+			Progs:     bpfProgs,
+			Addr2line: addr2line,
+			Ksyms:     kallsyms,
+			Kfuncs:    kfuncs,
+		}
+		return bpfsnoop.Run(reader, &helpers, reusedMaps, w)
 	})
 
 	err = errg.Wait()


### PR DESCRIPTION
Separate huge `Run()` function to several functions in order to improve readability, extensibility and to fix some code logic bugs hide in it.