### PR TITLE
fninsn: Kprobe kfunc instructions 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,9 @@ $(READ_BPF_OBJ): $(READ_BPF_SRC) $(VMLINUX_OBJ)
 $(TAILCALL_BPF_OBJ): $(TAILCALL_BPF_SRC) $(VMLINUX_OBJ)
 	$(BPF2GO) tailcall bpf/tailcall.c -- $(BPF2GO_EXTRA_FLAGS)
 
+$(INSN_BPF_OBJ): $(INSN_BPF_SRC) $(VMLINUX_OBJ)
+	$(BPF2GO) insn bpf/bpfsnoop_insn.c -- $(BPF2GO_EXTRA_FLAGS)
+
 $(BPFSNOOP_BPF_OBJ): $(BPFSNOOP_BPF_SRC) $(VMLINUX_OBJ)
 	$(BPF2GO) bpfsnoop bpf/bpfsnoop.c -- $(BPF2GO_EXTRA_FLAGS)
 
@@ -62,4 +65,4 @@ publish: local_release
 	@if [ -z "$(VERSION)" ]; then echo "VERSION is not set"; exit 1; fi
 	$(CMD_TAR) -czf $(DIR_BIN)/$(BPFSNOOP_OBJ)-$(VERSION)-linux-amd64.tar.gz $(DIR_BIN)/$(BPFSNOOP_OBJ) $(DIR_BIN)/$(BPFSNOOP_CSM)
 	@$(CMD_MV) $(RELEASE_NOTES) $(DIR_BIN)/$(RELEASE_NOTES)
-	$(CMD_GH) release create $(VERSION) $(DIR_BIN)/$(BPFSNOOP_OBJ)-$(VERSION)-linux-amd64.tar.gz --title "BPFSNOOP $(VERSION)" --notes-file $(DIR_BIN)/$(RELEASE_NOTES)
+	$(CMD_GH) release create $(VERSION) $(DIR_BIN)/$(BPFSNOOP_OBJ)-$(VERSION)-linux-amd64.tar.gz --title "bpfsnoop $(VERSION)" --notes-file $(DIR_BIN)/$(RELEASE_NOTES)

--- a/bpf/bpfsnoop.c
+++ b/bpf/bpfsnoop.c
@@ -8,17 +8,19 @@
 #include "bpfsnoop.h"
 #include "bpfsnoop_arg_filter.h"
 #include "bpfsnoop_arg_output.h"
+#include "bpfsnoop_cfg.h"
+#include "bpfsnoop_event.h"
 #include "bpfsnoop_fn_data_output.h"
 #include "bpfsnoop_lbr.h"
 #include "bpfsnoop_pkt_filter.h"
 #include "bpfsnoop_pkt_output.h"
+#include "bpfsnoop_sess.h"
 
 volatile const __u32 PID = -1;
+volatile const __u32 CPU_MASK = 0xFFFF;
+volatile const __u64 FUNC_IP = 0;
 
 __u32 ready SEC(".data.ready") = 0;
-
-volatile const __u64 FUNC_IP = 0;
-volatile const __u32 CPU_MASK = 0xFFFF;
 
 #define MAX_STACK_DEPTH 50
 struct {
@@ -27,11 +29,6 @@ struct {
     __uint(key_size, sizeof(u32));
     __uint(value_size, MAX_STACK_DEPTH * sizeof(u64));
 } bpfsnoop_stacks SEC(".maps");
-
-struct {
-    __uint(type, BPF_MAP_TYPE_RINGBUF);
-    __uint(max_entries, 4096<<8);
-} bpfsnoop_events SEC(".maps");
 
 struct event bpfsnoop_evt_buff[1] SEC(".data.events");
 
@@ -54,9 +51,8 @@ get_tracee_caller_fp(void)
 }
 
 static __always_inline __u64
-gen_session_id(void)
+gen_session_id(__u64 fp)
 {
-    __u64 fp = get_tracee_caller_fp();
     __u32 rnd = bpf_get_prandom_u32();
 
     return ((__u64) rnd) << 32 | (fp & 0xFFFFFFFF);
@@ -65,14 +61,16 @@ gen_session_id(void)
 static __always_inline int
 emit_bpfsnoop_event(void *ctx)
 {
+    struct bpfsnoop_sess *sess, sess_init = {};
     struct bpfsnoop_lbr_data *lbr;
     struct bpfsnoop_str_data *str;
     struct bpfsnoop_pkt_data *pkt;
     struct bpfsnoop_arg_data *arg;
+    __u64 fp, session_id = 0;
     __u64 args[MAX_FN_ARGS];
+    bool can_output = false;
     struct event *evt;
     __u64 retval = 0;
-    __u64 session_id;
     size_t event_sz;
     __u32 cpu, pid;
 
@@ -86,7 +84,8 @@ emit_bpfsnoop_event(void *ctx)
     arg = &bpfsnoop_arg_buff[cpu];
     evt = &bpfsnoop_evt_buff[cpu];
 
-    if (cfg->output_lbr)
+    can_output = !cfg->both_entry_exit || cfg->is_entry;
+    if (cfg->output_lbr && can_output)
         lbr->nr_bytes = bpf_get_branch_snapshot(lbr->entries, sizeof(lbr->entries), 0); /* required 5.16 kernel. */
 
     /* Other filters must be after bpf_get_branch_snapshot() to avoid polluting
@@ -102,19 +101,44 @@ emit_bpfsnoop_event(void *ctx)
     if (cfg->pid && pid != cfg->pid)
         return BPF_OK;
 
-    session_id = gen_session_id();
-    if (!filter(args, session_id))
-        return BPF_OK;
+    fp = get_tracee_caller_fp();
+    if (cfg->both_entry_exit) {
+        if (cfg->is_entry) {
+            session_id = gen_session_id(fp);
+            if (!filter(args, session_id))
+                return BPF_OK;
 
+            sess_init.session_id = session_id;
+            add_session(fp, &sess_init);
+            evt->type = BPFSNOOP_EVENT_TYPE_FUNC_ENTRY;
+        } else {
+            sess = get_and_del_session(fp);
+            if (!sess)
+                return BPF_OK;
+
+            session_id = sess->session_id - 1;
+            evt->type = BPFSNOOP_EVENT_TYPE_FUNC_EXIT;
+        }
+    } else {
+        session_id = gen_session_id(fp);
+        if (!filter(args, session_id))
+            return BPF_OK;
+
+        evt->type = cfg->is_entry ? BPFSNOOP_EVENT_TYPE_FUNC_ENTRY
+                                  : BPFSNOOP_EVENT_TYPE_FUNC_EXIT;
+    }
+
+    evt->length = sizeof(*evt);
+    evt->kernel_ts = (__u32) bpf_ktime_get_ns();
     evt->session_id = session_id;
     evt->func_ip = FUNC_IP;
     evt->cpu = cpu;
     evt->pid = pid;
     bpf_get_current_comm(evt->comm, sizeof(evt->comm));
     evt->func_stack_id = -1;
-    if (cfg->output_stack)
+    if (cfg->output_stack && can_output)
         evt->func_stack_id = bpf_get_stackid(ctx, &bpfsnoop_stacks, BPF_F_FAST_STACK_CMP);
-    if (cfg->output_lbr)
+    if (cfg->output_lbr && can_output)
         output_lbr_data(lbr, session_id);
     output_fn_data(evt, str, args, retval);
     if (cfg->output_pkt)

--- a/bpf/bpfsnoop.h
+++ b/bpf/bpfsnoop.h
@@ -4,60 +4,7 @@
 #ifndef __BPFSNOOP_H_
 #define __BPFSNOOP_H_
 
-#include "vmlinux.h"
-
 #define BPFSNOOP_MAX_ENTRIES 65536
-
-struct bpfsnoop_fn_arg_flags {
-    bool is_number_ptr;
-    bool is_str;
-};
-
 #define MAX_FN_ARGS 12
-struct bpfsnoop_fn_args {
-    struct bpfsnoop_fn_arg_flags args[MAX_FN_ARGS];
-    __u32 nr_fn_args;
-    struct bpfsnoop_fn_arg_flags ret;
-    bool with_retval;
-    __u8 pad;
-} __attribute__((packed));
-
-struct bpfsnoop_config {
-    __u32 output_lbr:1;
-    __u32 output_stack:1;
-    __u32 output_pkt:1;
-    __u32 output_arg:1;
-    __u32 pad:28;
-    __u32 pid;
-
-    struct bpfsnoop_fn_args fn_args;
-} __attribute__((packed));
-
-volatile const struct bpfsnoop_config bpfsnoop_config = {};
-#define cfg (&bpfsnoop_config)
-
-struct bpfsnoop_fn_arg_data {
-    __u64 raw_data;
-    __u64 ptr_data;
-};
-
-struct bpfsnoop_fn_data {
-    struct bpfsnoop_fn_arg_data retval;
-    struct bpfsnoop_fn_arg_data args[MAX_FN_ARGS];
-};
-
-struct event {
-    __u64 session_id;
-    __u64 func_ip;
-    __u32 cpu;
-    __u32 pid;
-    __u8 comm[16];
-    __s64 func_stack_id;
-
-    /* fn_data must be the last attr of event in order to output arg data on
-     * demand.
-     */
-    struct bpfsnoop_fn_data fn_data;
-};
 
 #endif // __BPFSNOOP_H_

--- a/bpf/bpfsnoop_cfg.h
+++ b/bpf/bpfsnoop_cfg.h
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0 OR Apache-2.0
+/* Copyright 2025 Leon Hwang */
+
+#ifndef __BPFSNOOP_CFG_H_
+#define __BPFSNOOP_CFG_H_
+
+#include "vmlinux.h"
+
+#include "bpfsnoop.h"
+
+struct bpfsnoop_fn_arg_flags {
+    bool is_number_ptr;
+    bool is_str;
+};
+
+struct bpfsnoop_fn_args {
+    struct bpfsnoop_fn_arg_flags args[MAX_FN_ARGS];
+    __u32 nr_fn_args;
+    struct bpfsnoop_fn_arg_flags ret;
+    bool with_retval;
+    __u8 pad;
+} __attribute__((packed));
+
+struct bpfsnoop_config {
+    __u32 output_lbr:1;
+    __u32 output_stack:1;
+    __u32 output_pkt:1;
+    __u32 output_arg:1;
+    __u32 both_entry_exit:1;
+    __u32 is_entry:1;
+    __u32 pad:26;
+    __u32 pid;
+
+    struct bpfsnoop_fn_args fn_args;
+} __attribute__((packed));
+
+volatile const struct bpfsnoop_config bpfsnoop_config = {};
+#define cfg (&bpfsnoop_config)
+
+#endif // __BPFSNOOP_CFG_H_

--- a/bpf/bpfsnoop_event.h
+++ b/bpf/bpfsnoop_event.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0 OR Apache-2.0
+/* Copyright 2025 Leon Hwang */
+
+#ifndef __BPFSNOOP_EVENT_H_
+#define __BPFSNOOP_EVENT_H_
+
+#include "vmlinux.h"
+
+#include "bpfsnoop.h"
+
+enum {
+    BPFSNOOP_EVENT_TYPE_UNSPEC = 0,
+    BPFSNOOP_EVENT_TYPE_FUNC_ENTRY,
+    BPFSNOOP_EVENT_TYPE_FUNC_EXIT,
+    BPFSNOOP_EVENT_TYPE_INSN,
+};
+
+struct bpfsnoop_fn_arg_data {
+    __u64 raw_data;
+    __u64 ptr_data;
+};
+
+struct bpfsnoop_fn_data {
+    struct bpfsnoop_fn_arg_data retval;
+    struct bpfsnoop_fn_arg_data args[MAX_FN_ARGS];
+};
+
+struct event {
+    __u16 type;
+    __u16 length;
+    __u32 kernel_ts;
+    __u64 session_id;
+    __u64 func_ip;
+    __u32 cpu;
+    __u32 pid;
+    __u8 comm[16];
+    __s64 func_stack_id;
+
+    /* fn_data must be the last attr of event in order to output arg data on
+     * demand.
+     */
+    struct bpfsnoop_fn_data fn_data;
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 4096<<8);
+} bpfsnoop_events SEC(".maps");
+
+#endif // __BPFSNOOP_EVENT_H_

--- a/bpf/bpfsnoop_fn_data_output.h
+++ b/bpf/bpfsnoop_fn_data_output.h
@@ -9,6 +9,8 @@
 #include "bpf_helpers.h"
 
 #include "bpfsnoop.h"
+#include "bpfsnoop_cfg.h"
+#include "bpfsnoop_event.h"
 
 struct bpfsnoop_str_data {
     __u8 arg[32];

--- a/bpf/bpfsnoop_insn.c
+++ b/bpf/bpfsnoop_insn.c
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0 OR Apache-2.0
+/* Copyright 2025 Leon Hwang */
+#include "vmlinux.h"
+#include "bpf_helpers.h"
+#include "bpf_tracing.h"
+#include "bpf_map_helpers.h"
+
+#include "bpfsnoop_event.h"
+#include "bpfsnoop_sess.h"
+
+volatile const __u64 INSN_IP = 0;
+
+__u32 ready SEC(".data.ready") = 0;
+
+struct bpfsnoop_insn_event {
+    __u16 type;
+    __u16 length;
+    __u32 kernel_ts;
+    __u64 session_id;
+    __u64 insn_ip;
+    __u32 cpu;
+};
+
+static __always_inline struct bpfsnoop_sess *
+try_get_session(struct pt_regs *ctx)
+{
+    struct bpfsnoop_sess *sess;
+    __u64 fp;
+    int i;
+
+    fp = PT_REGS_FP(ctx);
+    const int max_tries = 3;
+    for (i = 0; i < max_tries; i++) {
+        (void) bpf_probe_read_kernel(&fp, sizeof(fp), (void *) fp);
+        sess = get_session(fp);
+        if (sess)
+            return sess;
+    }
+
+    return NULL;
+}
+
+SEC("kprobe")
+int k_insn(struct pt_regs *ctx)
+{
+    struct bpfsnoop_insn_event init_event = {}, *evt = &init_event;
+    struct bpfsnoop_sess *sess;
+
+    if (!ready)
+        return BPF_OK;
+
+    sess = try_get_session(ctx);
+    if (!sess)
+        return BPF_OK;
+
+    evt->type = BPFSNOOP_EVENT_TYPE_INSN;
+    evt->length = sizeof(*evt);
+    evt->kernel_ts = (__u32) bpf_ktime_get_ns();
+    evt->session_id = sess->session_id;
+    evt->insn_ip = INSN_IP;
+    evt->cpu = bpf_get_smp_processor_id();
+
+    bpf_ringbuf_output(&bpfsnoop_events, evt, sizeof(*evt), 0);
+
+    return BPF_OK;
+}
+
+char __license[] SEC("license") = "GPL";

--- a/bpf/bpfsnoop_sess.h
+++ b/bpf/bpfsnoop_sess.h
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0 OR Apache-2.0
+/* Copyright 2025 Leon Hwang */
+
+#ifndef __BPFSNOOP_SESS_H_
+#define __BPFSNOOP_SESS_H_
+
+#include "vmlinux.h"
+
+#include "bpf_helpers.h"
+
+#include "bpfsnoop.h"
+
+struct bpfsnoop_sess {
+    __u64 session_id;
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, BPFSNOOP_MAX_ENTRIES);
+    __type(key, __u64);
+    __type(value, struct bpfsnoop_sess);
+} bpfsnoop_sessions SEC(".maps");
+
+static __always_inline void
+add_session(__u64 fp, struct bpfsnoop_sess *sess)
+{
+    (void) bpf_map_update_elem(&bpfsnoop_sessions, &fp, sess, BPF_ANY);
+}
+
+static __always_inline struct bpfsnoop_sess *
+get_session(__u64 fp)
+{
+    return (struct bpfsnoop_sess *) bpf_map_lookup_elem(&bpfsnoop_sessions, &fp);
+}
+
+static __always_inline struct bpfsnoop_sess *
+get_and_del_session(__u64 fp)
+{
+    struct bpfsnoop_sess *sess;
+
+    sess = (typeof(sess)) bpf_map_lookup_elem(&bpfsnoop_sessions, &fp);
+    if (sess)
+        (void) bpf_map_delete_elem(&bpfsnoop_sessions, &fp);
+
+    return sess;
+}
+
+#endif // __BPFSNOOP_SESS_H_

--- a/bpf/read.c
+++ b/bpf/read.c
@@ -7,7 +7,7 @@
 
 volatile const __u64 __addr;
 volatile const __u32 __size = 0;
-__u8 buff[4096];
+__u8 buff[4096] SEC(".data.buff");
 bool run SEC(".data.run");
 
 SEC("fentry/__x64_sys_nanosleep")

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/gobwas/glob v0.2.3
 	github.com/hashicorp/golang-lru/v2 v2.0.7
-	github.com/jschwinger233/elibpcap v1.0.0
+	github.com/jschwinger233/elibpcap v1.0.1
 	github.com/klauspost/compress v1.17.11
 	github.com/leonhwangprojects/bice v0.1.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20240912202439-0a2b6291aafd h1:EVX1s+X
 github.com/ianlancetaylor/demangle v0.0.0-20240912202439-0a2b6291aafd/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
 github.com/josharian/native v1.1.0 h1:uuaP0hAbW7Y4l0ZRQ6C9zfb7Mg1mbFKry/xzDAfmtLA=
 github.com/josharian/native v1.1.0/go.mod h1:7X/raswPFr05uY3HiLlYeyQntB6OO7E/d2Cu7qoaN2w=
-github.com/jschwinger233/elibpcap v1.0.0 h1:UQuP3XT9orz26lW6DPTu9B9OBYirB57LmhPNGxQqU2U=
-github.com/jschwinger233/elibpcap v1.0.0/go.mod h1:fUmq00C6Pechtr089JDPhvIc6TxrbUHDlZ5QCYc9tJQ=
+github.com/jschwinger233/elibpcap v1.0.1 h1:VK2nupxq9eLry2shRw4ujvCOQ/MW42ZhDyiQEcL0qlk=
+github.com/jschwinger233/elibpcap v1.0.1/go.mod h1:fUmq00C6Pechtr089JDPhvIc6TxrbUHDlZ5QCYc9tJQ=
 github.com/jsimonetti/rtnetlink/v2 v2.0.1 h1:xda7qaHDSVOsADNouv7ukSuicKZO7GgVUCXxpaIEIlM=
 github.com/jsimonetti/rtnetlink/v2 v2.0.1/go.mod h1:7MoNYNbb3UaDHtF8udiJo/RH6VsTKP1pqKLUTVCvToE=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=

--- a/internal/bpfsnoop/bpf_read_kernel.go
+++ b/internal/bpfsnoop/bpf_read_kernel.go
@@ -11,9 +11,13 @@ import (
 	"github.com/cilium/ebpf/link"
 )
 
+const (
+	readLimit = 65536
+)
+
 func readKernel(spec *ebpf.CollectionSpec, addr uint64, size uint32) ([]byte, error) {
 	readSize := (size + 7) & (^uint32(7)) // round up to 8-times bytes
-	if readSize > 65536 {
+	if readSize > readLimit {
 		return nil, fmt.Errorf("read size %d is too large", readSize)
 	}
 

--- a/internal/bpfsnoop/bpfsnoop.go
+++ b/internal/bpfsnoop/bpfsnoop.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 	"unsafe"
 
 	"github.com/cilium/ebpf"
@@ -18,10 +19,16 @@ import (
 )
 
 const (
-	MAX_STACK_DEPTH = 50
+	eventTypeUnspec uint16 = iota
+	eventTypeFuncEntry
+	eventTypeFuncExit
+	eventTypeInsn
 )
 
 type Event struct {
+	Type    uint16
+	Length  uint16
+	KernNs  uint32
 	SessID  uint64
 	FuncIP  uintptr
 	CPU     uint32
@@ -40,11 +47,13 @@ type Helpers struct {
 	Addr2line *Addr2Line
 	Ksyms     *Kallsyms
 	Kfuncs    KFuncs
+	Insns     *FuncInsns
 }
 
 func Run(reader *ringbuf.Reader, helpers *Helpers, maps map[string]*ebpf.Map, w io.Writer) error {
 	lbrStack := newLBRStack()
 	fnStack := newFnStack()
+	sess := NewSessions()
 
 	stacks := maps["bpfsnoop_stacks"]
 	lbrs := maps["bpfsnoop_lbrs"]
@@ -84,12 +93,35 @@ func Run(reader *ringbuf.Reader, helpers *Helpers, maps map[string]*ebpf.Map, w 
 			return fmt.Errorf("failed to read ringbuf: %w", err)
 		}
 
+		typ := *(*uint16)(unsafe.Pointer(&record.RawSample[0]))
+		if typ == eventTypeInsn {
+			event := (*InsnEvent)(unsafe.Pointer(&record.RawSample[0]))
+			if ok := outputInsnEvent(&sb, sess, helpers.Insns, event); ok {
+				fmt.Fprintln(w, sb.String())
+				sb.Reset()
+			}
+			continue
+		}
+
 		if len(record.RawSample) < int(unsafe.Sizeof(Event{}))-int(unsafe.Sizeof(FnData{})) {
 			continue
 		}
 
 		event := (*Event)(unsafe.Pointer(&record.RawSample[0]))
 		fnInfo := getFuncInfo(event, helpers)
+
+		var duration time.Duration
+		withDuration := fnInfo.insnMode
+		if withDuration {
+			if event.Type == eventTypeFuncEntry {
+				sess.Add(event.SessID, event.KernNs)
+			} else {
+				s, ok := sess.GetAndDel(event.SessID + 1)
+				if ok {
+					duration = time.Duration(event.KernNs - s.started)
+				}
+			}
+		}
 
 		if !noColorOutput {
 			color.New(color.FgYellow, color.Bold).Fprint(&sb, fnInfo.name, " ")
@@ -98,7 +130,7 @@ func Run(reader *ringbuf.Reader, helpers *Helpers, maps map[string]*ebpf.Map, w 
 			fmt.Fprint(&sb, fnInfo.name, " args")
 		}
 
-		err = outputFnArgs(&sb, fnInfo, helpers, &strData, strs, event, findSymbol)
+		err = outputFnArgs(&sb, fnInfo, helpers, &strData, strs, event, findSymbol, event.Type == eventTypeFuncExit)
 		if err != nil {
 			return fmt.Errorf("failed to output function data: %w", err)
 		}
@@ -106,8 +138,14 @@ func Run(reader *ringbuf.Reader, helpers *Helpers, maps map[string]*ebpf.Map, w 
 		if !noColorOutput {
 			color.New(color.FgCyan).Fprintf(&sb, " cpu=%d", event.CPU)
 			color.New(color.FgMagenta).Fprintf(&sb, " process=(%d:%s)", event.Pid, strx.NullTerminated(event.Comm[:]))
+			if withDuration && event.Type == eventTypeFuncExit {
+				color.RGB(0xFF, 0x00, 0x7F /* rose red */).Fprintf(&sb, " duration=%s", duration)
+			}
 		} else {
 			fmt.Fprintf(&sb, " cpu=%d process=(%d:%s)", event.CPU, event.Pid, strx.NullTerminated(event.Comm[:]))
+			if withDuration && event.Type == eventTypeFuncExit {
+				fmt.Fprintf(&sb, " duration=%s", duration)
+			}
 		}
 		fmt.Fprintln(&sb)
 
@@ -131,7 +169,10 @@ func Run(reader *ringbuf.Reader, helpers *Helpers, maps map[string]*ebpf.Map, w 
 			return fmt.Errorf("failed to output function stack: %w", err)
 		}
 
-		fmt.Fprintln(w, sb.String())
+		if !withDuration || event.Type == eventTypeFuncExit {
+			fmt.Fprintln(&sb)
+		}
+		fmt.Fprint(w, sb.String())
 
 		sb.Reset()
 		lbrStack.reset()

--- a/internal/bpfsnoop/bpfsnoop_config.go
+++ b/internal/bpfsnoop/bpfsnoop_config.go
@@ -4,10 +4,12 @@
 package bpfsnoop
 
 const (
-	lbrConfigFlagOutputLbrIdx = 0 + iota
-	lbrConfigFlagOutputStackIdx
-	lbrConfigFlagOutputPktIdx
-	lbrConfigFlagOutputArgIdx
+	configFlagOutputLbrIdx = 0 + iota
+	configFlagOutputStackIdx
+	configFlagOutputPktIdx
+	configFlagOutputArgIdx
+	configFlagBothEntryExitIdx
+	configFlagIsEntryIdx
 )
 
 type BpfsnoopConfig struct {
@@ -22,24 +24,36 @@ type BpfsnoopConfig struct {
 
 func (cfg *BpfsnoopConfig) SetOutputLbr(v bool) {
 	if v {
-		cfg.Flags |= 1 << lbrConfigFlagOutputLbrIdx
+		cfg.Flags |= 1 << configFlagOutputLbrIdx
 	}
 }
 
 func (cfg *BpfsnoopConfig) SetOutputStack(v bool) {
 	if v {
-		cfg.Flags |= 1 << lbrConfigFlagOutputStackIdx
+		cfg.Flags |= 1 << configFlagOutputStackIdx
 	}
 }
 
 func (cfg *BpfsnoopConfig) SetOutputPktTuple(v bool) {
 	if v {
-		cfg.Flags |= 1 << lbrConfigFlagOutputPktIdx
+		cfg.Flags |= 1 << configFlagOutputPktIdx
 	}
 }
 
 func (cfg *BpfsnoopConfig) SetOutputArgData(v bool) {
 	if v {
-		cfg.Flags |= 1 << lbrConfigFlagOutputArgIdx
+		cfg.Flags |= 1 << configFlagOutputArgIdx
+	}
+}
+
+func (cfg *BpfsnoopConfig) SetBothEntryExit(v bool) {
+	if v {
+		cfg.Flags |= 1 << configFlagBothEntryExitIdx
+	}
+}
+
+func (cfg *BpfsnoopConfig) SetIsEntry(v bool) {
+	if v {
+		cfg.Flags |= 1 << configFlagIsEntryIdx
 	}
 }

--- a/internal/bpfsnoop/bpfsnoop_func.go
+++ b/internal/bpfsnoop/bpfsnoop_func.go
@@ -15,8 +15,10 @@ type funcInfo struct {
 	args     []funcArgumentOutput
 	params   []FuncParamFlags
 	retParam FuncParamFlags
+	insnMode bool
 	pktTuple bool
 	isTp     bool
+	isProg   bool
 }
 
 func getFuncInfo(event *Event, helpers *Helpers) *funcInfo {
@@ -29,6 +31,7 @@ func getFuncInfo(event *Event, helpers *Helpers) *funcInfo {
 		info.params = progInfo.funcParams
 		info.retParam = progInfo.retParam
 		info.pktTuple = progInfo.pktOutput
+		info.isProg = true
 		return &info
 	}
 
@@ -48,6 +51,7 @@ func getFuncInfo(event *Event, helpers *Helpers) *funcInfo {
 	info.args = fn.Args
 	info.params = fn.Prms
 	info.retParam = fn.Ret
+	info.insnMode = fn.Insn
 	info.pktTuple = fn.Pkt
 
 	if fn.IsTp {

--- a/internal/bpfsnoop/bpfsnoop_func_data.go
+++ b/internal/bpfsnoop/bpfsnoop_func_data.go
@@ -55,7 +55,7 @@ func outputFnRetval(sb *strings.Builder, s string, info *funcInfo, event *Event,
 	}
 }
 
-func outputFnArgs(sb *strings.Builder, info *funcInfo, helpers *Helpers, strData *StrData, strs *ebpf.Map, event *Event, f btfx.FindSymbol) error {
+func outputFnArgs(sb *strings.Builder, info *funcInfo, helpers *Helpers, strData *StrData, strs *ebpf.Map, event *Event, f btfx.FindSymbol, retval bool) error {
 	if info.proto == nil {
 		fmt.Fprint(sb, "args=(..UNK..)")
 		outputFnRetval(sb, "", info, event, f)
@@ -142,7 +142,7 @@ func outputFnArgs(sb *strings.Builder, info *funcInfo, helpers *Helpers, strData
 	}
 	fmt.Fprintf(sb, ")")
 
-	if mode == TracingModeExit && !info.isTp {
+	if retval {
 		outputFnRetval(sb, retStr, info, event, f)
 	}
 

--- a/internal/bpfsnoop/bpfsnoop_func_stack.go
+++ b/internal/bpfsnoop/bpfsnoop_func_stack.go
@@ -13,6 +13,10 @@ import (
 	"github.com/fatih/color"
 )
 
+const (
+	MAX_STACK_DEPTH = 50
+)
+
 type FuncStack struct {
 	IPs [MAX_STACK_DEPTH]uint64
 }

--- a/internal/bpfsnoop/bpfsnoop_insn.go
+++ b/internal/bpfsnoop/bpfsnoop_insn.go
@@ -1,0 +1,44 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package bpfsnoop
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/fatih/color"
+)
+
+type InsnEvent struct {
+	Type   uint16
+	Length uint16
+	KernNs uint32
+	SessID uint64
+	InsnIP uint64
+	CPU    uint32
+}
+
+func outputInsnEvent(sb *strings.Builder, sess *Sessions, insns *FuncInsns, event *InsnEvent) bool {
+	insn, ok := insns.Insns[event.InsnIP]
+	if !ok {
+		return false
+	}
+
+	var duration time.Duration
+	if s, ok := sess.Get(event.SessID); ok {
+		duration = time.Duration(event.KernNs - s.started)
+	}
+
+	if !noColorOutput {
+		color.New(color.FgYellow).Fprint(sb, insn.Func)
+		color.New(color.FgCyan).Fprintf(sb, " cpu=%-2d", event.CPU)
+		color.RGB(0xFF, 0x00, 0x7F /* rose red */).Fprintf(sb, " duration=%-12s", duration)
+	} else {
+		fmt.Fprintf(sb, "%s cpu=%-2d duration=%-12s", insn.Func, event.CPU, duration)
+	}
+	fmt.Fprintf(sb, " insn=%s", insn.Desc)
+
+	return true
+}

--- a/internal/bpfsnoop/bpfsnoop_insn.go
+++ b/internal/bpfsnoop/bpfsnoop_insn.go
@@ -20,17 +20,18 @@ type InsnEvent struct {
 	CPU    uint32
 }
 
-func outputInsnEvent(sb *strings.Builder, sess *Sessions, insns *FuncInsns, event *InsnEvent) bool {
+func outputInsnEvent(sb *strings.Builder, sessions *Sessions, insns *FuncInsns, event *InsnEvent) {
 	insn, ok := insns.Insns[event.InsnIP]
 	if !ok {
-		return false
+		return
 	}
 
-	var duration time.Duration
-	if s, ok := sess.Get(event.SessID); ok {
-		duration = time.Duration(event.KernNs - s.started)
+	sess, ok := sessions.Get(event.SessID)
+	if !ok {
+		return
 	}
 
+	duration := time.Duration(event.KernNs - sess.started)
 	if !noColorOutput {
 		color.New(color.FgYellow).Fprint(sb, insn.Func)
 		color.New(color.FgCyan).Fprintf(sb, " cpu=%-2d", event.CPU)
@@ -38,7 +39,7 @@ func outputInsnEvent(sb *strings.Builder, sess *Sessions, insns *FuncInsns, even
 	} else {
 		fmt.Fprintf(sb, "%s cpu=%-2d duration=%-12s", insn.Func, event.CPU, duration)
 	}
-	fmt.Fprintf(sb, " insn=%s", insn.Desc)
+	fmt.Fprintf(sb, " insn=%s\n", insn.Desc)
 
-	return true
+	sess.outputs = append(sess.outputs, sb.String())
 }

--- a/internal/bpfsnoop/bpfsnoop_maps.go
+++ b/internal/bpfsnoop/bpfsnoop_maps.go
@@ -59,6 +59,9 @@ func PrepareBPFMaps(spec *ebpf.CollectionSpec) map[string]*ebpf.Map {
 	stacks, err := ebpf.NewMap(spec.Maps["bpfsnoop_stacks"])
 	assert.NoErr(err, "Failed to create bpfsnoop_stacks map: %v")
 
+	sessions, err := ebpf.NewMap(spec.Maps["bpfsnoop_sessions"])
+	assert.NoErr(err, "Failed to create bpfsnoop_sessions map: %v")
+
 	readyDataMapSpec := spec.Maps[".data.ready"]
 	readyDataMapSpec.Flags |= unix.BPF_F_MMAPABLE
 	readyData, err := ebpf.NewMap(readyDataMapSpec)
@@ -75,6 +78,8 @@ func PrepareBPFMaps(spec *ebpf.CollectionSpec) map[string]*ebpf.Map {
 	assert.NoErr(err, "Failed to create events map: %v")
 
 	return map[string]*ebpf.Map{
+		"bpfsnoop_sessions": sessions,
+
 		"bpfsnoop_events": events,
 		"bpfsnoop_lbrs":   lbrs,
 		"bpfsnoop_strs":   strs,

--- a/internal/bpfsnoop/bpfsnoop_sess.go
+++ b/internal/bpfsnoop/bpfsnoop_sess.go
@@ -5,28 +5,31 @@ package bpfsnoop
 
 type Session struct {
 	started uint32
+	outputs []string
 }
 
 type Sessions struct {
-	sessions map[uint64]Session
+	sessions map[uint64]*Session
 }
 
 func NewSessions() *Sessions {
 	return &Sessions{
-		sessions: make(map[uint64]Session),
+		sessions: make(map[uint64]*Session),
 	}
 }
 
-func (s *Sessions) Add(sessID uint64, started uint32) {
-	s.sessions[sessID] = Session{started: started}
+func (s *Sessions) Add(sessID uint64, started uint32) *Session {
+	sess := &Session{started: started}
+	s.sessions[sessID] = sess
+	return sess
 }
 
-func (s *Sessions) Get(sessID uint64) (Session, bool) {
+func (s *Sessions) Get(sessID uint64) (*Session, bool) {
 	sess, ok := s.sessions[sessID]
 	return sess, ok
 }
 
-func (s *Sessions) GetAndDel(sessID uint64) (Session, bool) {
+func (s *Sessions) GetAndDel(sessID uint64) (*Session, bool) {
 	sess, ok := s.sessions[sessID]
 	if ok {
 		delete(s.sessions, sessID)

--- a/internal/bpfsnoop/bpfsnoop_sess.go
+++ b/internal/bpfsnoop/bpfsnoop_sess.go
@@ -1,0 +1,35 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package bpfsnoop
+
+type Session struct {
+	started uint32
+}
+
+type Sessions struct {
+	sessions map[uint64]Session
+}
+
+func NewSessions() *Sessions {
+	return &Sessions{
+		sessions: make(map[uint64]Session),
+	}
+}
+
+func (s *Sessions) Add(sessID uint64, started uint32) {
+	s.sessions[sessID] = Session{started: started}
+}
+
+func (s *Sessions) Get(sessID uint64) (Session, bool) {
+	sess, ok := s.sessions[sessID]
+	return sess, ok
+}
+
+func (s *Sessions) GetAndDel(sessID uint64) (Session, bool) {
+	sess, ok := s.sessions[sessID]
+	if ok {
+		delete(s.sessions, sessID)
+	}
+	return sess, ok
+}

--- a/internal/bpfsnoop/flags.go
+++ b/internal/bpfsnoop/flags.go
@@ -33,6 +33,8 @@ var (
 	kfuncKmods      []string
 	noColorOutput   bool
 	limitEvents     uint
+
+	debugTraceInsnCnt uint
 )
 
 type Flags struct {
@@ -53,7 +55,7 @@ func ParseFlags() (*Flags, error) {
 
 	f := flag.NewFlagSet("bpfsnoop", flag.ExitOnError)
 	f.StringSliceVarP(&flags.progs, "prog", "p", nil, "bpf prog info for bpfsnoop in format PROG[,PROG,..], PROG: PROGID[:<prog function name>], PROGID: <prog ID> or 'i/id:<prog ID>' or 'p/pinned:<pinned file>' or 't/tag:<prog tag>' or 'n/name:<prog full name>' or 'pid:<pid>'; all bpf progs will be traced if '*' is specified")
-	f.StringSliceVarP(&flags.kfuncs, "kfunc", "k", nil, "filter kernel functions")
+	f.StringSliceVarP(&flags.kfuncs, "kfunc", "k", nil, "filter kernel functions, '(i)' prefix means insn tracing, '<kfunc>[:<arg>][:<type>]' format, e.g. 'tcp_v4_connect:(sk):struct sock *', '*:(struct sk_buff *)skb'")
 	f.StringSliceVarP(&flags.ktps, "tracepoint", "t", nil, "filter kernel tracepoints")
 	f.BoolVar(&kfuncAllKmods, "kfunc-all-kmods", false, "filter functions in all kernel modules")
 	f.StringSliceVar(&kfuncKmods, "kfunc-kmods", nil, "filter functions in specified kernel modules")
@@ -74,6 +76,7 @@ func ParseFlags() (*Flags, error) {
 	f.StringVar(&filterPkt, "filter-pkt", "", "filter packet with pcap-filter(7) expr if function argument is skb or xdp, e.g. 'icmp and host 1.1.1.1'")
 	f.UintVar(&limitEvents, "limit-events", 0, "limited number events to output, 0 to output all events")
 	f.BoolVar(&flags.showFuncProto, "show-func-proto", false, "show function prototype of -p,-k")
+	f.UintVar(&debugTraceInsnCnt, "trace-insn-debug-cnt", 0, "trace insn count for debug")
 
 	f.BoolVarP(&flags.showFuncProto, "show-func-proto-internal", "S", false, "show function prototype of -p,-k")
 	f.UintVarP(&limitEvents, "limit-events-internal", "E", 0, "limited number events to output, 0 to output all events")
@@ -82,6 +85,7 @@ func ParseFlags() (*Flags, error) {
 	f.MarkHidden("output-flamegraph")
 	f.MarkHidden("show-func-proto-internal")
 	f.MarkHidden("limit-events-internal")
+	f.MarkHidden("trace-insn-debug-cnt")
 
 	err := f.Parse(os.Args)
 

--- a/internal/bpfsnoop/flags_kfunc.go
+++ b/internal/bpfsnoop/flags_kfunc.go
@@ -12,10 +12,16 @@ type KfuncFlag struct {
 	name string
 	arg  string
 	typ  string
+	insn bool
 }
 
 func parseKfuncFlag(k string) (KfuncFlag, error) {
 	var kf KfuncFlag
+
+	if strings.HasPrefix(k, "(i)") {
+		kf.insn = true
+		k = k[3:]
+	}
 
 	fields := strings.Split(k, ":")
 	switch len(fields) {

--- a/internal/bpfsnoop/func_insn.go
+++ b/internal/bpfsnoop/func_insn.go
@@ -1,0 +1,92 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package bpfsnoop
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/bpfsnoop/gapstone"
+	"github.com/cilium/ebpf"
+)
+
+type FuncInsn struct {
+	Func string
+	Off  uint64
+	IP   uint64
+	Insn gapstone.Instruction
+	Desc string
+}
+
+type FuncInsns struct {
+	Insns map[uint64]FuncInsn
+}
+
+func (f *FuncInsns) parseFuncInsns(kfunc *KFunc, engine *gapstone.Engine, ksyms *Kallsyms, readSpec *ebpf.CollectionSpec) error {
+	kaddr := kfunc.Ksym.addr
+	bytesCnt := guessBytes(uintptr(kaddr), ksyms, 0)
+	if bytesCnt > readLimit {
+		return fmt.Errorf("func %s insn count %d is larger than limit %d", kfunc.Ksym.name, bytesCnt, readLimit)
+	}
+
+	data, err := readKernel(readSpec, kaddr, uint32(bytesCnt))
+	if err != nil {
+		return fmt.Errorf("failed to read kernel memory from %#x: %w", kaddr, err)
+	}
+
+	data = trimTailingInsns(data)
+	insns, err := engine.Disasm(data, kaddr, 0)
+	if err != nil {
+		return fmt.Errorf("failed to disassemble insns: %w", err)
+	}
+
+	insns = insns[4:] // Skip several insns as they should not be traced.
+	if debugTraceInsnCnt != 0 && len(insns) > int(debugTraceInsnCnt) {
+		insns = insns[:debugTraceInsnCnt]
+	}
+
+	for _, insn := range insns {
+		if bytes.Equal(insn.Bytes, []byte{0xc3}) /* retq */ {
+			continue
+		}
+
+		offset := uint64(insn.Address) - kaddr
+		f.Insns[uint64(insn.Address)] = FuncInsn{
+			Func: kfunc.Ksym.name,
+			Off:  offset,
+			IP:   uint64(insn.Address),
+			Insn: insn,
+			Desc: fmt.Sprintf("+%#-6x  %s", offset, printInsnInfo(uint64(insn.Address), insn)),
+		}
+	}
+
+	return nil
+}
+
+func NewFuncInsns(kfuncs KFuncs, ksyms *Kallsyms, readSpec *ebpf.CollectionSpec) (*FuncInsns, error) {
+	if len(kfuncs) == 0 {
+		return &FuncInsns{}, nil
+	}
+
+	engine, err := createGapstoneEngine()
+	if err != nil {
+		return &FuncInsns{}, fmt.Errorf("failed to create capstone engine: %w", err)
+	}
+	defer engine.Close()
+
+	var insns FuncInsns
+	insns.Insns = make(map[uint64]FuncInsn)
+
+	for _, kfunc := range kfuncs {
+		if !kfunc.Insn {
+			continue
+		}
+
+		if err := insns.parseFuncInsns(kfunc, engine, ksyms, readSpec); err != nil {
+			return &FuncInsns{}, fmt.Errorf("failed to parse insns of func %s: %w", kfunc.Ksym.name, err)
+		}
+	}
+
+	return &insns, nil
+}

--- a/internal/bpfsnoop/gapstone.go
+++ b/internal/bpfsnoop/gapstone.go
@@ -1,0 +1,27 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package bpfsnoop
+
+import (
+	"fmt"
+
+	"github.com/bpfsnoop/gapstone"
+)
+
+func createGapstoneEngine() (*gapstone.Engine, error) {
+	engine, err := gapstone.New(int(gapstone.CS_ARCH_X86), int(gapstone.CS_MODE_64))
+	if err != nil {
+		return nil, fmt.Errorf("failed to new gapstone engine: %w", err)
+	}
+
+	if !disasmIntelSyntax {
+		err = engine.SetOption(uint(gapstone.CS_OPT_SYNTAX), uint(gapstone.CS_OPT_SYNTAX_ATT))
+		if err != nil {
+			_ = engine.Close()
+			return nil, fmt.Errorf("failed to set att syntax: %w", err)
+		}
+	}
+
+	return &engine, nil
+}

--- a/internal/bpfsnoop/kernel_functions.go
+++ b/internal/bpfsnoop/kernel_functions.go
@@ -52,6 +52,7 @@ type KFunc struct {
 	Args []funcArgumentOutput
 	Prms []FuncParamFlags
 	Ret  FuncParamFlags
+	Insn bool
 	IsTp bool
 	Pkt  bool
 }
@@ -71,7 +72,8 @@ func matchKernelFunc(matches []*kfuncMatch, fn *btf.Func, maxArgs int, ksyms *Ka
 	}
 
 	funcProto := fn.Type.(*btf.FuncProto)
-	if !matchKfunc(fn.Name, funcProto, matches) {
+	insnMode, matched := matchKfunc(fn.Name, funcProto, matches)
+	if !matched {
 		return nil, false
 	}
 
@@ -105,6 +107,7 @@ func matchKernelFunc(matches []*kfuncMatch, fn *btf.Func, maxArgs int, ksyms *Ka
 		if MAX_BPF_FUNC_ARGS_PREV < len(funcProto.Params) && len(funcProto.Params) <= MAX_BPF_FUNC_ARGS {
 			kf := KFunc{Ksym: ksym, Func: fn}
 			kf.Prms = params
+			kf.Insn = insnMode
 			kf.Ret = ret
 			return &kf, true
 		}
@@ -114,6 +117,7 @@ func matchKernelFunc(matches []*kfuncMatch, fn *btf.Func, maxArgs int, ksyms *Ka
 	if len(funcProto.Params) <= maxArgs {
 		kf := KFunc{Ksym: ksym, Func: fn}
 		kf.Prms = params
+		kf.Insn = insnMode
 		kf.Ret = ret
 		return &kf, true
 	}

--- a/internal/bpfsnoop/kernel_functions_match.go
+++ b/internal/bpfsnoop/kernel_functions_match.go
@@ -62,11 +62,11 @@ func (m kfuncMatch) match(fn string, fp *btf.FuncProto) bool {
 	return false
 }
 
-func matchKfunc(fn string, fp *btf.FuncProto, matches []*kfuncMatch) bool {
+func matchKfunc(fn string, fp *btf.FuncProto, matches []*kfuncMatch) (bool, bool) {
 	for _, m := range matches {
 		if m.match(fn, fp) {
-			return true
+			return m.flag.insn, true
 		}
 	}
-	return false
+	return false, false
 }

--- a/internal/bpfsnoop/kernel_tracepoints.go
+++ b/internal/bpfsnoop/kernel_tracepoints.go
@@ -38,7 +38,7 @@ func matchKernelTracepoints(tps []string, tpInfos map[string]tracepointInfo, sil
 			continue
 		}
 
-		ok := matchKfunc(tpName, &fp, matches)
+		_, ok := matchKfunc(tpName, &fp, matches)
 		if !ok {
 			continue
 		}

--- a/makefiles/variables.mk
+++ b/makefiles/variables.mk
@@ -24,6 +24,9 @@ BPF2GO_EXTRA_FLAGS := -g -D__TARGET_ARCH_x86 -I./bpf -I./bpf/headers -I./lib/lib
 BPFSNOOP_BPF_OBJ := bpfsnoop_bpfel.o bpfsnoop_bpfeb.o
 BPFSNOOP_BPF_SRC := bpf/bpfsnoop.c $(wildcard bpf/*.h) $(wildcard bpf/headers/*.h)
 
+INSN_BPF_OBJ := insn_bpfel.o insn_bpfeb.o
+INSN_BPF_SRC := bpf/bpfsnoop_insn.c
+
 FEAT_BPF_OBJ := feat_bpfel.o feat_bpfeb.o
 FEAT_BPF_SRC := bpf/feature.c
 
@@ -43,6 +46,7 @@ TAILCALL_BPF_OBJ := tailcall_bpfel.o tailcall_bpfeb.o
 TAILCALL_BPF_SRC := bpf/tailcall.c
 
 BPF_OBJS := $(BPFSNOOP_BPF_OBJ) \
+			$(INSN_BPF_OBJ) \
 			$(READ_BPF_OBJ) \
 			$(FEAT_BPF_OBJ) \
 			$(TAILCALL_BPF_OBJ) \


### PR DESCRIPTION
Fixes #25 

e.g.

```bash
$ sudo ./bpfsnoop -k '(i)tcp_v4_rcv:skb' --filter-pkt 'host 1.1.1.1' --output-pkt
tcp_v4_rcv args=((struct sk_buff *)skb=0xffff9722421f4700) cpu=6 process=(0:swapper/6)
Pkt tuple: 1.1.1.1:443 -> 192.168.241.133:43024 (TCP:FIN|PSH|ACK)
tcp_v4_rcv cpu=6  duration=30.631µs     insn=+0xb     0xffffffff965fa05b: 41 56              	pushq	%r14
tcp_v4_rcv cpu=6  duration=34.024µs     insn=+0xd     0xffffffff965fa05d: 45 31 f6           	xorl	%r14d, %r14d
tcp_v4_rcv cpu=6  duration=36.534µs     insn=+0x10    0xffffffff965fa060: 41 55              	pushq	%r13
tcp_v4_rcv cpu=6  duration=38.723µs     insn=+0x12    0xffffffff965fa062: 41 54              	pushq	%r12
tcp_v4_rcv cpu=6  duration=42.585µs     insn=+0x14    0xffffffff965fa064: 53                 	pushq	%rbx
tcp_v4_rcv cpu=6  duration=44.304µs     insn=+0x15    0xffffffff965fa065: 48 89 fb           	movq	%rdi, %rbx
tcp_v4_rcv cpu=6  duration=46.537µs     insn=+0x1c    0xffffffff965fa06c: 65 48 8b 04 25 28 00 00 00	movq	%gs:0x28, %rax
tcp_v4_rcv cpu=6  duration=47.375µs     insn=+0x25    0xffffffff965fa075: 48 89 45 d0        	movq	%rax, -0x30(%rbp)
tcp_v4_rcv cpu=6  duration=48.941µs     insn=+0x29    0xffffffff965fa079: 48 8b 47 10        	movq	0x10(%rdi), %rax
tcp_v4_rcv cpu=6  duration=50.286µs     insn=+0x2d    0xffffffff965fa07d: 4c 8b a0 18 01 00 00	movq	0x118(%rax), %r12
tcp_v4_rcv cpu=6  duration=51.752µs     insn=+0x34    0xffffffff965fa084: 48 85 ff           	testq	%rdi, %rdi
tcp_v4_rcv cpu=6  duration=53.637µs     insn=+0x37    0xffffffff965fa087: 74 0a              	je	0xffffffff965fa093
tcp_v4_rcv cpu=6  duration=54.854µs     insn=+0x39    0xffffffff965fa089: f6 47 3c 80        	testb	$0x80, 0x3c(%rdi)
tcp_v4_rcv cpu=6  duration=56.57µs      insn=+0x3d    0xffffffff965fa08d: 0f 85 86 00 00 00  	jne	0xffffffff965fa119
tcp_v4_rcv cpu=6  duration=57.961µs     insn=+0x43    0xffffffff965fa093: 48 8b 43 58        	movq	0x58(%rbx), %rax
tcp_v4_rcv cpu=6  duration=59.312µs     insn=+0x47    0xffffffff965fa097: 48 83 f8 01        	cmpq	$1, %rax
tcp_v4_rcv cpu=6  duration=60.781µs     insn=+0x4b    0xffffffff965fa09b: 76 10              	jbe	0xffffffff965fa0ad
tcp_v4_rcv cpu=6  duration=62.274µs     insn=+0x4d    0xffffffff965fa09d: 48 83 e0 fe        	andq	$0xfffffffffffffffe, %rax
tcp_v4_rcv cpu=6  duration=63.498µs     insn=+0x51    0xffffffff965fa0a1: 44 8b b8 94 00 00 00	movl	0x94(%rax), %r15d
tcp_v4_rcv cpu=6  duration=64.224µs     insn=+0x58    0xffffffff965fa0a8: 45 85 ff           	testl	%r15d, %r15d
tcp_v4_rcv cpu=6  duration=65.768µs     insn=+0x5b    0xffffffff965fa0ab: 75 07              	jne	0xffffffff965fa0b4
tcp_v4_rcv cpu=6  duration=66.531µs     insn=+0x5d    0xffffffff965fa0ad: 44 8b bb 94 00 00 00	movl	0x94(%rbx), %r15d
tcp_v4_rcv cpu=6  duration=68.143µs     insn=+0x64    0xffffffff965fa0b4: c6 45 ca 00        	movb	$0, -0x36(%rbp)
tcp_v4_rcv cpu=6  duration=70.164µs     insn=+0x68    0xffffffff965fa0b8: c7 45 cc 02 00 00 00	movl	$2, -0x34(%rbp)
tcp_v4_rcv cpu=6  duration=70.96µs      insn=+0x6f    0xffffffff965fa0bf: f6 83 80 00 00 00 07	testb	$7, 0x80(%rbx)
tcp_v4_rcv cpu=6  duration=72.469µs     insn=+0x76    0xffffffff965fa0c6: 74 5a              	je	0xffffffff965fa122
tcp_v4_rcv cpu=6  duration=73.483µs     insn=+0xd2    0xffffffff965fa122: 49 8b 84 24 a8 01 00 00	movq	0x1a8(%r12), %rax
tcp_v4_rcv cpu=6  duration=74.632µs     insn=+0xda    0xffffffff965fa12a: 65 48 ff 40 50     	incq	%gs:0x50(%rax)
tcp_v4_rcv cpu=6  duration=76.422µs     insn=+0xdf    0xffffffff965fa12f: 8b 7b 70           	movl	0x70(%rbx), %edi
tcp_v4_rcv cpu=6  duration=79.747µs     insn=+0xe2    0xffffffff965fa132: 8b 43 74           	movl	0x74(%rbx), %eax
tcp_v4_rcv cpu=6  duration=80.897µs     insn=+0xe5    0xffffffff965fa135: 89 fe              	movl	%edi, %esi
tcp_v4_rcv cpu=6  duration=83.334µs     insn=+0xe7    0xffffffff965fa137: 29 c6              	subl	%eax, %esi
tcp_v4_rcv cpu=6  duration=85.106µs     insn=+0xe9    0xffffffff965fa139: 83 fe 13           	cmpl	$0x13, %esi
tcp_v4_rcv cpu=6  duration=86.277µs     insn=+0xec    0xffffffff965fa13c: 0f 86 65 02 00 00  	jbe	0xffffffff965fa3a7
tcp_v4_rcv cpu=6  duration=87.1µs       insn=+0xf2    0xffffffff965fa142: 48 8b 83 d0 00 00 00	movq	0xd0(%rbx), %rax
tcp_v4_rcv cpu=6  duration=88.115µs     insn=+0xf9    0xffffffff965fa149: 0f b6 70 0c        	movzbl	0xc(%rax), %esi
tcp_v4_rcv cpu=6  duration=90.005µs     insn=+0xfd    0xffffffff965fa14d: 89 f0              	movl	%esi, %eax
tcp_v4_rcv cpu=6  duration=91.501µs     insn=+0xff    0xffffffff965fa14f: c0 e8 04           	shrb	$4, %al
tcp_v4_rcv cpu=6  duration=93.609µs     insn=+0x102   0xffffffff965fa152: 40 80 fe 4f        	cmpb	$0x4f, %sil
tcp_v4_rcv cpu=6  duration=95.047µs     insn=+0x106   0xffffffff965fa156: 0f 86 71 03 00 00  	jbe	0xffffffff965fa4cd
tcp_v4_rcv cpu=6  duration=95.992µs     insn=+0x10c   0xffffffff965fa15c: 8b 7b 70           	movl	0x70(%rbx), %edi
tcp_v4_rcv cpu=6  duration=99.109µs     insn=+0x10f   0xffffffff965fa15f: 8b 73 74           	movl	0x74(%rbx), %esi
tcp_v4_rcv cpu=6  duration=100.485µs    insn=+0x112   0xffffffff965fa162: 0f b6 c0           	movzbl	%al, %eax
tcp_v4_rcv cpu=6  duration=101.959µs    insn=+0x115   0xffffffff965fa165: c1 e0 02           	shll	$2, %eax
tcp_v4_rcv cpu=6  duration=103.774µs    insn=+0x118   0xffffffff965fa168: 41 89 f8           	movl	%edi, %r8d
tcp_v4_rcv cpu=6  duration=105.274µs    insn=+0x11b   0xffffffff965fa16b: 41 29 f0           	subl	%esi, %r8d
tcp_v4_rcv cpu=6  duration=106.451µs    insn=+0x11e   0xffffffff965fa16e: 41 39 c0           	cmpl	%eax, %r8d
tcp_v4_rcv cpu=6  duration=108.079µs    insn=+0x121   0xffffffff965fa171: 0f 82 62 03 00 00  	jb	0xffffffff965fa4d9
tcp_v4_rcv cpu=6  duration=108.986µs    insn=+0x127   0xffffffff965fa177: 0f b6 bb 80 00 00 00	movzbl	0x80(%rbx), %edi
tcp_v4_rcv cpu=6  duration=110.183µs    insn=+0x12e   0xffffffff965fa17e: 0f b6 83 82 00 00 00	movzbl	0x82(%rbx), %eax
tcp_v4_rcv cpu=6  duration=110.887µs    insn=+0x135   0xffffffff965fa185: 4c 8b 83 c8 00 00 00	movq	0xc8(%rbx), %r8
tcp_v4_rcv cpu=6  duration=111.709µs    insn=+0x13c   0xffffffff965fa18c: 44 0f b7 ab b8 00 00 00	movzwl	0xb8(%rbx), %r13d
tcp_v4_rcv cpu=6  duration=112.632µs    insn=+0x144   0xffffffff965fa194: 89 fe              	movl	%edi, %esi
tcp_v4_rcv cpu=6  duration=114.091µs    insn=+0x146   0xffffffff965fa196: 83 e0 7f           	andl	$0x7f, %eax
tcp_v4_rcv cpu=6  duration=115.714µs    insn=+0x149   0xffffffff965fa199: 4b 8d 0c 28        	leaq	(%r8, %r13), %rcx
tcp_v4_rcv cpu=6  duration=117.028µs    insn=+0x14d   0xffffffff965fa19d: 83 e6 60           	andl	$0x60, %esi
tcp_v4_rcv cpu=6  duration=118.446µs    insn=+0x150   0xffffffff965fa1a0: 88 83 82 00 00 00  	movb	%al, 0x82(%rbx)
tcp_v4_rcv cpu=6  duration=119.583µs    insn=+0x156   0xffffffff965fa1a6: 48 89 4d c0        	movq	%rcx, -0x40(%rbp)
tcp_v4_rcv cpu=6  duration=121.274µs    insn=+0x15a   0xffffffff965fa1aa: 40 80 fe 20        	cmpb	$0x20, %sil
tcp_v4_rcv cpu=6  duration=123.442µs    insn=+0x15e   0xffffffff965fa1ae: 74 4f              	je	0xffffffff965fa1ff
tcp_v4_rcv cpu=6  duration=124.386µs    insn=+0x1af   0xffffffff965fa1ff: 83 c8 80           	orl	$0xffffff80, %eax
tcp_v4_rcv cpu=6  duration=126.419µs    insn=+0x1b2   0xffffffff965fa202: 4c 8b ab d0 00 00 00	movq	0xd0(%rbx), %r13
tcp_v4_rcv cpu=6  duration=127.237µs    insn=+0x1b9   0xffffffff965fa209: 88 83 82 00 00 00  	movb	%al, 0x82(%rbx)
tcp_v4_rcv cpu=6  duration=128.327µs    insn=+0x1bf   0xffffffff965fa20f: 0f b6 83 81 00 00 00	movzbl	0x81(%rbx), %eax
tcp_v4_rcv cpu=6  duration=129.389µs    insn=+0x1c6   0xffffffff965fa216: a8 60              	testb	$0x60, %al
tcp_v4_rcv cpu=6  duration=130.583µs    insn=+0x1c8   0xffffffff965fa218: 0f 85 53 03 00 00  	jne	0xffffffff965fa571
tcp_v4_rcv cpu=6  duration=131.826µs    insn=+0x1ce   0xffffffff965fa21e: 83 e7 9f           	andl	$0xffffff9f, %edi
tcp_v4_rcv cpu=6  duration=133.55µs     insn=+0x1d1   0xffffffff965fa221: 40 88 bb 80 00 00 00	movb	%dil, 0x80(%rbx)
tcp_v4_rcv cpu=6  duration=134.769µs    insn=+0x1d8   0xffffffff965fa228: 44 89 7d b8        	movl	%r15d, -0x48(%rbp)
tcp_v4_rcv cpu=6  duration=136.755µs    insn=+0x1dc   0xffffffff965fa22c: 4d 89 ef           	movq	%r13, %r15
tcp_v4_rcv cpu=6  duration=138.437µs    insn=+0x1df   0xffffffff965fa22f: 41 0f b6 57 0c     	movzbl	0xc(%r15), %edx
tcp_v4_rcv cpu=6  duration=139.914µs    insn=+0x1e4   0xffffffff965fa234: 48 8d 45 ca        	leaq	-0x36(%rbp), %rax
tcp_v4_rcv cpu=6  duration=142.312µs    insn=+0x1e8   0xffffffff965fa238: 41 0f b7 0f        	movzwl	(%r15), %ecx
tcp_v4_rcv cpu=6  duration=145.335µs    insn=+0x1ec   0xffffffff965fa23c: 45 89 f1           	movl	%r14d, %r9d
tcp_v4_rcv cpu=6  duration=147.516µs    insn=+0x1ef   0xffffffff965fa23f: 45 0f b7 47 02     	movzwl	2(%r15), %r8d
tcp_v4_rcv cpu=6  duration=148.833µs    insn=+0x1f4   0xffffffff965fa244: 49 8b bc 24 40 03 00 00	movq	0x340(%r12), %rdi
tcp_v4_rcv cpu=6  duration=150.364µs    insn=+0x1fc   0xffffffff965fa24c: 50                 	pushq	%rax
tcp_v4_rcv cpu=6  duration=152.129µs    insn=+0x1fd   0xffffffff965fa24d: 48 89 de           	movq	%rbx, %rsi
tcp_v4_rcv cpu=6  duration=154.133µs    insn=+0x200   0xffffffff965fa250: c0 ea 04           	shrb	$4, %dl
tcp_v4_rcv cpu=6  duration=155.829µs    insn=+0x203   0xffffffff965fa253: 0f b6 d2           	movzbl	%dl, %edx
tcp_v4_rcv cpu=6  duration=157.312µs    insn=+0x206   0xffffffff965fa256: c1 e2 02           	shll	$2, %edx
tcp_v4_rcv cpu=6  duration=159.215µs    insn=+0x209   0xffffffff965fa259: e8 e2 d1 ff ff     	callq	0xffffffff965f7440
tcp_v4_rcv cpu=6  duration=160.789µs    insn=+0x20e   0xffffffff965fa25e: 41 58              	popq	%r8
tcp_v4_rcv cpu=6  duration=162.614µs    insn=+0x210   0xffffffff965fa260: 49 89 c5           	movq	%rax, %r13
tcp_v4_rcv cpu=6  duration=173.549µs    insn=+0x213   0xffffffff965fa263: 48 85 c0           	testq	%rax, %rax
tcp_v4_rcv cpu=6  duration=176.096µs    insn=+0x216   0xffffffff965fa266: 0f 84 0f 05 00 00  	je	0xffffffff965fa77b
tcp_v4_rcv cpu=6  duration=177.622µs    insn=+0x21c   0xffffffff965fa26c: 0f b6 40 12        	movzbl	0x12(%rax), %eax
tcp_v4_rcv cpu=6  duration=179.317µs    insn=+0x220   0xffffffff965fa270: 3c 06              	cmpb	$6, %al
tcp_v4_rcv cpu=6  duration=181.112µs    insn=+0x222   0xffffffff965fa272: 0f 85 f7 01 00 00  	jne	0xffffffff965fa46f
tcp_v4_rcv cpu=6  duration=182.497µs    insn=+0x228   0xffffffff965fa278: 31 ff              	xorl	%edi, %edi
tcp_v4_rcv cpu=6  duration=185.001µs    insn=+0x22a   0xffffffff965fa27a: 48 89 de           	movq	%rbx, %rsi
tcp_v4_rcv cpu=6  duration=186.819µs    insn=+0x22d   0xffffffff965fa27d: e8 1e a9 ff ff     	callq	0xffffffff965f4ba0
tcp_v4_rcv cpu=6  duration=188.772µs    insn=+0x232   0xffffffff965fa282: 85 c0              	testl	%eax, %eax
tcp_v4_rcv cpu=6  duration=190.768µs    insn=+0x234   0xffffffff965fa284: 0f 84 79 03 00 00  	je	0xffffffff965fa603
tcp_v4_rcv cpu=6  duration=192.607µs    insn=+0x23a   0xffffffff965fa28a: 48 8b 75 c0        	movq	-0x40(%rbp), %rsi
tcp_v4_rcv cpu=6  duration=194.068µs    insn=+0x23e   0xffffffff965fa28e: 4c 89 fa           	movq	%r15, %rdx
tcp_v4_rcv cpu=6  duration=195.917µs    insn=+0x241   0xffffffff965fa291: 48 89 df           	movq	%rbx, %rdi
tcp_v4_rcv cpu=6  duration=197.711µs    insn=+0x244   0xffffffff965fa294: e8 57 97 ff ff     	callq	0xffffffff965f39f0
tcp_v4_rcv cpu=6  duration=198.959µs    insn=+0x249   0xffffffff965fa299: 0f b6 83 80 00 00 00	movzbl	0x80(%rbx), %eax
tcp_v4_rcv cpu=6  duration=200.388µs    insn=+0x250   0xffffffff965fa2a0: 83 e0 60           	andl	$0x60, %eax
tcp_v4_rcv cpu=6  duration=202.614µs    insn=+0x253   0xffffffff965fa2a3: 3c 20              	cmpb	$0x20, %al
tcp_v4_rcv cpu=6  duration=204.121µs    insn=+0x255   0xffffffff965fa2a5: 0f 84 be 00 00 00  	je	0xffffffff965fa369
tcp_v4_rcv cpu=6  duration=205.736µs    insn=+0x25b   0xffffffff965fa2ab: 80 bb 82 00 00 00 00	cmpb	$0, 0x82(%rbx)
tcp_v4_rcv cpu=6  duration=206.688µs    insn=+0x262   0xffffffff965fa2b2: 0f 88 b1 00 00 00  	js	0xffffffff965fa369
tcp_v4_rcv cpu=6  duration=227.523µs    insn=+0x319   0xffffffff965fa369: 4c 89 fa           	movq	%r15, %rdx
tcp_v4_rcv cpu=6  duration=230.776µs    insn=+0x31c   0xffffffff965fa36c: 48 89 de           	movq	%rbx, %rsi
tcp_v4_rcv cpu=6  duration=232.902µs    insn=+0x31f   0xffffffff965fa36f: 4c 89 ef           	movq	%r13, %rdi
tcp_v4_rcv cpu=6  duration=235.525µs    insn=+0x322   0xffffffff965fa372: e8 e9 15 00 00     	callq	0xffffffff965fb960
tcp_v4_rcv cpu=6  duration=238.309µs    insn=+0x327   0xffffffff965fa377: 83 f8 02           	cmpl	$2, %eax
tcp_v4_rcv cpu=6  duration=240.071µs    insn=+0x32a   0xffffffff965fa37a: 74 4f              	je	0xffffffff965fa3cb
tcp_v4_rcv cpu=6  duration=248.846µs    insn=+0x37b   0xffffffff965fa3cb: 48 89 de           	movq	%rbx, %rsi
tcp_v4_rcv cpu=6  duration=296.687µs    insn=+0x37e   0xffffffff965fa3ce: 4c 89 ef           	movq	%r13, %rdi
tcp_v4_rcv cpu=6  duration=299.112µs    insn=+0x381   0xffffffff965fa3d1: e8 aa c0 ff ff     	callq	0xffffffff965f6480
tcp_v4_rcv cpu=6  duration=354.902µs    insn=+0x386   0xffffffff965fa3d6: e9 24 ff ff ff     	jmp	0xffffffff965fa2ff
tcp_v4_rcv cpu=6  duration=357.372µs    insn=+0x2af   0xffffffff965fa2ff: 8b 75 cc           	movl	-0x34(%rbp), %esi
tcp_v4_rcv cpu=6  duration=360.135µs    insn=+0x2b2   0xffffffff965fa302: f7 c6 fd ff ff ff  	testl	$0xfffffffd, %esi
tcp_v4_rcv cpu=6  duration=363.01µs     insn=+0x2b8   0xffffffff965fa308: 0f 85 c6 fd ff ff  	jne	0xffffffff965fa0d4
tcp_v4_rcv cpu=6  duration=365.315µs    insn=+0x2be   0xffffffff965fa30e: e9 b5 fd ff ff     	jmp	0xffffffff965fa0c8
tcp_v4_rcv cpu=6  duration=366.857µs    insn=+0x78    0xffffffff965fa0c8: c7 45 cc 02 00 00 00	movl	$2, -0x34(%rbp)
tcp_v4_rcv cpu=6  duration=368.759µs    insn=+0x7f    0xffffffff965fa0cf: be 02 00 00 00     	movl	$2, %esi
tcp_v4_rcv cpu=6  duration=370.78µs     insn=+0x84    0xffffffff965fa0d4: 48 89 df           	movq	%rbx, %rdi
tcp_v4_rcv cpu=6  duration=373.28µs     insn=+0x87    0xffffffff965fa0d7: e8 24 eb ed ff     	callq	0xffffffff964d8c00
tcp_v4_rcv cpu=6  duration=377.338µs    insn=+0x8c    0xffffffff965fa0dc: 45 31 e4           	xorl	%r12d, %r12d
tcp_v4_rcv cpu=6  duration=380.339µs    insn=+0x8f    0xffffffff965fa0df: 48 8b 45 d0        	movq	-0x30(%rbp), %rax
tcp_v4_rcv cpu=6  duration=382.347µs    insn=+0x93    0xffffffff965fa0e3: 65 48 2b 04 25 28 00 00 00	subq	%gs:0x28, %rax
tcp_v4_rcv cpu=6  duration=384.357µs    insn=+0x9c    0xffffffff965fa0ec: 0f 85 63 08 00 00  	jne	0xffffffff965fa955
tcp_v4_rcv cpu=6  duration=385.846µs    insn=+0xa2    0xffffffff965fa0f2: 48 8d 65 d8        	leaq	-0x28(%rbp), %rsp
tcp_v4_rcv cpu=6  duration=387.806µs    insn=+0xa6    0xffffffff965fa0f6: 44 89 e0           	movl	%r12d, %eax
tcp_v4_rcv cpu=6  duration=389.294µs    insn=+0xa9    0xffffffff965fa0f9: 5b                 	popq	%rbx
tcp_v4_rcv cpu=6  duration=390.922µs    insn=+0xaa    0xffffffff965fa0fa: 41 5c              	popq	%r12
tcp_v4_rcv cpu=6  duration=393.058µs    insn=+0xae    0xffffffff965fa0fe: 41 5e              	popq	%r14
tcp_v4_rcv cpu=6  duration=394.748µs    insn=+0xb0    0xffffffff965fa100: 41 5f              	popq	%r15
tcp_v4_rcv cpu=6  duration=396.457µs    insn=+0xb2    0xffffffff965fa102: 5d                 	popq	%rbp
tcp_v4_rcv cpu=6  duration=397.833µs    insn=+0xb3    0xffffffff965fa103: 31 d2              	xorl	%edx, %edx
tcp_v4_rcv cpu=6  duration=399.814µs    insn=+0xb5    0xffffffff965fa105: 31 c9              	xorl	%ecx, %ecx
tcp_v4_rcv cpu=6  duration=401.543µs    insn=+0xb7    0xffffffff965fa107: 31 f6              	xorl	%esi, %esi
tcp_v4_rcv cpu=6  duration=403.11µs     insn=+0xb9    0xffffffff965fa109: 31 ff              	xorl	%edi, %edi
tcp_v4_rcv cpu=6  duration=404.979µs    insn=+0xbb    0xffffffff965fa10b: 45 31 c0           	xorl	%r8d, %r8d
tcp_v4_rcv cpu=6  duration=406.811µs    insn=+0xbe    0xffffffff965fa10e: 45 31 c9           	xorl	%r9d, %r9d
tcp_v4_rcv cpu=6  duration=408.501µs    insn=+0xc1    0xffffffff965fa111: 45 31 d2           	xorl	%r10d, %r10d
tcp_v4_rcv args=((struct sk_buff *)skb=0xffff9722421f4700) retval=(int)0 cpu=6 process=(0:swapper/6) duration=411.053µs
Pkt tuple: 1.1.1.1:443 -> 192.168.241.133:43024 (TCP:FIN|PSH|ACK)
```