### PR TITLE
disasm,fninsn: Unify printing insn info

### DIFF
--- a/internal/bpfsnoop/func_insn.go
+++ b/internal/bpfsnoop/func_insn.go
@@ -57,7 +57,7 @@ func (f *FuncInsns) parseFuncInsns(kfunc *KFunc, engine *gapstone.Engine, ksyms 
 			Off:  offset,
 			IP:   uint64(insn.Address),
 			Insn: insn,
-			Desc: fmt.Sprintf("+%#-6x  %s", offset, printInsnInfo(uint64(insn.Address), insn)),
+			Desc: printInsnInfo(uint64(insn.Address), offset, insn.Bytes, insn.Mnemonic, insn.OpStr),
 		}
 	}
 


### PR DESCRIPTION
It's to add offset to disasm kfunc, bpf prog and insn tracing.

```bash
$ sudo ./bpfsnoop -k icmp_rcv -d -B 100
2025/04/28 07:07:07 Disassembling icmp_rcv at 0xffffffffbc615630 (100 bytes) ..
; icmp_rcv+0x0 net/ipv4/icmp.c:1180
0xffffffffbc615630 <+0/0x0>:      0f 1f 44 00 00     	nopl	(%rax, %rax)
0xffffffffbc615635 <+5/0x5>:      55                 	pushq	%rbp
; icmp_rcv+0x6 include/net/xfrm.h:1185
0xffffffffbc615636 <+6/0x6>:      31 f6              	xorl	%esi, %esi
; icmp_rcv+0x8 net/ipv4/icmp.c:1180
0xffffffffbc615638 <+8/0x8>:      48 89 e5           	movq	%rsp, %rbp
0xffffffffbc61563b <+11/0xb>:     41 57              	pushq	%r15
0xffffffffbc61563d <+13/0xd>:     41 56              	pushq	%r14
0xffffffffbc61563f <+15/0xf>:     41 55              	pushq	%r13
0xffffffffbc615641 <+17/0x11>:    41 54              	pushq	%r12
0xffffffffbc615643 <+19/0x13>:    53                 	pushq	%rbx
0xffffffffbc615644 <+20/0x14>:    48 89 fb           	movq	%rdi, %rbx
0xffffffffbc615647 <+23/0x17>:    48 83 ec 08        	subq	$8, %rsp
; icmp_rcv+0x1b include/linux/skbuff.h:1134
0xffffffffbc61564b <+27/0x1b>:    4c 8b 67 58        	movq	0x58(%rdi), %r12
0xffffffffbc61564f <+31/0x1f>:    49 83 e4 fe        	andq	$0xfffffffffffffffe, %r12
0xffffffffbc615653 <+35/0x23>:    49 8b 04 24        	movq	(%r12), %rax
0xffffffffbc615657 <+39/0x27>:    4c 8b b0 18 01 00 00	movq	0x118(%rax), %r14
; icmp_rcv+0x2e include/net/xfrm.h:1185
0xffffffffbc61565e <+46/0x2e>:    e8 2d e3 ff ff     	callq	0xffffffffbc613990	; __xfrm_policy_check2.constprop.0+0x0 include/net/xfrm.h:1159
; icmp_rcv+0x33 net/ipv4/icmp.c:1186
0xffffffffbc615663 <+51/0x33>:    85 c0              	testl	%eax, %eax
0xffffffffbc615665 <+53/0x35>:    0f 85 bc 00 00 00  	jne	0xffffffffbc615727	; icmp_rcv+0xf7 net/ipv4/icmp.c:1211
0xffffffffbc61566b <+59/0x3b>:    f6 43 7f 02        	testb	$2, 0x7f(%rbx)
0xffffffffbc61566f <+63/0x3f>:    0f 84 bf 01 00 00  	je	0xffffffffbc615834	; icmp_rcv+0x204 net/ipv4/icmp.c:1192
; icmp_rcv+0x45 include/linux/skbuff.h:4732
0xffffffffbc615675 <+69/0x45>:    48 8b 83 e0 00 00 00	movq	0xe0(%rbx), %rax
; icmp_rcv+0x4c include/linux/skbuff.h:4733
0xffffffffbc61567c <+76/0x4c>:    0f b6 50 05        	movzbl	5(%rax), %edx
; icmp_rcv+0x50 include/linux/skbuff.h:4735
0xffffffffbc615680 <+80/0x50>:    c1 e2 03           	shll	$3, %edx
0xffffffffbc615683 <+83/0x53>:    48 63 d2           	movslq	%edx, %rdx
; icmp_rcv+0x56 net/ipv4/icmp.c:1190
0xffffffffbc615686 <+86/0x56>:    48 01 d0           	addq	%rdx, %rax
0xffffffffbc615689 <+89/0x59>:    0f 84 a5 01 00 00  	je	0xffffffffbc615834	; icmp_rcv+0x204 net/ipv4/icmp.c:1192
0xffffffffbc61568f <+95/0x5f>:    8b 30              	movl	(%rax), %esi

$ sudo ./bpfsnoop -p 2 -d -B 100
; /home/btissoir/Src/hid/drivers/hid/bpf/entrypoints/entrypoints.bpf.c:18:5 int BPF_PROG(hid_tail_call, struct hid_bpf_ctx *hctx)
0xffffffffc013a978 <+0/0x0>:      0f 1f 44 00 00     	nopl	(%rax, %rax)
0xffffffffc013a97d <+5/0x5>:      31 c0              	xorl	%eax, %eax
0xffffffffc013a97f <+7/0x7>:      55                 	pushq	%rbp
0xffffffffc013a980 <+8/0x8>:      48 89 e5           	movq	%rsp, %rbp
0xffffffffc013a983 <+11/0xb>:     50                 	pushq	%rax
0xffffffffc013a984 <+12/0xc>:     48 8b 77 00        	movq	(%rdi), %rsi
; /home/btissoir/Src/hid/drivers/hid/bpf/entrypoints/entrypoints.bpf.c:20:2 bpf_tail_call(ctx, &hid_jmp_table, hctx->index);
0xffffffffc013a988 <+16/0x10>:    49 bb 00 00 00 00 00 80 00 00	movabsq	$0x800000000000, %r11
0xffffffffc013a992 <+26/0x1a>:    4c 39 de           	cmpq	%r11, %rsi
0xffffffffc013a995 <+29/0x1d>:    73 04              	jae	0xffffffffc013a99b	; hid_tail_call+0x23 /home/btissoir/Src/hid/drivers/hid/bpf/entrypoints/entrypoints.bpf.c:20 [bpf]
0xffffffffc013a997 <+31/0x1f>:    31 d2              	xorl	%edx, %edx
0xffffffffc013a999 <+33/0x21>:    eb 03              	jmp	0xffffffffc013a99e	; hid_tail_call+0x26 /home/btissoir/Src/hid/drivers/hid/bpf/entrypoints/entrypoints.bpf.c:20 [bpf]
0xffffffffc013a99b <+35/0x23>:    8b 56 00           	movl	(%rsi), %edx
0xffffffffc013a99e <+38/0x26>:    48 be 00 80 ca 82 43 93 ff ff	movabsq	$18446624516899241984, %rsi
0xffffffffc013a9a8 <+48/0x30>:    89 d2              	movl	%edx, %edx
0xffffffffc013a9aa <+50/0x32>:    39 56 24           	cmpl	%edx, 0x24(%rsi)
0xffffffffc013a9ad <+53/0x35>:    76 2d              	jbe	0xffffffffc013a9dc	; hid_tail_call+0x64 /home/btissoir/Src/hid/drivers/hid/bpf/entrypoints/entrypoints.bpf.c:18 [bpf]
0xffffffffc013a9af <+55/0x37>:    8b 85 fc ff ff ff  	movl	-4(%rbp), %eax
0xffffffffc013a9b5 <+61/0x3d>:    83 f8 21           	cmpl	$0x21, %eax
0xffffffffc013a9b8 <+64/0x40>:    73 22              	jae	0xffffffffc013a9dc	; hid_tail_call+0x64 /home/btissoir/Src/hid/drivers/hid/bpf/entrypoints/entrypoints.bpf.c:18 [bpf]
0xffffffffc013a9ba <+66/0x42>:    83 c0 01           	addl	$1, %eax
0xffffffffc013a9bd <+69/0x45>:    89 85 fc ff ff ff  	movl	%eax, -4(%rbp)
0xffffffffc013a9c3 <+75/0x4b>:    48 8b 8c d6 10 01 00 00	movq	0x110(%rsi, %rdx, 8), %rcx
0xffffffffc013a9cb <+83/0x53>:    48 85 c9           	testq	%rcx, %rcx
0xffffffffc013a9ce <+86/0x56>:    74 0c              	je	0xffffffffc013a9dc	; hid_tail_call+0x64 /home/btissoir/Src/hid/drivers/hid/bpf/entrypoints/entrypoints.bpf.c:18 [bpf]
0xffffffffc013a9d0 <+88/0x58>:    58                 	popq	%rax
0xffffffffc013a9d1 <+89/0x59>:    48 8b 49 30        	movq	0x30(%rcx), %rcx
0xffffffffc013a9d5 <+93/0x5d>:    48 83 c1 0b        	addq	$0xb, %rcx
0xffffffffc013a9d9 <+97/0x61>:    ff e1              	jmpq	*%rcx
0xffffffffc013a9db <+99/0x63>:    cc                 	int3
; /home/btissoir/Src/hid/drivers/hid/bpf/entrypoints/entrypoints.bpf.c:18:5 int BPF_PROG(hid_tail_call, struct hid_bpf_ctx *hctx)
0xffffffffc013a9dc <+100/0x64>:   31 c0              	xorl	%eax, %eax
0xffffffffc013a9de <+102/0x66>:   c9                 	leave
0xffffffffc013a9df <+103/0x67>:   c3                 	retq
0xffffffffc013a9e0 <+104/0x68>:   cc                 	int3

$ sudo ./bpfsnoop -k '(i)icmp_rcv' --filter-pkt 'host 1.1.1.1'  --trace-insn-debug-cnt 10
2025/04/28 07:07:50 bpfsnoop is running..
icmp_rcv args=((struct sk_buff *)skb=0xffff93438ee73e00) cpu=6 process=(0:swapper/6)
icmp_rcv cpu=6  duration=57.332µs     insn=0xffffffffbc61563b <+11/0xb>:     41 57              	pushq	%r15
icmp_rcv cpu=6  duration=60.664µs     insn=0xffffffffbc61563d <+13/0xd>:     41 56              	pushq	%r14
icmp_rcv cpu=6  duration=63.672µs     insn=0xffffffffbc61563f <+15/0xf>:     41 55              	pushq	%r13
icmp_rcv cpu=6  duration=66.42µs      insn=0xffffffffbc615641 <+17/0x11>:    41 54              	pushq	%r12
icmp_rcv cpu=6  duration=68.981µs     insn=0xffffffffbc615643 <+19/0x13>:    53                 	pushq	%rbx
icmp_rcv cpu=6  duration=70.799µs     insn=0xffffffffbc615644 <+20/0x14>:    48 89 fb           	movq	%rdi, %rbx
icmp_rcv cpu=6  duration=73.456µs     insn=0xffffffffbc615647 <+23/0x17>:    48 83 ec 08        	subq	$8, %rsp
icmp_rcv cpu=6  duration=75.105µs     insn=0xffffffffbc61564b <+27/0x1b>:    4c 8b 67 58        	movq	0x58(%rdi), %r12
icmp_rcv cpu=6  duration=76.958µs     insn=0xffffffffbc61564f <+31/0x1f>:    49 83 e4 fe        	andq	$0xfffffffffffffffe, %r12
icmp_rcv cpu=6  duration=80.099µs     insn=0xffffffffbc615653 <+35/0x23>:    49 8b 04 24        	movq	(%r12), %rax
icmp_rcv args=((struct sk_buff *)skb=0xffff93438ee73e00) retval=(int)1 cpu=6 process=(0:swapper/6) duration=84.739µs
```