### PR TITLE
disasm: Output insn offsets

### DIFF
--- a/internal/bpfsnoop/disasm.go
+++ b/internal/bpfsnoop/disasm.go
@@ -196,8 +196,11 @@ func dumpKfunc(kfunc string, kmods []string, bytes uint, readSpec *ebpf.Collecti
 	}
 
 	printInsnInfo := func(pc uint64, opcode string, mnemonic string, opstr string) {
-		fmt.Fprintf(&sb, "%s: %-19s\t%s\t%s",
-			color.New(color.FgBlue).Sprintf("%#x", pc), opcode,
+		offset := pc - uint64(kaddr)
+		fmt.Fprintf(&sb, "%s %-14s %-19s\t%s\t%s",
+			color.New(color.FgBlue).Sprintf("%#x", pc),
+			fmt.Sprintf("<+%d/%#x>:", offset, offset),
+			opcode,
 			color.GreenString(mnemonic), color.RedString(opstr))
 	}
 


### PR DESCRIPTION
This patch added offsets along with addresses:

![image](https://github.com/user-attachments/assets/46497c56-6560-4f8d-88cf-139bef07e442)

gdb's `disas` has a similar output, let's implement like that:

![image](https://github.com/user-attachments/assets/73f79023-1d42-4cab-bb06-62a9ece63594)

In practice, this is useful when:

1. Mapping bpftrace's `kstack` output to source line:
```
    do_sys_poll+495
    __x64_sys_poll+199
    x64_sys_call+8242
    do_syscall_64+129
    entry_SYSCALL_64_after_hwframe+120
```
The offsets are in decimal.

2. Mapping kernel panic log to source line:
```
[ 1530.421276]  __do_softirq+0xdd/0x28d
[ 1530.421284]  irq_exit_rcu+0xb9/0xf0
[ 1530.421290]  common_interrupt+0xb1/0xd0
```
The offsets are in hex.
