### PR TITLE
cc: Basic BTF-based C expression compiler for --filter-arg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ go.work
 /bpf/headers/vmlinux.h
 
 /bin/*
+coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -66,3 +66,11 @@ publish: local_release
 	$(CMD_TAR) -czf $(DIR_BIN)/$(BPFSNOOP_OBJ)-$(VERSION)-linux-amd64.tar.gz $(DIR_BIN)/$(BPFSNOOP_OBJ) $(DIR_BIN)/$(BPFSNOOP_CSM)
 	@$(CMD_MV) $(RELEASE_NOTES) $(DIR_BIN)/$(RELEASE_NOTES)
 	$(CMD_GH) release create $(VERSION) $(DIR_BIN)/$(BPFSNOOP_OBJ)-$(VERSION)-linux-amd64.tar.gz --title "bpfsnoop $(VERSION)" --notes-file $(DIR_BIN)/$(RELEASE_NOTES)
+
+.PHONY: test
+test:
+	@go clean -testcache
+	GOEXPERIMENT=nocoverageredesign go test -race -timeout 60s -coverpkg=./internal/cc -coverprofile=coverage.txt -covermode atomic ./internal/cc
+	go tool cover -func=coverage.txt
+	@rm -f coverage.txt
+	@go clean -testcache

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	golang.org/x/sync v0.8.0
+	rsc.io/c2go v0.0.0-20170620140410-520c22818a08
 )
 
 require (
@@ -26,7 +27,6 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	golang.org/x/net v0.33.0 // indirect
-	rsc.io/c2go v0.0.0-20170620140410-520c22818a08 // indirect
 )
 
 require (

--- a/internal/bpfsnoop/bpf_spec.go
+++ b/internal/bpfsnoop/bpf_spec.go
@@ -13,7 +13,7 @@ func TrimSpec(spec *ebpf.CollectionSpec) {
 			pktFilter.clear(prog)
 		}
 
-		if len(argFilter) == 0 {
+		if len(argFilter.args) == 0 {
 			clearFilterArgSubprog(prog)
 		}
 

--- a/internal/bpfsnoop/error.go
+++ b/internal/bpfsnoop/error.go
@@ -8,4 +8,5 @@ import "errors"
 var (
 	ErrNotFound = errors.New("not found")
 	ErrFinished = errors.New("finished")
+	errSkipped  = errors.New("skipped")
 )

--- a/internal/cc/bpf_btf.go
+++ b/internal/cc/bpf_btf.go
@@ -1,0 +1,19 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import (
+	"github.com/Asphaltt/mybtf"
+	"github.com/cilium/ebpf/btf"
+)
+
+func canCalculate(t btf.Type) bool {
+	switch mybtf.UnderlyingType(t).(type) {
+	case *btf.Int, *btf.Enum, *btf.Pointer, *btf.Array:
+		return true
+
+	default:
+		return false
+	}
+}

--- a/internal/cc/error.go
+++ b/internal/cc/error.go
@@ -1,0 +1,12 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import "errors"
+
+var (
+	ErrNotImplemented    = errors.New("not implemented")
+	ErrRegisterNotEnough = errors.New("not enough registers")
+	ErrVarNotFound       = errors.New("not found variable")
+)

--- a/internal/cc/eval.go
+++ b/internal/cc/eval.go
@@ -1,0 +1,1421 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/Asphaltt/mybtf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
+	"rsc.io/c2go/cc"
+)
+
+const (
+	evalValueTypeUnspec int = iota
+	evalValueTypeNum
+	evalValueTypeRegBtf
+	evalValueTypeEnumMaybe
+)
+
+type evalValue struct {
+	typ  int
+	reg  asm.Register
+	num  int64
+	name string
+	btf  btf.Type
+	mem  *btf.Member
+}
+
+func (v evalValue) String() string {
+	switch v.typ {
+	case evalValueTypeNum:
+		return fmt.Sprintf("%d", v.num)
+	case evalValueTypeRegBtf:
+		return fmt.Sprintf("r%d(%v)", v.reg, v.btf)
+	case evalValueTypeEnumMaybe:
+		return v.name
+	default:
+		return "unspecified"
+	}
+}
+
+func (c *compiler) emitReg2bool(reg asm.Register) {
+	c.emit(asm.Mov.Imm(reg, 1))
+	c.emit(Ja(1))
+	c.emit(asm.Xor.Reg(reg, reg))
+}
+
+func (c *compiler) extractEnum(typ btf.Type, enum string) (int, error) {
+	t := mybtf.UnderlyingType(typ)
+
+	e, ok := t.(*btf.Enum)
+	if !ok {
+		return 0, fmt.Errorf("type %v is not an enum for '%s'", typ, enum)
+	}
+
+	for _, v := range e.Values {
+		if v.Name == enum {
+			return int(v.Value), nil
+		}
+	}
+
+	return 0, fmt.Errorf("enum '%s' not found in type %v", enum, typ)
+}
+
+func (c *compiler) adjustNum(num int64, ref evalValue) int64 {
+	if ref.typ != evalValueTypeRegBtf {
+		return num
+	}
+
+	if isMemberBitfield(ref.mem) {
+		mask := (int64(1) << uint64(ref.mem.BitfieldSize)) - 1
+		return num & mask
+	}
+
+	size, _ := btf.Sizeof(ref.btf)
+	switch size {
+	case 1:
+		return num & 0xFF
+
+	case 2:
+		return num & 0xFFFF
+
+	case 4:
+		return num & 0xFFFFFFFF
+
+	default:
+		return num
+	}
+}
+
+func (c *compiler) preHandleBinaryOp(a, b evalValue) (evalValue, evalValue, error) {
+	if a.typ == evalValueTypeRegBtf && !canCalculate(a.btf) {
+		return a, b, fmt.Errorf("disallow type %v for binary op", a.btf)
+	}
+
+	if b.typ == evalValueTypeRegBtf && !canCalculate(b.btf) {
+		return a, b, fmt.Errorf("disallow type %v for binary op", b.btf)
+	}
+
+	if a.typ == evalValueTypeEnumMaybe && b.typ == evalValueTypeRegBtf {
+		num, err := c.extractEnum(b.btf, a.name)
+		if err != nil {
+			return a, b, fmt.Errorf("failed to extract enum: %w", err)
+		}
+
+		a.num = c.adjustNum(int64(num), b)
+		a.typ = evalValueTypeNum
+		return a, b, nil
+	}
+
+	if a.typ == evalValueTypeRegBtf && b.typ == evalValueTypeEnumMaybe {
+		num, err := c.extractEnum(a.btf, b.name)
+		if err != nil {
+			return a, b, fmt.Errorf("failed to extract enum: %w", err)
+		}
+
+		b.num = c.adjustNum(int64(num), a)
+		b.typ = evalValueTypeNum
+		return a, b, nil
+	}
+
+	a.num = c.adjustNum(a.num, b)
+	b.num = c.adjustNum(b.num, a)
+
+	return a, b, nil
+}
+
+func (c *compiler) add(left, right evalValue) (evalValue, error) {
+	left, right, err := c.preHandleBinaryOp(left, right)
+	if err != nil {
+		return evalValue{}, err
+	}
+
+	switch {
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeNum:
+		left.num += right.num
+		return left, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeRegBtf:
+		var size int
+		t := mybtf.UnderlyingType(left.btf)
+		if ptr, ok := t.(*btf.Pointer); ok {
+			size, _ = btf.Sizeof(ptr.Target)
+		} else if arr, ok := t.(*btf.Array); ok {
+			size, _ = btf.Sizeof(arr.Type)
+		}
+		if size != 0 {
+			c.emit(asm.Mul.Imm(right.reg, int32(size)))
+		}
+
+		c.emit(asm.Add.Reg(left.reg, right.reg))
+		c.regalloc.Free(right.reg)
+		return left, nil
+
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeRegBtf:
+		if left.num == 0 {
+			return right, nil
+		}
+
+		t := mybtf.UnderlyingType(right.btf)
+		if ptr, ok := t.(*btf.Pointer); ok {
+			if _, ok := mybtf.UnderlyingType(ptr.Target).(*btf.Void); ok {
+				c.emit(asm.Add.Imm(right.reg, int32(left.num)))
+			} else {
+				size, _ := btf.Sizeof(ptr.Target)
+				if size == 0 {
+					c.regalloc.Free(right.reg)
+					return right, fmt.Errorf("disallow type %v for add", right.btf)
+				}
+
+				c.emit(asm.Add.Imm(right.reg, int32(left.num)*int32(size)))
+			}
+		} else if arr, ok := t.(*btf.Array); ok {
+			size, _ := btf.Sizeof(arr.Type)
+			if size == 0 {
+				c.regalloc.Free(right.reg)
+				return right, fmt.Errorf("disallow type %v for add", right.btf)
+			}
+
+			c.emit(asm.Add.Imm(right.reg, int32(left.num)*int32(size)))
+		} else {
+			c.emit(asm.Add.Imm(right.reg, int32(left.num)))
+		}
+
+		return right, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeNum:
+		if right.num == 0 {
+			return left, nil
+		}
+
+		t := mybtf.UnderlyingType(left.btf)
+		if ptr, ok := t.(*btf.Pointer); ok {
+			if _, ok := mybtf.UnderlyingType(ptr.Target).(*btf.Void); ok {
+				c.emit(asm.Add.Imm(left.reg, int32(right.num)))
+			} else {
+				size, _ := btf.Sizeof(ptr.Target)
+				if size == 0 {
+					c.regalloc.Free(left.reg)
+					return left, fmt.Errorf("disallow type %v for add", left.btf)
+				}
+
+				c.emit(asm.Add.Imm(left.reg, int32(right.num)*int32(size)))
+			}
+		} else if arr, ok := t.(*btf.Array); ok {
+			size, _ := btf.Sizeof(arr.Type)
+			if size == 0 {
+				c.regalloc.Free(left.reg)
+				return left, fmt.Errorf("disallow type %v for add", left.btf)
+			}
+
+			c.emit(asm.Add.Imm(left.reg, int32(right.num)*int32(size)))
+		} else {
+			c.emit(asm.Add.Imm(left.reg, int32(right.num)))
+		}
+
+		return left, nil
+
+	default:
+		return evalValue{}, ErrNotImplemented
+	}
+}
+
+func (c *compiler) and(left, right evalValue) (evalValue, error) {
+	left, right, err := c.preHandleBinaryOp(left, right)
+	if err != nil {
+		return evalValue{}, err
+	}
+
+	switch {
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeNum:
+		left.num &= right.num
+		return left, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeRegBtf:
+		c.emit(asm.And.Reg(left.reg, right.reg))
+		c.regalloc.Free(right.reg)
+		return left, nil
+
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeRegBtf:
+		c.emit(asm.And.Imm(right.reg, int32(left.num)))
+		return right, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeNum:
+		c.emit(asm.And.Imm(left.reg, int32(right.num)))
+		return left, nil
+
+	default:
+		return evalValue{}, ErrNotImplemented
+	}
+}
+
+func (c *compiler) andand(left, right evalValue) (evalValue, error) {
+	left, right, err := c.preHandleBinaryOp(left, right)
+	if err != nil {
+		return evalValue{}, err
+	}
+
+	switch {
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeNum:
+		left.num = int64(bool2int(left.num != 0 && right.num != 0))
+		return left, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeRegBtf:
+		c.emit(JmpOff(asm.JEq, left.reg, 0, 3))
+		c.emit(JmpOff(asm.JEq, right.reg, 0, 2))
+		c.emitReg2bool(left.reg)
+		c.regalloc.Free(right.reg)
+		return left, nil
+
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeRegBtf:
+		if left.num == 0 {
+			c.regalloc.Free(right.reg)
+			return left, nil
+		}
+
+		c.emit(JmpOff(asm.JEq, right.reg, 0, 2))
+		c.emitReg2bool(right.reg)
+		return right, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeNum:
+		if right.num == 0 {
+			c.regalloc.Free(left.reg)
+			return right, nil
+		}
+
+		c.emit(JmpOff(asm.JEq, left.reg, 0, 2))
+		c.emitReg2bool(left.reg)
+		return left, nil
+
+	default:
+		return evalValue{}, ErrNotImplemented
+	}
+}
+
+func (c *compiler) cond(cond, left, right evalValue) (evalValue, error) {
+	if cond.typ == evalValueTypeRegBtf && !canCalculate(cond.btf) {
+		c.regalloc.Free(cond.reg)
+		return cond, fmt.Errorf("disallow type %v for cond", cond.btf)
+	}
+
+	if left.typ == evalValueTypeRegBtf && !canCalculate(left.btf) {
+		c.regalloc.Free(left.reg)
+		return left, fmt.Errorf("disallow type %v for cond", left.btf)
+	}
+
+	if right.typ == evalValueTypeRegBtf && !canCalculate(right.btf) {
+		c.regalloc.Free(right.reg)
+		return right, fmt.Errorf("disallow type %v for cond", right.btf)
+	}
+
+	if cond.typ == evalValueTypeNum {
+		if cond.num == 0 {
+			return right, nil
+		}
+		return left, nil
+	}
+
+	c.emit(JmpOff(asm.JEq, cond.reg, 0, 2))
+
+	if left.typ == evalValueTypeNum {
+		c.emit(asm.Mov.Imm(cond.reg, int32(left.num)))
+	} else {
+		c.emit(asm.Mov.Reg(cond.reg, left.reg))
+		c.regalloc.Free(left.reg)
+	}
+	c.emit(Ja(1))
+
+	if right.typ == evalValueTypeNum {
+		c.emit(asm.Mov.Imm(cond.reg, int32(right.num)))
+	} else {
+		c.emit(asm.Mov.Reg(cond.reg, right.reg))
+		c.regalloc.Free(right.reg)
+	}
+
+	return cond, nil
+}
+
+func (c *compiler) div(left, right evalValue) (evalValue, error) {
+	left, right, err := c.preHandleBinaryOp(left, right)
+	if err != nil {
+		return evalValue{}, err
+	}
+
+	if right.typ == evalValueTypeNum && right.num == 0 {
+		return evalValue{}, fmt.Errorf("division by zero")
+	}
+
+	if left.typ == evalValueTypeNum && right.typ == evalValueTypeNum {
+		left.num /= right.num
+		return left, nil
+	}
+
+	if left.typ == evalValueTypeNum && right.typ == evalValueTypeRegBtf {
+		reg, err := c.regalloc.Alloc()
+		if err != nil {
+			return evalValue{}, err
+		}
+
+		c.emit(JmpOff(asm.JEq, right.reg, 0, 2))
+		c.emit(asm.Mov.Imm(reg, 0))
+		c.emit(Ja(2))
+		c.emit(asm.Mov.Imm(reg, int32(left.num)))
+		c.emit(asm.Div.Reg(reg, right.reg))
+		c.regalloc.Free(right.reg)
+		return evalValue{typ: evalValueTypeRegBtf, reg: reg, btf: right.btf}, nil
+	}
+
+	if left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeNum {
+		c.emit(asm.Div.Imm(left.reg, int32(right.num)))
+		return left, nil
+	}
+
+	if left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeRegBtf {
+		c.emit(JmpOff(asm.JEq, right.reg, 0, 2))
+		c.emit(asm.Mov.Imm(left.reg, 0))
+		c.emit(Ja(1))
+		c.emit(asm.Div.Reg(left.reg, right.reg))
+		c.regalloc.Free(right.reg)
+		return left, nil
+	}
+
+	return evalValue{}, ErrNotImplemented
+}
+
+func (c *compiler) eqeq(left, right evalValue) (evalValue, error) {
+	left, right, err := c.preHandleBinaryOp(left, right)
+	if err != nil {
+		return evalValue{}, err
+	}
+
+	switch {
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeNum:
+		left.num = int64(bool2int(left.num == right.num))
+		return left, nil
+
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeRegBtf:
+		c.emit(JmpOff(asm.JNE, right.reg, int64(left.num), 2))
+		c.emitReg2bool(right.reg)
+		return right, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeNum:
+		c.emit(JmpOff(asm.JNE, left.reg, int64(right.num), 2))
+		c.emitReg2bool(left.reg)
+		return left, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeRegBtf:
+		c.emit(JmpReg(asm.JNE, left.reg, right.reg, 2))
+		c.emitReg2bool(left.reg)
+		c.regalloc.Free(right.reg)
+		return left, nil
+
+	default:
+		return evalValue{}, ErrNotImplemented
+	}
+}
+
+func (c *compiler) gt(left, right evalValue) (evalValue, error) {
+	left, right, err := c.preHandleBinaryOp(left, right)
+	if err != nil {
+		return evalValue{}, err
+	}
+
+	switch {
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeNum:
+		left.num = int64(bool2int(left.num > right.num))
+		return left, nil
+
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeRegBtf:
+		c.emit(JmpOff(asm.JLE, right.reg, int64(left.num), 2))
+		c.emitReg2bool(right.reg)
+		return right, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeNum:
+		c.emit(JmpOff(asm.JLE, left.reg, int64(right.num), 2))
+		c.emitReg2bool(left.reg)
+		return left, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeRegBtf:
+		c.emit(JmpReg(asm.JLE, left.reg, right.reg, 2))
+		c.emitReg2bool(left.reg)
+		c.regalloc.Free(right.reg)
+		return left, nil
+
+	default:
+		return evalValue{}, ErrNotImplemented
+	}
+}
+
+func (c *compiler) gteq(left, right evalValue) (evalValue, error) {
+	left, right, err := c.preHandleBinaryOp(left, right)
+	if err != nil {
+		return evalValue{}, err
+	}
+
+	switch {
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeNum:
+		left.num = int64(bool2int(left.num >= right.num))
+		return left, nil
+
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeRegBtf:
+		c.emit(JmpOff(asm.JLT, right.reg, int64(left.num), 2))
+		c.emitReg2bool(right.reg)
+		return right, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeNum:
+		c.emit(JmpOff(asm.JLT, left.reg, int64(right.num), 2))
+		c.emitReg2bool(left.reg)
+		return left, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeRegBtf:
+		c.emit(JmpReg(asm.JLT, left.reg, right.reg, 2))
+		c.emitReg2bool(left.reg)
+		c.regalloc.Free(right.reg)
+		return left, nil
+
+	default:
+		return evalValue{}, ErrNotImplemented
+	}
+}
+
+func (c *compiler) lsh(left, right evalValue) (evalValue, error) {
+	left, right, err := c.preHandleBinaryOp(left, right)
+	if err != nil {
+		return evalValue{}, err
+	}
+
+	if left.typ == evalValueTypeNum && right.typ == evalValueTypeNum {
+		left.num <<= right.num
+		return left, nil
+	}
+
+	if left.typ == evalValueTypeNum && right.typ == evalValueTypeRegBtf {
+		num := left.num
+		if num == 0 {
+			c.regalloc.Free(right.reg)
+			return left, nil
+		}
+
+		reg, err := c.regalloc.Alloc()
+		if err != nil {
+			return evalValue{}, err
+		}
+
+		c.emit(asm.Mov.Imm(reg, int32(num)))
+		c.emit(asm.LSh.Reg(reg, right.reg))
+		c.regalloc.Free(right.reg)
+		return evalValue{typ: evalValueTypeRegBtf, reg: reg, btf: right.btf}, nil
+	}
+
+	if left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeNum {
+		num := right.num
+		if num < 0 {
+			return evalValue{}, fmt.Errorf("shift count is negative")
+		}
+		if num == 0 {
+			return left, nil
+		}
+
+		c.emit(asm.LSh.Imm(left.reg, int32(num)))
+		return left, nil
+	}
+
+	if left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeRegBtf {
+		c.emit(JmpOff(asm.JLE, right.reg, 0, 1))
+		c.emit(asm.LSh.Reg(left.reg, right.reg))
+		c.regalloc.Free(right.reg)
+		return left, nil
+	}
+
+	return evalValue{}, ErrNotImplemented
+}
+
+func (c *compiler) lt(left, right evalValue) (evalValue, error) {
+	left, right, err := c.preHandleBinaryOp(left, right)
+	if err != nil {
+		return evalValue{}, err
+	}
+
+	switch {
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeNum:
+		left.num = int64(bool2int(left.num < right.num))
+		return left, nil
+
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeRegBtf:
+		c.emit(JmpOff(asm.JGE, right.reg, int64(left.num), 2))
+		c.emitReg2bool(right.reg)
+		return right, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeNum:
+		c.emit(JmpOff(asm.JGE, left.reg, int64(right.num), 2))
+		c.emitReg2bool(left.reg)
+		return left, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeRegBtf:
+		c.emit(JmpReg(asm.JGE, left.reg, right.reg, 2))
+		c.emitReg2bool(left.reg)
+		c.regalloc.Free(right.reg)
+		return left, nil
+
+	default:
+		return evalValue{}, ErrNotImplemented
+	}
+}
+
+func (c *compiler) lteq(left, right evalValue) (evalValue, error) {
+	left, right, err := c.preHandleBinaryOp(left, right)
+	if err != nil {
+		return evalValue{}, err
+	}
+
+	switch {
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeNum:
+		left.num = int64(bool2int(left.num <= right.num))
+		return left, nil
+
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeRegBtf:
+		c.emit(JmpOff(asm.JGT, right.reg, int64(left.num), 2))
+		c.emitReg2bool(right.reg)
+		return right, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeNum:
+		c.emit(JmpOff(asm.JGT, left.reg, int64(right.num), 2))
+		c.emitReg2bool(left.reg)
+		return left, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeRegBtf:
+		c.emit(JmpReg(asm.JGT, left.reg, right.reg, 2))
+		c.emitReg2bool(left.reg)
+		c.regalloc.Free(right.reg)
+		return left, nil
+
+	default:
+		return evalValue{}, ErrNotImplemented
+	}
+}
+
+func (c *compiler) minus(val evalValue) (evalValue, error) {
+	switch val.typ {
+	case evalValueTypeNum:
+		val.num = -val.num
+		return val, nil
+
+	case evalValueTypeRegBtf:
+		c.emit(asm.Neg.Reg(val.reg, val.reg))
+		return val, nil
+
+	default:
+		return evalValue{}, ErrNotImplemented
+	}
+}
+
+func (c *compiler) mod(left, right evalValue) (evalValue, error) {
+	left, right, err := c.preHandleBinaryOp(left, right)
+	if err != nil {
+		return evalValue{}, err
+	}
+
+	if right.typ == evalValueTypeNum && right.num == 0 {
+		return evalValue{}, fmt.Errorf("mod by zero")
+	}
+
+	switch {
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeNum:
+		left.num = left.num % right.num
+		return left, nil
+
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeRegBtf:
+		if left.num == 0 {
+			c.regalloc.Free(right.reg)
+			return left, nil
+		}
+
+		reg, err := c.regalloc.Alloc()
+		if err != nil {
+			return evalValue{}, err
+		}
+
+		c.emit(asm.Mov.Imm(reg, int32(left.num)))
+		c.emit(asm.Mod.Reg(reg, right.reg))
+		c.regalloc.Free(right.reg)
+		return evalValue{typ: evalValueTypeRegBtf, reg: reg, btf: right.btf}, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeNum:
+		if right.num == 1 {
+			c.emit(asm.Mov.Imm(left.reg, 0))
+			return left, nil
+		}
+
+		c.emit(asm.Mod.Imm(left.reg, int32(right.num)))
+		return left, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeRegBtf:
+		c.emit(JmpOff(asm.JEq, right.reg, 0, 1))
+		c.emit(asm.Mod.Reg(left.reg, right.reg))
+		c.regalloc.Free(right.reg)
+		return left, nil
+
+	default:
+		return evalValue{}, ErrNotImplemented
+	}
+}
+
+func (c *compiler) mul(left, right evalValue) (evalValue, error) {
+	left, right, err := c.preHandleBinaryOp(left, right)
+	if err != nil {
+		return evalValue{}, err
+	}
+
+	if left.typ == evalValueTypeNum && right.typ == evalValueTypeNum {
+		left.num *= right.num
+		return left, nil
+	}
+
+	if left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeRegBtf {
+		c.emit(asm.Mul.Reg(left.reg, right.reg))
+		c.regalloc.Free(right.reg)
+		return left, nil
+	}
+
+	if right.typ == evalValueTypeRegBtf {
+		left, right = right, left
+	}
+
+	if left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeNum {
+		if right.num == 0 {
+			c.regalloc.Free(left.reg)
+			return right, nil
+		}
+		if right.num == 1 {
+			return left, nil
+		}
+
+		c.emit(asm.Mul.Imm(left.reg, int32(right.num)))
+		return left, nil
+	}
+
+	return evalValue{}, ErrNotImplemented
+}
+
+func (c *compiler) not(val evalValue) (evalValue, error) {
+	switch val.typ {
+	case evalValueTypeNum:
+		val.num = int64(bool2int(val.num == 0))
+		return val, nil
+
+	case evalValueTypeRegBtf:
+		if !canCalculate(val.btf) {
+			c.regalloc.Free(val.reg)
+			return val, fmt.Errorf("disallow type %v for not", val.btf)
+		}
+
+		c.emit(JmpOff(asm.JNE, val.reg, 0, 2))
+		c.emitReg2bool(val.reg)
+		return val, nil
+
+	default:
+		return evalValue{}, ErrNotImplemented
+	}
+}
+
+func (c *compiler) noteq(left, right evalValue) (evalValue, error) {
+	left, right, err := c.preHandleBinaryOp(left, right)
+	if err != nil {
+		return evalValue{}, err
+	}
+
+	switch {
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeNum:
+		left.num = int64(bool2int(left.num != right.num))
+		return left, nil
+
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeRegBtf:
+		c.emit(JmpOff(asm.JEq, right.reg, int64(left.num), 2))
+		c.emitReg2bool(right.reg)
+		return right, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeNum:
+		c.emit(JmpOff(asm.JEq, left.reg, int64(right.num), 2))
+		c.emitReg2bool(left.reg)
+		return left, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeRegBtf:
+		c.emit(JmpReg(asm.JEq, left.reg, right.reg, 2))
+		c.emitReg2bool(left.reg)
+		c.regalloc.Free(right.reg)
+		return left, nil
+
+	default:
+		return evalValue{}, ErrNotImplemented
+	}
+}
+
+func (c *compiler) or(left, right evalValue) (evalValue, error) {
+	left, right, err := c.preHandleBinaryOp(left, right)
+	if err != nil {
+		return evalValue{}, err
+	}
+
+	switch {
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeNum:
+		left.num |= right.num
+		return left, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeRegBtf:
+		c.emit(asm.Or.Reg(left.reg, right.reg))
+		c.regalloc.Free(right.reg)
+		return left, nil
+
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeRegBtf:
+		if left.num == 0 {
+			c.regalloc.Free(right.reg)
+			return left, nil
+		}
+
+		c.emit(asm.Or.Imm(right.reg, int32(left.num)))
+		return right, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeNum:
+		if right.num == 0 {
+			c.regalloc.Free(left.reg)
+			return right, nil
+		}
+
+		c.emit(asm.Or.Imm(left.reg, int32(right.num)))
+		return left, nil
+
+	default:
+		return evalValue{}, ErrNotImplemented
+	}
+}
+
+func (c *compiler) oror(left, right evalValue) (evalValue, error) {
+	left, right, err := c.preHandleBinaryOp(left, right)
+	if err != nil {
+		return evalValue{}, err
+	}
+
+	switch {
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeNum:
+		left.num = int64(bool2int(left.num != 0 || right.num != 0))
+		return left, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeRegBtf:
+		c.emit(JmpOff(asm.JNE, left.reg, 0, 3))
+		c.emit(JmpOff(asm.JNE, right.reg, 0, 2))
+		c.emit(asm.Xor.Reg(left.reg, left.reg))
+		c.emit(Ja(1))
+		c.emit(asm.Mov.Imm(left.reg, 1))
+		c.regalloc.Free(right.reg)
+		return left, nil
+
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeRegBtf:
+		if left.num != 0 {
+			left.num = 1
+			c.regalloc.Free(right.reg)
+			return left, nil
+		}
+
+		c.emit(JmpOff(asm.JEq, right.reg, 0, 2))
+		c.emitReg2bool(right.reg)
+		return right, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeNum:
+		if right.num != 0 {
+			right.num = 1
+			c.regalloc.Free(left.reg)
+			return right, nil
+		}
+
+		c.emit(JmpOff(asm.JEq, left.reg, 0, 2))
+		c.emitReg2bool(left.reg)
+		return left, nil
+
+	default:
+		return evalValue{}, ErrNotImplemented
+	}
+}
+
+func (c *compiler) preDec(val evalValue) (evalValue, error) {
+	switch val.typ {
+	case evalValueTypeNum:
+		val.num--
+		return val, nil
+
+	case evalValueTypeRegBtf:
+		if !canCalculate(val.btf) {
+			c.regalloc.Free(val.reg)
+			return val, fmt.Errorf("disallow type %v for pre-decrement", val.btf)
+		}
+
+		c.emit(asm.Sub.Imm(val.reg, 1))
+		return val, nil
+
+	default:
+		return evalValue{}, ErrNotImplemented
+	}
+}
+
+func (c *compiler) preInc(val evalValue) (evalValue, error) {
+	switch val.typ {
+	case evalValueTypeNum:
+		val.num++
+		return val, nil
+
+	case evalValueTypeRegBtf:
+		if !canCalculate(val.btf) {
+			c.regalloc.Free(val.reg)
+			return val, fmt.Errorf("disallow type %v for pre-increment", val.btf)
+		}
+
+		c.emit(asm.Add.Imm(val.reg, 1))
+		return val, nil
+
+	default:
+		return evalValue{}, ErrNotImplemented
+	}
+}
+
+func (c *compiler) rsh(left, right evalValue) (evalValue, error) {
+	left, right, err := c.preHandleBinaryOp(left, right)
+	if err != nil {
+		return evalValue{}, err
+	}
+
+	if left.typ == evalValueTypeNum && right.typ == evalValueTypeNum {
+		left.num >>= right.num
+		return left, nil
+	}
+
+	if left.typ == evalValueTypeNum && right.typ == evalValueTypeRegBtf {
+		if left.num == 0 {
+			c.regalloc.Free(right.reg)
+			return left, nil
+		}
+
+		reg, err := c.regalloc.Alloc()
+		if err != nil {
+			return evalValue{}, err
+		}
+
+		c.emit(asm.Mov.Imm(reg, int32(left.num)))
+		c.emit(asm.RSh.Reg(reg, right.reg))
+		c.regalloc.Free(right.reg)
+		return evalValue{typ: evalValueTypeRegBtf, reg: reg, btf: right.btf}, nil
+	}
+
+	if left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeNum {
+		if right.num < 0 {
+			return evalValue{}, fmt.Errorf("shift count is negative")
+		}
+		if right.num == 0 {
+			return left, nil
+		}
+
+		c.emit(asm.RSh.Imm(left.reg, int32(right.num)))
+		return left, nil
+	}
+
+	if left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeRegBtf {
+		c.emit(asm.RSh.Reg(left.reg, right.reg))
+		c.regalloc.Free(right.reg)
+		return left, nil
+	}
+
+	return evalValue{}, ErrNotImplemented
+}
+
+func (c *compiler) sub(left, right evalValue) (evalValue, error) {
+	left, right, err := c.preHandleBinaryOp(left, right)
+	if err != nil {
+		return evalValue{}, err
+	}
+
+	if left.typ == evalValueTypeNum && right.typ == evalValueTypeNum {
+		left.num -= right.num
+		return left, nil
+	}
+
+	if left.typ == evalValueTypeNum && right.typ == evalValueTypeRegBtf {
+		t := mybtf.UnderlyingType(right.btf)
+		_, isInt := t.(*btf.Int)
+		_, isEnum := t.(*btf.Enum)
+		if !isInt && !isEnum {
+			c.regalloc.Free(right.reg)
+			return right, fmt.Errorf("disallow type %v for sub", right.btf)
+		}
+
+		if left.num == 0 {
+			c.emit(asm.Neg.Reg(right.reg, right.reg))
+			return right, nil
+		}
+
+		c.emit(asm.Sub.Imm(right.reg, int32(left.num)))
+		return right, nil
+	}
+
+	if left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeNum {
+		if right.num == 0 {
+			return left, nil
+		}
+
+		t := mybtf.UnderlyingType(left.btf)
+		if ptr, ok := t.(*btf.Pointer); ok {
+			size, _ := btf.Sizeof(ptr.Target)
+			if size == 0 {
+				c.emit(asm.Sub.Imm(left.reg, int32(right.num)))
+				return left, nil
+			}
+
+			c.emit(asm.Sub.Imm(left.reg, int32(right.num)*int32(size)))
+		} else if arr, ok := t.(*btf.Array); ok {
+			size, _ := btf.Sizeof(arr.Type)
+			if size == 0 {
+				c.regalloc.Free(left.reg)
+				return left, fmt.Errorf("disallow type %v for sub", left.btf)
+			}
+
+			c.emit(asm.Sub.Imm(left.reg, int32(right.num)*int32(size)))
+		} else {
+			c.emit(asm.Sub.Imm(left.reg, int32(right.num)))
+		}
+		return left, nil
+	}
+
+	if left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeRegBtf {
+		var size int
+		t := mybtf.UnderlyingType(left.btf)
+		if ptr, ok := t.(*btf.Pointer); ok {
+			size, _ = btf.Sizeof(ptr.Target)
+		} else if arr, ok := t.(*btf.Array); ok {
+			size, _ = btf.Sizeof(arr.Type)
+		}
+		if size != 0 {
+			c.emit(asm.Mul.Imm(right.reg, int32(size)))
+		}
+
+		c.emit(asm.Sub.Reg(left.reg, right.reg))
+		c.regalloc.Free(right.reg)
+		return left, nil
+	}
+
+	return evalValue{}, ErrNotImplemented
+}
+
+func (c *compiler) twid(val evalValue) (evalValue, error) {
+	switch val.typ {
+	case evalValueTypeNum:
+		val.num = ^val.num
+		return val, nil
+
+	case evalValueTypeRegBtf:
+		if !canCalculate(val.btf) {
+			c.regalloc.Free(val.reg)
+			return val, fmt.Errorf("disallow type %v for twid", val.btf)
+		}
+
+		c.emit(asm.Xor.Imm(val.reg, -1))
+		return val, nil
+
+	default:
+		return evalValue{}, ErrNotImplemented
+	}
+}
+
+func (c *compiler) xor(left, right evalValue) (evalValue, error) {
+	left, right, err := c.preHandleBinaryOp(left, right)
+	if err != nil {
+		return evalValue{}, err
+	}
+
+	switch {
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeNum:
+		left.num ^= right.num
+		return left, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeRegBtf:
+		c.emit(asm.Xor.Reg(left.reg, right.reg))
+		c.regalloc.Free(right.reg)
+		return left, nil
+
+	case left.typ == evalValueTypeNum && right.typ == evalValueTypeRegBtf:
+		if left.num == 0 {
+			c.regalloc.Free(right.reg)
+			return left, nil
+		}
+
+		c.emit(asm.Xor.Imm(right.reg, int32(left.num)))
+		return right, nil
+
+	case left.typ == evalValueTypeRegBtf && right.typ == evalValueTypeNum:
+		if right.num == 0 {
+			c.regalloc.Free(left.reg)
+			return right, nil
+		}
+
+		c.emit(asm.Xor.Imm(left.reg, int32(right.num)))
+		return left, nil
+
+	default:
+		return evalValue{}, ErrNotImplemented
+	}
+}
+
+func (c *compiler) eval(expr *cc.Expr) (evalValue, error) {
+	switch expr.Op {
+	case cc.Dot, cc.Arrow, cc.Index, cc.Addr, cc.Indir:
+		return c.access(expr)
+
+	case cc.Add:
+		l, err := c.eval(expr.Left)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate left operand: %w", err)
+		}
+
+		r, err := c.eval(expr.Right)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate right operand: %w", err)
+		}
+
+		return c.add(l, r)
+
+	case cc.And:
+		l, err := c.eval(expr.Left)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate left operand: %w", err)
+		}
+
+		r, err := c.eval(expr.Right)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate right operand: %w", err)
+		}
+
+		return c.and(l, r)
+
+	case cc.AndAnd:
+		l, err := c.eval(expr.Left)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate left operand: %w", err)
+		}
+
+		r, err := c.eval(expr.Right)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate right operand: %w", err)
+		}
+
+		return c.andand(l, r)
+
+	case cc.Cond:
+		cond, err := c.eval(expr.List[0])
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate cond operand: %w", err)
+		}
+
+		l, err := c.eval(expr.List[1])
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate true operand: %w", err)
+		}
+
+		r, err := c.eval(expr.List[2])
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate false operand: %w", err)
+		}
+
+		return c.cond(cond, l, r)
+
+	case cc.Div:
+		l, err := c.eval(expr.Left)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate left operand: %w", err)
+		}
+
+		r, err := c.eval(expr.Right)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate right operand: %w", err)
+		}
+
+		return c.div(l, r)
+
+	case cc.EqEq:
+		l, err := c.eval(expr.Left)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate left operand: %w", err)
+		}
+
+		r, err := c.eval(expr.Right)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate right operand: %w", err)
+		}
+
+		return c.eqeq(l, r)
+
+	case cc.Gt:
+		l, err := c.eval(expr.Left)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate left operand: %w", err)
+		}
+
+		r, err := c.eval(expr.Right)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate right operand: %w", err)
+		}
+
+		return c.gt(l, r)
+
+	case cc.GtEq:
+		l, err := c.eval(expr.Left)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate left operand: %w", err)
+		}
+
+		r, err := c.eval(expr.Right)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate right operand: %w", err)
+		}
+
+		return c.gteq(l, r)
+
+	case cc.Lsh:
+		l, err := c.eval(expr.Left)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate left operand: %w", err)
+		}
+
+		r, err := c.eval(expr.Right)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate right operand: %w", err)
+		}
+
+		return c.lsh(l, r)
+
+	case cc.Lt:
+		l, err := c.eval(expr.Left)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate left operand: %w", err)
+		}
+
+		r, err := c.eval(expr.Right)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate right operand: %w", err)
+		}
+
+		return c.lt(l, r)
+
+	case cc.LtEq:
+		l, err := c.eval(expr.Left)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate left operand: %w", err)
+		}
+
+		r, err := c.eval(expr.Right)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate right operand: %w", err)
+		}
+
+		return c.lteq(l, r)
+
+	case cc.Minus:
+		val, err := c.eval(expr.Left)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate operand: %w", err)
+		}
+
+		return c.minus(val)
+
+	case cc.Mod:
+		l, err := c.eval(expr.Left)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate left operand: %w", err)
+		}
+
+		r, err := c.eval(expr.Right)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate right operand: %w", err)
+		}
+
+		return c.mod(l, r)
+
+	case cc.Mul:
+		l, err := c.eval(expr.Left)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate left operand: %w", err)
+		}
+
+		r, err := c.eval(expr.Right)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate right operand: %w", err)
+		}
+
+		return c.mul(l, r)
+
+	case cc.Name:
+		if slices.Contains([]string{"NULL", "false"}, expr.Text) {
+			return evalValue{
+				typ: evalValueTypeNum,
+				num: 0,
+			}, nil
+		}
+		if expr.Text == "true" {
+			return evalValue{
+				typ: evalValueTypeNum,
+				num: 1,
+			}, nil
+		}
+
+		idx := slices.Index(c.vars, expr.Text)
+		if idx == -1 {
+			return evalValue{
+				typ:  evalValueTypeEnumMaybe,
+				name: expr.Text,
+			}, nil
+		}
+
+		// variable
+
+		reg, err := c.regalloc.Alloc()
+		if err != nil {
+			return evalValue{}, err
+		}
+
+		c.emitLoadArg(idx, reg)
+		return evalValue{
+			typ: evalValueTypeRegBtf,
+			reg: reg,
+			btf: c.btfs[idx],
+		}, nil
+
+	case cc.Not:
+		v, err := c.eval(expr.Left)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate operand: %w", err)
+		}
+
+		return c.not(v)
+
+	case cc.NotEq:
+		l, err := c.eval(expr.Left)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate left operand: %w", err)
+		}
+
+		r, err := c.eval(expr.Right)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate right operand: %w", err)
+		}
+
+		return c.noteq(l, r)
+
+	case cc.Number:
+		num, err := parseNumber(expr.Text)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to parse number: %w", err)
+		}
+
+		return evalValue{
+			typ: evalValueTypeNum,
+			num: num,
+		}, nil
+
+	case cc.Or:
+		l, err := c.eval(expr.Left)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate left operand: %w", err)
+		}
+
+		r, err := c.eval(expr.Right)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate right operand: %w", err)
+		}
+
+		return c.or(l, r)
+
+	case cc.OrOr:
+		l, err := c.eval(expr.Left)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate left operand: %w", err)
+		}
+
+		r, err := c.eval(expr.Right)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate right operand: %w", err)
+		}
+
+		return c.oror(l, r)
+
+	case cc.Paren:
+		return c.eval(expr.Left)
+
+	case cc.Plus:
+		return c.eval(expr.Left)
+
+	case cc.PreDec:
+		v, err := c.eval(expr.Left)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate operand: %w", err)
+		}
+
+		return c.preDec(v)
+
+	case cc.PreInc:
+		v, err := c.eval(expr.Left)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate operand: %w", err)
+		}
+
+		return c.preInc(v)
+
+	case cc.Rsh:
+		l, err := c.eval(expr.Left)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate left operand: %w", err)
+		}
+
+		r, err := c.eval(expr.Right)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate right operand: %w", err)
+		}
+
+		return c.rsh(l, r)
+
+	case cc.Sub:
+		l, err := c.eval(expr.Left)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate left operand: %w", err)
+		}
+
+		r, err := c.eval(expr.Right)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate right operand: %w", err)
+		}
+
+		return c.sub(l, r)
+
+	case cc.Twid:
+		v, err := c.eval(expr.Left)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate operand: %w", err)
+		}
+
+		return c.twid(v)
+
+	case cc.Xor:
+		l, err := c.eval(expr.Left)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate left operand: %w", err)
+		}
+
+		r, err := c.eval(expr.Right)
+		if err != nil {
+			return evalValue{}, fmt.Errorf("failed to evaluate right operand: %w", err)
+		}
+
+		return c.xor(l, r)
+
+	default:
+		return evalValue{}, fmt.Errorf("unsupported operator: %s", expr.Op)
+	}
+}

--- a/internal/cc/eval_test.go
+++ b/internal/cc/eval_test.go
@@ -1,0 +1,4890 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/bpfsnoop/bpfsnoop/internal/test"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
+	"rsc.io/c2go/cc"
+)
+
+func TestEvalValue(t *testing.T) {
+	tests := []struct {
+		name string
+		eval evalValue
+		exp  string
+	}{
+		{
+			name: "num",
+			eval: evalValue{
+				typ: evalValueTypeNum,
+				num: 123,
+			},
+			exp: "123",
+		},
+		{
+			name: "btf",
+			eval: evalValue{
+				typ: evalValueTypeRegBtf,
+				reg: asm.R9,
+				btf: getSkbBtf(t),
+			},
+			exp: `r9(Pointer[target=Struct:"sk_buff"])`,
+		},
+		{
+			name: "enum",
+			eval: evalValue{
+				typ:  evalValueTypeEnumMaybe,
+				name: "BPF_PROG_TYPE_XDP",
+			},
+			exp: "BPF_PROG_TYPE_XDP",
+		},
+		{
+			name: "unknown",
+			eval: evalValue{
+				typ: -1,
+			},
+			exp: "unspecified",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			test.AssertEqual(t, tt.eval.String(), tt.exp)
+		})
+	}
+}
+
+func TestExtractEnum(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("not enum", func(t *testing.T) {
+		_, err := c.extractEnum(&btf.Int{}, "")
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "type Int[unsigned size=0] is not an enum")
+	})
+
+	t.Run("valid enum", func(t *testing.T) {
+		progType := getBpfProgTypeBtf(t)
+		enum, err := c.extractEnum(progType, "BPF_PROG_TYPE_XDP")
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, enum, 6)
+	})
+
+	t.Run("invalid enum", func(t *testing.T) {
+		progType := getBpfProgTypeBtf(t)
+		_, err := c.extractEnum(progType, "BPF_PROG_TYPE_INVALID")
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "enum 'BPF_PROG_TYPE_INVALID' not found in type")
+	})
+}
+
+func TestAdjustNum(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("not reg", func(t *testing.T) {
+		n := c.adjustNum(-1, evalValue{})
+		test.AssertEqual(t, n, -1)
+	})
+
+	t.Run("bitfield", func(t *testing.T) {
+		n := c.adjustNum(0b1101, evalValue{
+			typ: evalValueTypeRegBtf,
+			mem: &btf.Member{
+				BitfieldSize: 3,
+			},
+		})
+		test.AssertEqual(t, n, 0b101)
+	})
+
+	t.Run("u8", func(t *testing.T) {
+		u8, err := c.kernelBtf.AnyTypeByName("__u8")
+		test.AssertNoErr(t, err)
+
+		n := c.adjustNum(257, evalValue{
+			typ: evalValueTypeRegBtf,
+			btf: u8,
+		})
+		test.AssertEqual(t, n, 1)
+	})
+
+	t.Run("u16", func(t *testing.T) {
+		u16, err := c.kernelBtf.AnyTypeByName("__u16")
+		test.AssertNoErr(t, err)
+
+		n := c.adjustNum(0x12345678, evalValue{
+			typ: evalValueTypeRegBtf,
+			btf: u16,
+		})
+		test.AssertEqual(t, n, 0x5678)
+	})
+
+	t.Run("u32", func(t *testing.T) {
+		u32, err := c.kernelBtf.AnyTypeByName("__u32")
+		test.AssertNoErr(t, err)
+
+		n := c.adjustNum(0x12345678, evalValue{
+			typ: evalValueTypeRegBtf,
+			btf: u32,
+		})
+		test.AssertEqual(t, n, 0x12345678)
+	})
+
+	t.Run("u64", func(t *testing.T) {
+		u64, err := c.kernelBtf.AnyTypeByName("__u64")
+		test.AssertNoErr(t, err)
+
+		n := c.adjustNum(0x12345678, evalValue{
+			typ: evalValueTypeRegBtf,
+			btf: u64,
+		})
+		test.AssertEqual(t, n, 0x12345678)
+	})
+}
+
+func TestPreHandleBinaryOp(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("a.btf cannot be calculated", func(t *testing.T) {
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = skb
+
+		a, b, err = c.preHandleBinaryOp(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("b.btf cannot be calculated", func(t *testing.T) {
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var a, b evalValue
+		b.typ = evalValueTypeRegBtf
+		b.btf = skb
+
+		a, b, err = c.preHandleBinaryOp(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("a is invalid enum", func(t *testing.T) {
+		progType := getBpfProgTypeBtf(t)
+
+		var a, b evalValue
+		a.typ = evalValueTypeEnumMaybe
+		a.name = "BPF_PROG_TYPE_NONE"
+		b.typ = evalValueTypeRegBtf
+		b.btf = progType
+
+		a, b, err := c.preHandleBinaryOp(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "failed to extract enum")
+	})
+
+	t.Run("a is valid enum", func(t *testing.T) {
+		progType := getBpfProgTypeBtf(t)
+
+		var a, b evalValue
+		a.typ = evalValueTypeEnumMaybe
+		a.name = "BPF_PROG_TYPE_XDP"
+		b.typ = evalValueTypeRegBtf
+		b.btf = progType
+
+		a, b, err := c.preHandleBinaryOp(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, a.typ, evalValueTypeNum)
+		test.AssertEqual(t, a.num, 6)
+	})
+
+	t.Run("b is invalid enum", func(t *testing.T) {
+		progType := getBpfProgTypeBtf(t)
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = progType
+		b.typ = evalValueTypeEnumMaybe
+		b.name = "BPF_PROG_TYPE_NONE"
+
+		a, b, err := c.preHandleBinaryOp(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "failed to extract enum")
+	})
+
+	t.Run("b is valid enum", func(t *testing.T) {
+		progType := getBpfProgTypeBtf(t)
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = progType
+		b.typ = evalValueTypeEnumMaybe
+		b.name = "BPF_PROG_TYPE_XDP"
+
+		a, b, err := c.preHandleBinaryOp(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, b.typ, evalValueTypeNum)
+		test.AssertEqual(t, b.num, 6)
+	})
+
+	t.Run("not enum", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		b.typ = evalValueTypeRegBtf
+		b.btf = getBpfProgBtf(t)
+
+		a, b, err := c.preHandleBinaryOp(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, a.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, b.typ, evalValueTypeRegBtf)
+	})
+}
+
+func TestAdd(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("failed to pre-handle", func(t *testing.T) {
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = skb
+
+		a, err = c.add(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("num + num", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeNum
+		b.num = 456
+
+		res, err := c.add(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 123+456)
+	})
+
+	t.Run("reg(ptr) + reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.reg, _ = c.regalloc.Alloc()
+		a.btf = getSkbBtf(t)
+		b.typ = evalValueTypeRegBtf
+		b.reg, _ = c.regalloc.Alloc()
+		b.btf = getU64Btf(t)
+
+		size, _ := btf.Sizeof(a.btf.(*btf.Pointer).Target)
+
+		res, err := c.add(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Mul.Imm(b.reg, int32(size)),
+			asm.Add.Reg(a.reg, b.reg),
+		})
+	})
+
+	t.Run("reg(array) + reg", func(t *testing.T) {
+		expr, err := cc.ParseExpr("skb->cb")
+		test.AssertNoErr(t, err)
+
+		defer c.reset()
+
+		a, err := c.access(expr)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, a.typ, evalValueTypeRegBtf)
+
+		var b evalValue
+		b.typ = evalValueTypeRegBtf
+		b.reg, _ = c.regalloc.Alloc()
+		b.btf = getU64Btf(t)
+
+		size, _ := btf.Sizeof(getU8Btf(t))
+
+		res, err := c.add(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+			asm.Add.Imm(asm.R8, 40),
+			asm.Mul.Imm(b.reg, int32(size)),
+			asm.Add.Reg(a.reg, b.reg),
+		})
+	})
+
+	t.Run("num(0) + reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.add(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, b.reg)
+	})
+
+	t.Run("num(1) + reg(void *)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 1
+		b.typ = evalValueTypeRegBtf
+		b.btf = &btf.Pointer{Target: &btf.Void{}}
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.add(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, b.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Add.Imm(b.reg, 1),
+		})
+	})
+
+	t.Run("num(1) + reg(func *)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 1
+		b.typ = evalValueTypeRegBtf
+		b.btf = &btf.Pointer{Target: &btf.FuncProto{}}
+		b.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.add(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("num(1) + reg(struct bpf_map *)", func(t *testing.T) {
+		defer c.reset()
+
+		bpfMap, err := c.kernelBtf.AnyTypeByName("bpf_map")
+		test.AssertNoErr(t, err)
+
+		size, _ := btf.Sizeof(bpfMap)
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 1
+		b.typ = evalValueTypeRegBtf
+		b.btf = &btf.Pointer{Target: bpfMap}
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.add(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, b.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Add.Imm(b.reg, int32(size)),
+		})
+	})
+
+	t.Run("num(1) + reg(array[void])", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 1
+		b.typ = evalValueTypeRegBtf
+		b.btf = &btf.Array{
+			Index:  getU8Btf(t),
+			Type:   &btf.Void{},
+			Nelems: 10,
+		}
+		b.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.add(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("num(1) + reg(array[struct bpf_map *])", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 1
+		b.typ = evalValueTypeRegBtf
+		b.btf = &btf.Array{
+			Index:  getU8Btf(t),
+			Type:   getBpfMapBtf(t),
+			Nelems: 10,
+		}
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.add(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, b.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Add.Imm(b.reg, 8),
+		})
+	})
+
+	t.Run("num(1) + reg(u64)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 1
+		b.typ = evalValueTypeRegBtf
+		b.btf = getU64Btf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.add(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, b.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Add.Imm(b.reg, 1),
+		})
+	})
+
+	t.Run("reg + num(0)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 0
+
+		res, err := c.add(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEmptySlice(t, c.insns)
+	})
+
+	t.Run("reg(void *) + num(1)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = &btf.Pointer{Target: &btf.Void{}}
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 1
+
+		res, err := c.add(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Add.Imm(a.reg, 1),
+		})
+	})
+
+	t.Run("reg(func *) + num(1)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = &btf.Pointer{Target: &btf.FuncProto{}}
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 1
+
+		_, err := c.add(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("reg(struct bpf_map *) + num(1)", func(t *testing.T) {
+		defer c.reset()
+
+		bpfMap, err := c.kernelBtf.AnyTypeByName("bpf_map")
+		test.AssertNoErr(t, err)
+
+		size, _ := btf.Sizeof(bpfMap)
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = &btf.Pointer{Target: bpfMap}
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 1
+
+		res, err := c.add(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Add.Imm(a.reg, int32(size)),
+		})
+	})
+
+	t.Run("reg(array[void]) + num(1)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = &btf.Array{
+			Index:  getU8Btf(t),
+			Type:   &btf.Void{},
+			Nelems: 10,
+		}
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 1
+
+		_, err := c.add(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("reg(array[struct bpf_map *]) + num(1)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = &btf.Array{
+			Index:  getU8Btf(t),
+			Type:   getBpfMapBtf(t),
+			Nelems: 10,
+		}
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 1
+
+		res, err := c.add(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Add.Imm(a.reg, 8),
+		})
+	})
+
+	t.Run("reg(u64) + num(1)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getU64Btf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 1
+
+		res, err := c.add(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Add.Imm(a.reg, 1),
+		})
+	})
+
+	t.Run("not implemented", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeUnspec
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeRegBtf
+		b.btf = getU8Btf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.add(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrNotImplemented))
+	})
+}
+
+func TestAnd(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("failed to pre-handle", func(t *testing.T) {
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = skb
+
+		_, err = c.and(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("num & num", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeNum
+		b.num = 456
+
+		res, err := c.and(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 123&456)
+	})
+
+	t.Run("reg & reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.reg, _ = c.regalloc.Alloc()
+		a.btf = getSkbBtf(t)
+		b.typ = evalValueTypeRegBtf
+		b.reg, _ = c.regalloc.Alloc()
+		b.btf = getU64Btf(t)
+
+		res, err := c.and(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.And.Reg(a.reg, b.reg),
+		})
+	})
+
+	t.Run("num & reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.and(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, b.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.And.Imm(b.reg, 123),
+		})
+	})
+
+	t.Run("reg & num", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 123
+
+		res, err := c.and(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.And.Imm(a.reg, 123),
+		})
+	})
+
+	t.Run("not implemented", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeUnspec
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeRegBtf
+		b.btf = getU8Btf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.and(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrNotImplemented))
+	})
+}
+
+func TestAndand(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("failed to pre-handle", func(t *testing.T) {
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = skb
+
+		_, err = c.andand(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("num(123) && num(456)", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeNum
+		b.num = 456
+
+		res, err := c.andand(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 1)
+	})
+
+	t.Run("num(0) && num(0)", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		b.typ = evalValueTypeNum
+
+		res, err := c.andand(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 0)
+	})
+
+	t.Run("reg && reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.reg, _ = c.regalloc.Alloc()
+		a.btf = getSkbBtf(t)
+		b.typ = evalValueTypeRegBtf
+		b.reg, _ = c.regalloc.Alloc()
+		b.btf = getU64Btf(t)
+
+		res, err := c.andand(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JEq, a.reg, 0, 3),
+			JmpOff(asm.JEq, b.reg, 0, 2),
+			asm.Mov.Imm(a.reg, 1),
+			Ja(1),
+			asm.Xor.Reg(a.reg, a.reg),
+		})
+	})
+
+	t.Run("num(0) && reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 0
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.andand(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 0)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEmptySlice(t, c.insns)
+	})
+
+	t.Run("num(1) && reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 1
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.andand(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, b.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JEq, b.reg, 0, 2),
+			asm.Mov.Imm(b.reg, 1),
+			Ja(1),
+			asm.Xor.Reg(b.reg, b.reg),
+		})
+	})
+
+	t.Run("reg && num(0)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 0
+
+		res, err := c.andand(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 0)
+		test.AssertFalse(t, c.regalloc.IsUsed(a.reg))
+		test.AssertEmptySlice(t, c.insns)
+	})
+
+	t.Run("reg && num(1)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 1
+
+		res, err := c.andand(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JEq, a.reg, 0, 2),
+			asm.Mov.Imm(a.reg, 1),
+			Ja(1),
+			asm.Xor.Reg(a.reg, a.reg),
+		})
+	})
+
+	t.Run("not implemented", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeUnspec
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeRegBtf
+		b.btf = getU8Btf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.andand(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrNotImplemented))
+	})
+}
+
+func TestCond(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("invalid cond", func(t *testing.T) {
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var cond, a, b evalValue
+		cond.typ = evalValueTypeRegBtf
+		cond.btf = skb
+
+		_, err = c.cond(cond, a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("invalid first value", func(t *testing.T) {
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var cond, a, b evalValue
+		cond.typ = evalValueTypeNum
+		a.typ = evalValueTypeRegBtf
+		a.btf = skb
+
+		_, err = c.cond(cond, a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("invalid second value", func(t *testing.T) {
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var cond, a, b evalValue
+		cond.typ = evalValueTypeNum
+		a.typ = evalValueTypeNum
+		b.typ = evalValueTypeRegBtf
+		b.btf = skb
+
+		_, err = c.cond(cond, a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("num(1) ? a : b", func(t *testing.T) {
+		var cond, a, b evalValue
+		cond.typ = evalValueTypeNum
+		cond.num = 1
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeNum
+		b.num = 456
+
+		res, err := c.cond(cond, a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 123)
+	})
+
+	t.Run("num(0) ? a : b", func(t *testing.T) {
+		var cond, a, b evalValue
+		cond.typ = evalValueTypeNum
+		cond.num = 0
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeNum
+		b.num = 456
+
+		res, err := c.cond(cond, a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 456)
+	})
+
+	t.Run("reg ? num(123) : num(456)", func(t *testing.T) {
+		defer c.reset()
+
+		var cond, a, b evalValue
+		cond.typ = evalValueTypeRegBtf
+		cond.reg, _ = c.regalloc.Alloc()
+		cond.btf = getSkbBtf(t)
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeNum
+		b.num = 456
+
+		res, err := c.cond(cond, a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, cond.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JEq, cond.reg, 0, 2),
+			asm.Mov.Imm(cond.reg, 123),
+			Ja(1),
+			asm.Mov.Imm(cond.reg, 456),
+		})
+	})
+
+	t.Run("reg ? reg : reg", func(t *testing.T) {
+		defer c.reset()
+
+		var cond, a, b evalValue
+		cond.typ = evalValueTypeRegBtf
+		cond.reg, _ = c.regalloc.Alloc()
+		cond.btf = getSkbBtf(t)
+		a.typ = evalValueTypeRegBtf
+		a.reg, _ = c.regalloc.Alloc()
+		a.btf = getU64Btf(t)
+		b.typ = evalValueTypeRegBtf
+		b.reg, _ = c.regalloc.Alloc()
+		b.btf = getU8Btf(t)
+
+		res, err := c.cond(cond, a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, cond.reg)
+		test.AssertFalse(t, c.regalloc.IsUsed(a.reg))
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JEq, cond.reg, 0, 2),
+			asm.Mov.Reg(cond.reg, a.reg),
+			Ja(1),
+			asm.Mov.Reg(cond.reg, b.reg),
+		})
+	})
+}
+
+func TestDiv(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("failed to pre-handle", func(t *testing.T) {
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = skb
+
+		_, err = c.div(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("x / num(0)", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeNum
+		b.num = 0
+
+		_, err := c.div(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "division by zero")
+	})
+
+	t.Run("num(456) / num(123)", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 456
+		b.typ = evalValueTypeNum
+		b.num = 123
+
+		res, err := c.div(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 456/123)
+	})
+
+	t.Run("num(456) / reg, no available reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 456
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		for i := range c.regalloc.registers[:] {
+			c.regalloc.registers[i] = true
+		}
+
+		_, err := c.div(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrRegisterNotEnough))
+	})
+
+	t.Run("num(456) / reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 456
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.div(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqual(t, res.reg, asm.R7)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JEq, b.reg, 0, 2),
+			asm.Mov.Imm(asm.R7, 0),
+			Ja(2),
+			asm.Mov.Imm(asm.R7, 456),
+			asm.Div.Reg(asm.R7, b.reg),
+		})
+	})
+
+	t.Run("reg / num(123)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 123
+
+		res, err := c.div(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Div.Imm(a.reg, 123),
+		})
+	})
+
+	t.Run("reg / reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.reg, _ = c.regalloc.Alloc()
+		a.btf = getSkbBtf(t)
+		b.typ = evalValueTypeRegBtf
+		b.reg, _ = c.regalloc.Alloc()
+		b.btf = getU64Btf(t)
+
+		res, err := c.div(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JEq, b.reg, 0, 2),
+			asm.Mov.Imm(a.reg, 0),
+			Ja(1),
+			asm.Div.Reg(a.reg, b.reg),
+		})
+	})
+
+	t.Run("not implemented", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeUnspec
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeRegBtf
+		b.btf = getU8Btf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.div(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrNotImplemented))
+	})
+}
+
+func TestEqeq(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("failed to pre-handle", func(t *testing.T) {
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = skb
+
+		_, err = c.eqeq(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("num == num", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeNum
+		b.num = 456
+
+		res, err := c.eqeq(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 0)
+	})
+
+	t.Run("num == reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.eqeq(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, b.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JNE, b.reg, int64(a.num), 2),
+			asm.Mov.Imm(b.reg, 1),
+			Ja(1),
+			asm.Xor.Reg(b.reg, b.reg),
+		})
+	})
+
+	t.Run("reg == num", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 123
+
+		res, err := c.eqeq(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JNE, a.reg, int64(b.num), 2),
+			asm.Mov.Imm(a.reg, 1),
+			Ja(1),
+			asm.Xor.Reg(a.reg, a.reg),
+		})
+	})
+
+	t.Run("reg == reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.reg, _ = c.regalloc.Alloc()
+		a.btf = getSkbBtf(t)
+		b.typ = evalValueTypeRegBtf
+		b.reg, _ = c.regalloc.Alloc()
+		b.btf = getU64Btf(t)
+
+		res, err := c.eqeq(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpReg(asm.JNE, a.reg, b.reg, 2),
+			asm.Mov.Imm(a.reg, 1),
+			Ja(1),
+			asm.Xor.Reg(a.reg, a.reg),
+		})
+	})
+
+	t.Run("not implemented", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeUnspec
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeRegBtf
+		b.btf = getU8Btf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.eqeq(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrNotImplemented))
+	})
+}
+
+func TestGt(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("failed to pre-handle", func(t *testing.T) {
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = skb
+
+		_, err = c.gt(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("num > num", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeNum
+		b.num = 456
+
+		res, err := c.gt(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 0)
+	})
+
+	t.Run("num > reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.gt(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, b.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JLE, b.reg, int64(a.num), 2),
+			asm.Mov.Imm(b.reg, 1),
+			Ja(1),
+			asm.Xor.Reg(b.reg, b.reg),
+		})
+	})
+
+	t.Run("reg > num", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 123
+
+		res, err := c.gt(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JLE, a.reg, int64(b.num), 2),
+			asm.Mov.Imm(a.reg, 1),
+			Ja(1),
+			asm.Xor.Reg(a.reg, a.reg),
+		})
+	})
+
+	t.Run("reg > reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.reg, _ = c.regalloc.Alloc()
+		a.btf = getSkbBtf(t)
+		b.typ = evalValueTypeRegBtf
+		b.reg, _ = c.regalloc.Alloc()
+		b.btf = getU64Btf(t)
+
+		res, err := c.gt(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpReg(asm.JLE, a.reg, b.reg, 2),
+			asm.Mov.Imm(a.reg, 1),
+			Ja(1),
+			asm.Xor.Reg(a.reg, a.reg),
+		})
+	})
+
+	t.Run("not implemented", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeUnspec
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeRegBtf
+		b.btf = getU8Btf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.gt(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrNotImplemented))
+	})
+}
+
+func TestGteq(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("failed to pre-handle", func(t *testing.T) {
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = skb
+
+		_, err = c.gteq(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("num >= num", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeNum
+		b.num = 456
+
+		res, err := c.gteq(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 0)
+	})
+
+	t.Run("num >= reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.gteq(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, b.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JLT, b.reg, int64(a.num), 2),
+			asm.Mov.Imm(b.reg, 1),
+			Ja(1),
+			asm.Xor.Reg(b.reg, b.reg),
+		})
+	})
+
+	t.Run("reg >= num", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 123
+
+		res, err := c.gteq(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JLT, a.reg, int64(b.num), 2),
+			asm.Mov.Imm(a.reg, 1),
+			Ja(1),
+			asm.Xor.Reg(a.reg, a.reg),
+		})
+	})
+
+	t.Run("reg >= reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.reg, _ = c.regalloc.Alloc()
+		a.btf = getSkbBtf(t)
+		b.typ = evalValueTypeRegBtf
+		b.reg, _ = c.regalloc.Alloc()
+		b.btf = getU64Btf(t)
+
+		res, err := c.gteq(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpReg(asm.JLT, a.reg, b.reg, 2),
+			asm.Mov.Imm(a.reg, 1),
+			Ja(1),
+			asm.Xor.Reg(a.reg, a.reg),
+		})
+	})
+
+	t.Run("not implemented", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeUnspec
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeRegBtf
+		b.btf = getU8Btf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.gteq(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrNotImplemented))
+	})
+}
+
+func TestLsh(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("failed to pre-handle", func(t *testing.T) {
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = skb
+
+		_, err = c.lsh(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("num << num", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeNum
+		b.num = 4
+
+		res, err := c.lsh(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 123<<4)
+	})
+
+	t.Run("num(0) << reg", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 0
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.lsh(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 0)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEmptySlice(t, c.insns)
+	})
+
+	t.Run("num(123) << reg, no available reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		for i := range c.regalloc.registers[:] {
+			c.regalloc.registers[i] = true
+		}
+
+		_, err := c.lsh(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrRegisterNotEnough))
+	})
+
+	t.Run("num(123) << reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.lsh(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, asm.R7)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Mov.Imm(asm.R7, 123),
+			asm.LSh.Reg(asm.R7, b.reg),
+		})
+	})
+
+	t.Run("reg << num(-1)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = -1
+
+		_, err := c.lsh(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "shift count is negative")
+	})
+
+	t.Run("reg << num(0)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 0
+
+		res, err := c.lsh(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEmptySlice(t, c.insns)
+	})
+
+	t.Run("reg << num(4)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 4
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.lsh(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.LSh.Imm(a.reg, 4),
+		})
+	})
+
+	t.Run("reg << reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.reg, _ = c.regalloc.Alloc()
+		a.btf = getSkbBtf(t)
+		b.typ = evalValueTypeRegBtf
+		b.reg, _ = c.regalloc.Alloc()
+		b.btf = getU64Btf(t)
+
+		res, err := c.lsh(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JLE, b.reg, 0, 1),
+			asm.LSh.Reg(a.reg, b.reg),
+		})
+	})
+
+	t.Run("not implemented", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeUnspec
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeRegBtf
+		b.btf = getU8Btf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.lsh(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrNotImplemented))
+	})
+}
+
+func TestLt(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("failed to pre-handle", func(t *testing.T) {
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = skb
+
+		_, err = c.lt(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("num < num", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeNum
+		b.num = 456
+
+		res, err := c.lt(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 1)
+	})
+
+	t.Run("num < reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.lt(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, b.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JGE, b.reg, int64(a.num), 2),
+			asm.Mov.Imm(b.reg, 1),
+			Ja(1),
+			asm.Xor.Reg(b.reg, b.reg),
+		})
+	})
+
+	t.Run("reg < num", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 123
+
+		res, err := c.lt(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JGE, a.reg, int64(b.num), 2),
+			asm.Mov.Imm(a.reg, 1),
+			Ja(1),
+			asm.Xor.Reg(a.reg, a.reg),
+		})
+	})
+
+	t.Run("reg < reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.reg, _ = c.regalloc.Alloc()
+		a.btf = getSkbBtf(t)
+		b.typ = evalValueTypeRegBtf
+		b.reg, _ = c.regalloc.Alloc()
+		b.btf = getU64Btf(t)
+
+		res, err := c.lt(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpReg(asm.JGE, a.reg, b.reg, 2),
+			asm.Mov.Imm(a.reg, 1),
+			Ja(1),
+			asm.Xor.Reg(a.reg, a.reg),
+		})
+	})
+
+	t.Run("not implemented", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeUnspec
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeRegBtf
+		b.btf = getU8Btf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.lt(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrNotImplemented))
+	})
+}
+
+func TestLteq(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("failed to pre-handle", func(t *testing.T) {
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = skb
+
+		_, err = c.lteq(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("num <= num", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeNum
+		b.num = 456
+
+		res, err := c.lteq(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 1)
+	})
+
+	t.Run("num <= reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.lteq(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, b.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JGT, b.reg, int64(a.num), 2),
+			asm.Mov.Imm(b.reg, 1),
+			Ja(1),
+			asm.Xor.Reg(b.reg, b.reg),
+		})
+	})
+
+	t.Run("reg <= num", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 123
+
+		res, err := c.lteq(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JGT, a.reg, int64(b.num), 2),
+			asm.Mov.Imm(a.reg, 1),
+			Ja(1),
+			asm.Xor.Reg(a.reg, a.reg),
+		})
+	})
+
+	t.Run("reg <= reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.reg, _ = c.regalloc.Alloc()
+		a.btf = getSkbBtf(t)
+		b.typ = evalValueTypeRegBtf
+		b.reg, _ = c.regalloc.Alloc()
+		b.btf = getU64Btf(t)
+
+		res, err := c.lteq(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpReg(asm.JGT, a.reg, b.reg, 2),
+			asm.Mov.Imm(a.reg, 1),
+			Ja(1),
+			asm.Xor.Reg(a.reg, a.reg),
+		})
+	})
+
+	t.Run("not implemented", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeUnspec
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeRegBtf
+		b.btf = getU8Btf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.lteq(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrNotImplemented))
+	})
+}
+
+func TestMinus(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("-num", func(t *testing.T) {
+		var a evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+
+		res, err := c.minus(a)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, -123)
+	})
+
+	t.Run("-reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.minus(a)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Neg.Reg(a.reg, a.reg),
+		})
+	})
+
+	t.Run("not implemented", func(t *testing.T) {
+		defer c.reset()
+
+		var a evalValue
+		a.typ = evalValueTypeUnspec
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.minus(a)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrNotImplemented))
+	})
+}
+
+func TestMod(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("failed to pre-handle", func(t *testing.T) {
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = skb
+
+		_, err = c.mod(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("x % num(0)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 0
+
+		_, err := c.mod(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "mod by zero")
+	})
+
+	t.Run("num(456) % num(123)", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 456
+		b.typ = evalValueTypeNum
+		b.num = 123
+
+		res, err := c.mod(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 456%123)
+	})
+
+	t.Run("num(0) % reg", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 0
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.mod(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 0)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEmptySlice(t, c.insns)
+	})
+
+	t.Run("num(456) % reg, no available reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 456
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		for i := range c.regalloc.registers[:] {
+			c.regalloc.registers[i] = true
+		}
+
+		_, err := c.mod(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrRegisterNotEnough))
+	})
+
+	t.Run("num(456) % reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 456
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.mod(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, asm.R7)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Mov.Imm(asm.R7, 456),
+			asm.Mod.Reg(asm.R7, b.reg),
+		})
+	})
+
+	t.Run("reg % num(1)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 1
+
+		res, err := c.mod(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Mov.Imm(a.reg, 0),
+		})
+	})
+
+	t.Run("reg % num(123)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 123
+
+		res, err := c.mod(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Mod.Imm(a.reg, 123),
+		})
+	})
+
+	t.Run("reg % reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.reg, _ = c.regalloc.Alloc()
+		a.btf = getSkbBtf(t)
+		b.typ = evalValueTypeRegBtf
+		b.reg, _ = c.regalloc.Alloc()
+		b.btf = getU64Btf(t)
+
+		res, err := c.mod(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JEq, b.reg, 0, 1),
+			asm.Mod.Reg(a.reg, b.reg),
+		})
+	})
+
+	t.Run("not implemented", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeUnspec
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeRegBtf
+		b.btf = getU8Btf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.mod(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrNotImplemented))
+	})
+}
+
+func TestMul(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("failed to pre-handle", func(t *testing.T) {
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = skb
+
+		_, err = c.mul(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("num * num", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeNum
+		b.num = 456
+
+		res, err := c.mul(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 123*456)
+	})
+
+	t.Run("reg * reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.reg, _ = c.regalloc.Alloc()
+		a.btf = getSkbBtf(t)
+		b.typ = evalValueTypeRegBtf
+		b.reg, _ = c.regalloc.Alloc()
+		b.btf = getU64Btf(t)
+
+		res, err := c.mul(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Mul.Reg(a.reg, b.reg),
+		})
+	})
+
+	t.Run("num(0) * reg", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 0
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.mul(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 0)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEmptySlice(t, c.insns)
+	})
+
+	t.Run("num(1) * reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 1
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.mul(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, b.reg)
+		test.AssertFalse(t, c.regalloc.IsUsed(a.reg))
+		test.AssertEmptySlice(t, c.insns)
+	})
+
+	t.Run("num(123) * reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.mul(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, asm.R8)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Mul.Imm(asm.R8, 123),
+		})
+	})
+
+	t.Run("not implemented", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeUnspec
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeRegBtf
+		b.btf = getU8Btf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.mul(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrNotImplemented))
+	})
+}
+
+func TestNot(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("!num", func(t *testing.T) {
+		var a evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+
+		res, err := c.not(a)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 0)
+	})
+
+	t.Run("!reg, invalid type", func(t *testing.T) {
+		defer c.reset()
+
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var a evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = skb
+		a.reg, _ = c.regalloc.Alloc()
+
+		_, err = c.not(a)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("!reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.not(a)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JNE, a.reg, 0, 2),
+			asm.Mov.Imm(a.reg, 1),
+			Ja(1),
+			asm.Xor.Reg(a.reg, a.reg),
+		})
+	})
+
+	t.Run("not implemented", func(t *testing.T) {
+		defer c.reset()
+
+		var a evalValue
+		a.typ = evalValueTypeUnspec
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.not(a)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrNotImplemented))
+	})
+}
+
+func TestNoteq(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("failed to pre-handle", func(t *testing.T) {
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = skb
+
+		_, err = c.noteq(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("num != num", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeNum
+		b.num = 456
+
+		res, err := c.noteq(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 1)
+	})
+
+	t.Run("num != reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.noteq(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, b.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JEq, b.reg, int64(a.num), 2),
+			asm.Mov.Imm(b.reg, 1),
+			Ja(1),
+			asm.Xor.Reg(b.reg, b.reg),
+		})
+	})
+
+	t.Run("reg != num", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 123
+
+		res, err := c.noteq(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JEq, a.reg, int64(b.num), 2),
+			asm.Mov.Imm(a.reg, 1),
+			Ja(1),
+			asm.Xor.Reg(a.reg, a.reg),
+		})
+	})
+
+	t.Run("reg != reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.reg, _ = c.regalloc.Alloc()
+		a.btf = getSkbBtf(t)
+		b.typ = evalValueTypeRegBtf
+		b.reg, _ = c.regalloc.Alloc()
+		b.btf = getU64Btf(t)
+
+		res, err := c.noteq(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpReg(asm.JEq, a.reg, b.reg, 2),
+			asm.Mov.Imm(a.reg, 1),
+			Ja(1),
+			asm.Xor.Reg(a.reg, a.reg),
+		})
+	})
+
+	t.Run("not implemented", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeUnspec
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeRegBtf
+		b.btf = getU8Btf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.noteq(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrNotImplemented))
+	})
+}
+
+func TestOr(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("failed to pre-handle", func(t *testing.T) {
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = skb
+
+		_, err = c.or(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("num | num", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeNum
+		b.num = 456
+
+		res, err := c.or(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 123|456)
+	})
+
+	t.Run("reg | reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.reg, _ = c.regalloc.Alloc()
+		a.btf = getSkbBtf(t)
+		b.typ = evalValueTypeRegBtf
+		b.reg, _ = c.regalloc.Alloc()
+		b.btf = getU64Btf(t)
+
+		res, err := c.or(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Or.Reg(a.reg, b.reg),
+		})
+	})
+
+	t.Run("num(0) | reg", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 0
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.or(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 0)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEmptySlice(t, c.insns)
+	})
+
+	t.Run("num(1) | reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 1
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.or(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, b.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Or.Imm(b.reg, 1),
+		})
+	})
+
+	t.Run("reg | num(0)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 0
+
+		res, err := c.or(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 0)
+		test.AssertFalse(t, c.regalloc.IsUsed(a.reg))
+		test.AssertEmptySlice(t, c.insns)
+	})
+
+	t.Run("reg | num(123)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 123
+
+		res, err := c.or(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Or.Imm(a.reg, 123),
+		})
+	})
+
+	t.Run("not implemented", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeUnspec
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeRegBtf
+		b.btf = getU8Btf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.or(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrNotImplemented))
+	})
+}
+
+func TestOror(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("failed to pre-handle", func(t *testing.T) {
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = skb
+
+		_, err = c.oror(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("num || num", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeNum
+		b.num = 456
+
+		res, err := c.oror(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 1)
+	})
+
+	t.Run("reg || reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.reg, _ = c.regalloc.Alloc()
+		a.btf = getSkbBtf(t)
+		b.typ = evalValueTypeRegBtf
+		b.reg, _ = c.regalloc.Alloc()
+		b.btf = getU64Btf(t)
+
+		res, err := c.oror(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JNE, a.reg, 0, 3),
+			JmpOff(asm.JNE, b.reg, 0, 2),
+			asm.Xor.Reg(a.reg, a.reg),
+			Ja(1),
+			asm.Mov.Imm(a.reg, 1),
+		})
+	})
+
+	t.Run("num(1) || reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 1
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.oror(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 1)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEmptySlice(t, c.insns)
+	})
+
+	t.Run("num(0) || reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 0
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.oror(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, b.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JEq, b.reg, 0, 2),
+			asm.Mov.Imm(b.reg, 1),
+			Ja(1),
+			asm.Xor.Reg(b.reg, b.reg),
+		})
+	})
+
+	t.Run("reg || num(1)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 1
+
+		res, err := c.oror(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 1)
+		test.AssertFalse(t, c.regalloc.IsUsed(a.reg))
+		test.AssertEmptySlice(t, c.insns)
+	})
+
+	t.Run("reg || num(0)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 0
+
+		res, err := c.oror(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			JmpOff(asm.JEq, a.reg, 0, 2),
+			asm.Mov.Imm(a.reg, 1),
+			Ja(1),
+			asm.Xor.Reg(a.reg, a.reg),
+		})
+	})
+
+	t.Run("not implemented", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeUnspec
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeRegBtf
+		b.btf = getU8Btf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.oror(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrNotImplemented))
+	})
+}
+
+func TestPreDec(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("num", func(t *testing.T) {
+		var a evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+
+		res, err := c.preDec(a)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 122)
+	})
+
+	t.Run("reg, invalid type", func(t *testing.T) {
+		defer c.reset()
+
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var a evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = skb
+
+		_, err = c.preDec(a)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.preDec(a)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Sub.Imm(a.reg, 1),
+		})
+	})
+
+	t.Run("not implemented", func(t *testing.T) {
+		defer c.reset()
+
+		var a evalValue
+		a.typ = evalValueTypeUnspec
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.preDec(a)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrNotImplemented))
+	})
+}
+
+func TestPreInc(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("num", func(t *testing.T) {
+		var a evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+
+		res, err := c.preInc(a)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 124)
+	})
+
+	t.Run("reg, invalid type", func(t *testing.T) {
+		defer c.reset()
+
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var a evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = skb
+
+		_, err = c.preInc(a)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.preInc(a)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Add.Imm(a.reg, 1),
+		})
+	})
+
+	t.Run("not implemented", func(t *testing.T) {
+		defer c.reset()
+
+		var a evalValue
+		a.typ = evalValueTypeUnspec
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.preInc(a)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrNotImplemented))
+	})
+}
+
+func TestRsh(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("failed to pre-handle", func(t *testing.T) {
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = skb
+
+		_, err = c.rsh(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("num >> num", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeNum
+		b.num = 456
+
+		res, err := c.rsh(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 123>>456)
+	})
+
+	t.Run("num(0) >> reg", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 0
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.rsh(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 0)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEmptySlice(t, c.insns)
+	})
+
+	t.Run("num(1) >> reg, no available reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 1
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		for i := range c.regalloc.registers[:] {
+			c.regalloc.registers[i] = true
+		}
+
+		_, err := c.rsh(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrRegisterNotEnough))
+	})
+
+	t.Run("num(1) >> reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 1
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.rsh(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, asm.R7)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Mov.Imm(asm.R7, 1),
+			asm.RSh.Reg(asm.R7, b.reg),
+		})
+	})
+
+	t.Run("reg >> num(-1)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = -1
+
+		_, err := c.rsh(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "shift count is negative")
+	})
+
+	t.Run("reg >> num(0)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 0
+
+		res, err := c.rsh(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEmptySlice(t, c.insns)
+	})
+
+	t.Run("reg >> num(1)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 1
+
+		res, err := c.rsh(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.RSh.Imm(a.reg, 1),
+		})
+	})
+
+	t.Run("reg >> reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.reg, _ = c.regalloc.Alloc()
+		a.btf = getSkbBtf(t)
+		b.typ = evalValueTypeRegBtf
+		b.reg, _ = c.regalloc.Alloc()
+		b.btf = getU64Btf(t)
+
+		res, err := c.rsh(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.RSh.Reg(a.reg, b.reg),
+		})
+	})
+
+	t.Run("not implemented", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeUnspec
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeRegBtf
+		b.btf = getU8Btf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.rsh(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrNotImplemented))
+	})
+}
+
+func TestSub(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("failed to pre-handle", func(t *testing.T) {
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = skb
+
+		_, err = c.sub(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("num - num", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeNum
+		b.num = 456
+
+		res, err := c.sub(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 123-456)
+	})
+
+	t.Run("num - reg(pointer)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.sub(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("num(0) - reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 0
+		b.typ = evalValueTypeRegBtf
+		b.btf = getU64Btf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.sub(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, b.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Neg.Reg(b.reg, b.reg),
+		})
+	})
+
+	t.Run("num(1) - reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 1
+		b.typ = evalValueTypeRegBtf
+		b.btf = getU64Btf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.sub(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, b.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Sub.Imm(b.reg, 1),
+		})
+	})
+
+	t.Run("reg - num(0)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 0
+
+		res, err := c.sub(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEmptySlice(t, c.insns)
+	})
+
+	t.Run("reg(void *) - num(123)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = &btf.Pointer{Target: &btf.Void{}}
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 123
+
+		res, err := c.sub(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Sub.Imm(a.reg, 123),
+		})
+	})
+
+	t.Run("reg(struct bpf_map **) - num(1)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = &btf.Pointer{Target: getBpfMapBtf(t)}
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 1
+
+		res, err := c.sub(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Sub.Imm(a.reg, 8),
+		})
+	})
+
+	t.Run("reg(array(void)) - num(1)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = &btf.Array{Type: &btf.Void{}, Nelems: 1}
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 1
+
+		_, err := c.sub(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("reg(array(struct bpf_map *)) - num(1)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = &btf.Array{Type: getBpfMapBtf(t), Nelems: 1}
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 1
+
+		res, err := c.sub(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Sub.Imm(a.reg, 8),
+		})
+	})
+
+	t.Run("reg - num(123)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getU64Btf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 123
+
+		res, err := c.sub(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Sub.Imm(a.reg, 123),
+		})
+	})
+
+	t.Run("reg(struct bpf_map **) - reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = &btf.Pointer{Target: getBpfMapBtf(t)}
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeRegBtf
+		b.btf = getU64Btf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.sub(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Mul.Imm(b.reg, 8),
+			asm.Sub.Reg(a.reg, b.reg),
+		})
+	})
+
+	t.Run("reg(array(struct bpf_map *)) - reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = &btf.Array{Type: getBpfMapBtf(t), Nelems: 1}
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeRegBtf
+		b.btf = getU64Btf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.sub(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Mul.Imm(b.reg, 8),
+			asm.Sub.Reg(a.reg, b.reg),
+		})
+	})
+
+	t.Run("reg - reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.reg, _ = c.regalloc.Alloc()
+		a.btf = getU64Btf(t)
+		b.typ = evalValueTypeRegBtf
+		b.reg, _ = c.regalloc.Alloc()
+		b.btf = getU8Btf(t)
+
+		res, err := c.sub(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Sub.Reg(a.reg, b.reg),
+		})
+	})
+
+	t.Run("not implemented", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeUnspec
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeRegBtf
+		b.btf = getU8Btf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.sub(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrNotImplemented))
+	})
+}
+
+func TestTwid(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("num", func(t *testing.T) {
+		var a evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+
+		res, err := c.twid(a)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, ^123)
+	})
+
+	t.Run("reg, invalid type", func(t *testing.T) {
+		defer c.reset()
+
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var a evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = skb
+
+		_, err = c.twid(a)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.twid(a)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Xor.Imm(a.reg, -1),
+		})
+	})
+
+	t.Run("not implemented", func(t *testing.T) {
+		defer c.reset()
+
+		var a evalValue
+		a.typ = evalValueTypeUnspec
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.twid(a)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrNotImplemented))
+	})
+}
+
+func TestXor(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("failed to pre-handle", func(t *testing.T) {
+		skb, err := c.kernelBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = skb
+
+		_, err = c.xor(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow type")
+	})
+
+	t.Run("num ^ num", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 123
+		b.typ = evalValueTypeNum
+		b.num = 456
+
+		res, err := c.xor(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 123^456)
+	})
+
+	t.Run("reg ^ reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.reg, _ = c.regalloc.Alloc()
+		a.btf = getSkbBtf(t)
+		b.typ = evalValueTypeRegBtf
+		b.reg, _ = c.regalloc.Alloc()
+		b.btf = getU64Btf(t)
+
+		res, err := c.xor(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Xor.Reg(a.reg, b.reg),
+		})
+	})
+
+	t.Run("num(0) ^ reg", func(t *testing.T) {
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 0
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.xor(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 0)
+		test.AssertFalse(t, c.regalloc.IsUsed(b.reg))
+		test.AssertEmptySlice(t, c.insns)
+	})
+
+	t.Run("num(1) ^ reg", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeNum
+		a.num = 1
+		b.typ = evalValueTypeRegBtf
+		b.btf = getSkbBtf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		res, err := c.xor(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, b.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Xor.Imm(b.reg, 1),
+		})
+	})
+
+	t.Run("reg ^ num(0)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 0
+
+		res, err := c.xor(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeNum)
+		test.AssertEqual(t, res.num, 0)
+		test.AssertFalse(t, c.regalloc.IsUsed(a.reg))
+		test.AssertEmptySlice(t, c.insns)
+	})
+
+	t.Run("reg ^ num(1)", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeRegBtf
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeNum
+		b.num = 1
+
+		res, err := c.xor(a, b)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, a.reg)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Xor.Imm(a.reg, 1),
+		})
+	})
+
+	t.Run("not implemented", func(t *testing.T) {
+		defer c.reset()
+
+		var a, b evalValue
+		a.typ = evalValueTypeUnspec
+		a.btf = getSkbBtf(t)
+		a.reg, _ = c.regalloc.Alloc()
+		b.typ = evalValueTypeRegBtf
+		b.btf = getU8Btf(t)
+		b.reg, _ = c.regalloc.Alloc()
+
+		_, err := c.xor(a, b)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrNotImplemented))
+	})
+}
+
+func TestEval(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("access", func(t *testing.T) {
+		defer c.reset()
+
+		expr, err := cc.ParseExpr("skb->len")
+		test.AssertNoErr(t, err)
+
+		res, err := c.eval(expr)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+			asm.Mov.Reg(asm.R3, asm.R8),
+			asm.Add.Imm(asm.R3, 112),
+			asm.Mov.Imm(asm.R2, 8),
+			asm.Mov.Reg(asm.R1, asm.RFP),
+			asm.Add.Imm(asm.R1, -8),
+			asm.FnProbeReadKernel.Call(),
+			asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+			asm.LSh.Imm(asm.R8, 32),
+			asm.RSh.Imm(asm.R8, 32),
+		})
+	})
+
+	t.Run("add", func(t *testing.T) {
+		t.Run("invalid left", func(t *testing.T) {
+			expr, err := cc.ParseExpr("not_found->xxx + 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate left operand")
+		})
+
+		t.Run("invalid right", func(t *testing.T) {
+			expr, err := cc.ParseExpr("1 + not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate right operand")
+		})
+
+		t.Run("add", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("skb->len + 1")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+				asm.Add.Imm(asm.R8, 1),
+			})
+		})
+	})
+
+	t.Run("and", func(t *testing.T) {
+		t.Run("invalid left", func(t *testing.T) {
+			expr, err := cc.ParseExpr("not_found->xxx & 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate left operand")
+		})
+
+		t.Run("invalid right", func(t *testing.T) {
+			expr, err := cc.ParseExpr("1 & not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate right operand")
+		})
+
+		t.Run("and", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("skb->len & 1")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+				asm.And.Imm(asm.R8, 1),
+			})
+		})
+	})
+
+	t.Run("andand", func(t *testing.T) {
+		t.Run("invalid left", func(t *testing.T) {
+			expr, err := cc.ParseExpr("not_found->xxx && 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate left operand")
+		})
+
+		t.Run("invalid right", func(t *testing.T) {
+			expr, err := cc.ParseExpr("1 && not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate right operand")
+		})
+
+		t.Run("andand", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("skb->len && 1")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+				JmpOff(asm.JEq, asm.R8, 0, 2),
+				asm.Mov.Imm(asm.R8, 1),
+				Ja(1),
+				asm.Xor.Reg(asm.R8, asm.R8),
+			})
+		})
+	})
+
+	t.Run("cond", func(t *testing.T) {
+		t.Run("invalid cond", func(t *testing.T) {
+			expr, err := cc.ParseExpr("not_found->xxx ? 1 : 2")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate cond operand")
+		})
+
+		t.Run("invalid true", func(t *testing.T) {
+			expr, err := cc.ParseExpr("1 ? not_found->xxx : 2")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate true operand")
+		})
+
+		t.Run("invalid false", func(t *testing.T) {
+			expr, err := cc.ParseExpr("1 ? 2 : not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate false operand")
+		})
+
+		t.Run("cond", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("skb->len ? 1 : 2")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+				JmpOff(asm.JEq, asm.R8, 0, 2),
+				asm.Mov.Imm(asm.R8, 1),
+				Ja(1),
+				asm.Mov.Imm(asm.R8, 2),
+			})
+		})
+	})
+
+	t.Run("div", func(t *testing.T) {
+		t.Run("invalid left", func(t *testing.T) {
+			expr, err := cc.ParseExpr("not_found->xxx / 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate left operand")
+		})
+
+		t.Run("invalid right", func(t *testing.T) {
+			expr, err := cc.ParseExpr("1 / not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate right operand")
+		})
+
+		t.Run("div", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("skb->len / 1")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+				asm.Div.Imm(asm.R8, 1),
+			})
+		})
+	})
+
+	t.Run("eqeq", func(t *testing.T) {
+		t.Run("invalid left", func(t *testing.T) {
+			expr, err := cc.ParseExpr("not_found->xxx == 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate left operand")
+		})
+
+		t.Run("invalid right", func(t *testing.T) {
+			expr, err := cc.ParseExpr("1 == not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate right operand")
+		})
+
+		t.Run("eqeq", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("skb->len == 1")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+				JmpOff(asm.JNE, asm.R8, 1, 2),
+				asm.Mov.Imm(asm.R8, 1),
+				Ja(1),
+				asm.Xor.Reg(asm.R8, asm.R8),
+			})
+		})
+	})
+
+	t.Run("gt", func(t *testing.T) {
+		t.Run("invalid left", func(t *testing.T) {
+			expr, err := cc.ParseExpr("not_found->xxx > 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate left operand")
+		})
+
+		t.Run("invalid right", func(t *testing.T) {
+			expr, err := cc.ParseExpr("1 > not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate right operand")
+		})
+
+		t.Run("gt", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("skb->len > 1")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+				JmpOff(asm.JLE, asm.R8, 1, 2),
+				asm.Mov.Imm(asm.R8, 1),
+				Ja(1),
+				asm.Xor.Reg(asm.R8, asm.R8),
+			})
+		})
+	})
+
+	t.Run("gteq", func(t *testing.T) {
+		t.Run("invalid left", func(t *testing.T) {
+			expr, err := cc.ParseExpr("not_found->xxx >= 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate left operand")
+		})
+
+		t.Run("invalid right", func(t *testing.T) {
+			expr, err := cc.ParseExpr("1 >= not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate right operand")
+		})
+
+		t.Run("gteq", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("skb->len >= 1")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+				JmpOff(asm.JLT, asm.R8, 1, 2),
+				asm.Mov.Imm(asm.R8, 1),
+				Ja(1),
+				asm.Xor.Reg(asm.R8, asm.R8),
+			})
+		})
+	})
+
+	t.Run("lsh", func(t *testing.T) {
+		t.Run("invalid left", func(t *testing.T) {
+			expr, err := cc.ParseExpr("not_found->xxx << 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate left operand")
+		})
+
+		t.Run("invalid right", func(t *testing.T) {
+			expr, err := cc.ParseExpr("1 << not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate right operand")
+		})
+
+		t.Run("lsh", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("skb->len << 1")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+				asm.LSh.Imm(asm.R8, 1),
+			})
+		})
+	})
+
+	t.Run("lt", func(t *testing.T) {
+		t.Run("invalid left", func(t *testing.T) {
+			expr, err := cc.ParseExpr("not_found->xxx < 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate left operand")
+		})
+
+		t.Run("invalid right", func(t *testing.T) {
+			expr, err := cc.ParseExpr("1 < not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate right operand")
+		})
+
+		t.Run("lt", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("skb->len < 1")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+				JmpOff(asm.JGE, asm.R8, 1, 2),
+				asm.Mov.Imm(asm.R8, 1),
+				Ja(1),
+				asm.Xor.Reg(asm.R8, asm.R8),
+			})
+		})
+	})
+
+	t.Run("lteq", func(t *testing.T) {
+		t.Run("invalid left", func(t *testing.T) {
+			expr, err := cc.ParseExpr("not_found->xxx <= 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate left operand")
+		})
+
+		t.Run("invalid right", func(t *testing.T) {
+			expr, err := cc.ParseExpr("1 <= not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate right operand")
+		})
+
+		t.Run("lteq", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("skb->len <= 1")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+				JmpOff(asm.JGT, asm.R8, 1, 2),
+				asm.Mov.Imm(asm.R8, 1),
+				Ja(1),
+				asm.Xor.Reg(asm.R8, asm.R8),
+			})
+		})
+	})
+
+	t.Run("minus", func(t *testing.T) {
+		t.Run("invalid operand", func(t *testing.T) {
+			expr, err := cc.ParseExpr("-not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate operand")
+		})
+
+		t.Run("minus", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("-skb->len")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+				asm.Neg.Reg(asm.R8, asm.R8),
+			})
+		})
+	})
+
+	t.Run("mod", func(t *testing.T) {
+		t.Run("invalid left", func(t *testing.T) {
+			expr, err := cc.ParseExpr("not_found->xxx % 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate left operand")
+		})
+
+		t.Run("invalid right", func(t *testing.T) {
+			expr, err := cc.ParseExpr("1 % not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate right operand")
+		})
+
+		t.Run("mod", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("skb->len % 2")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+				asm.Mod.Imm(asm.R8, 2),
+			})
+		})
+	})
+
+	t.Run("mul", func(t *testing.T) {
+		t.Run("invalid left", func(t *testing.T) {
+			expr, err := cc.ParseExpr("not_found->xxx * 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate left operand")
+		})
+
+		t.Run("invalid right", func(t *testing.T) {
+			expr, err := cc.ParseExpr("1 * not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate right operand")
+		})
+
+		t.Run("mul", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("skb->len * 2")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+				asm.Mul.Imm(asm.R8, 2),
+			})
+		})
+	})
+
+	t.Run("name", func(t *testing.T) {
+		t.Run("NULL,false", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("NULL")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeNum)
+			test.AssertEqual(t, res.num, 0)
+		})
+
+		t.Run("true", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("true")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeNum)
+			test.AssertEqual(t, res.num, 1)
+		})
+
+		t.Run("enum maybe", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("maybe")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeEnumMaybe)
+			test.AssertEqual(t, res.name, "maybe")
+		})
+
+		t.Run("no available register", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("skb")
+			test.AssertNoErr(t, err)
+
+			for i := range len(c.regalloc.registers) {
+				c.regalloc.registers[i] = true
+			}
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrRegisterNotEnough))
+		})
+
+		t.Run("skb", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("skb")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+			})
+		})
+	})
+
+	t.Run("not", func(t *testing.T) {
+		t.Run("invalid operand", func(t *testing.T) {
+			expr, err := cc.ParseExpr("!not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate operand")
+		})
+
+		t.Run("not", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("!skb->len")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+				JmpOff(asm.JNE, asm.R8, 0, 2),
+				asm.Mov.Imm(asm.R8, 1),
+				Ja(1),
+				asm.Xor.Reg(asm.R8, asm.R8),
+			})
+		})
+	})
+
+	t.Run("noteq", func(t *testing.T) {
+		t.Run("invalid left", func(t *testing.T) {
+			expr, err := cc.ParseExpr("not_found->xxx != 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate left operand")
+		})
+
+		t.Run("invalid right", func(t *testing.T) {
+			expr, err := cc.ParseExpr("1 != not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate right operand")
+		})
+
+		t.Run("noteq", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("skb->len != 1")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+				JmpOff(asm.JEq, asm.R8, 1, 2),
+				asm.Mov.Imm(asm.R8, 1),
+				Ja(1),
+				asm.Xor.Reg(asm.R8, asm.R8),
+			})
+		})
+	})
+
+	t.Run("number", func(t *testing.T) {
+		t.Run("invalid number", func(t *testing.T) {
+			expr := &cc.Expr{
+				Op:   cc.Number,
+				Text: "invalid",
+			}
+
+			_, err := c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "failed to parse number")
+		})
+
+		t.Run("number", func(t *testing.T) {
+			defer c.reset()
+
+			expr := &cc.Expr{
+				Op:   cc.Number,
+				Text: "1",
+			}
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeNum)
+			test.AssertEqual(t, res.num, 1)
+		})
+	})
+
+	t.Run("or", func(t *testing.T) {
+		t.Run("invalid left", func(t *testing.T) {
+			expr, err := cc.ParseExpr("not_found->xxx | 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate left operand")
+		})
+
+		t.Run("invalid right", func(t *testing.T) {
+			expr, err := cc.ParseExpr("1 | not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate right operand")
+		})
+
+		t.Run("or", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("skb->len | 1")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+				asm.Or.Imm(asm.R8, 1),
+			})
+		})
+	})
+
+	t.Run("oror", func(t *testing.T) {
+		t.Run("invalid left", func(t *testing.T) {
+			expr, err := cc.ParseExpr("not_found->xxx || 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate left operand")
+		})
+
+		t.Run("invalid right", func(t *testing.T) {
+			expr, err := cc.ParseExpr("1 || not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate right operand")
+		})
+
+		t.Run("oror", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("skb->len || 0")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+				JmpOff(asm.JEq, asm.R8, 0, 2),
+				asm.Mov.Imm(asm.R8, 1),
+				Ja(1),
+				asm.Xor.Reg(asm.R8, asm.R8),
+			})
+		})
+	})
+
+	t.Run("paren", func(t *testing.T) {
+		defer c.reset()
+
+		expr, err := cc.ParseExpr("(skb->len)")
+		test.AssertNoErr(t, err)
+
+		unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+		test.AssertNoErr(t, err)
+
+		res, err := c.eval(expr)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, res.reg, asm.R8)
+		test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+			asm.Mov.Reg(asm.R3, asm.R8),
+			asm.Add.Imm(asm.R3, 112),
+			asm.Mov.Imm(asm.R2, 8),
+			asm.Mov.Reg(asm.R1, asm.RFP),
+			asm.Add.Imm(asm.R1, -8),
+			asm.FnProbeReadKernel.Call(),
+			asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+			asm.LSh.Imm(asm.R8, 32),
+			asm.RSh.Imm(asm.R8, 32),
+		})
+	})
+
+	t.Run("plus", func(t *testing.T) {
+		t.Run("invalid operand", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("+not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+		})
+
+		t.Run("plus", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("+skb->len")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+			})
+		})
+	})
+
+	t.Run("pre-dec", func(t *testing.T) {
+		t.Run("invalid operand", func(t *testing.T) {
+			expr, err := cc.ParseExpr("--not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+		})
+
+		t.Run("pre-dec", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("--skb->len")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+				asm.Sub.Imm(asm.R8, 1),
+			})
+		})
+	})
+
+	t.Run("pre-inc", func(t *testing.T) {
+		t.Run("invalid operand", func(t *testing.T) {
+			expr, err := cc.ParseExpr("++not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+		})
+
+		t.Run("pre-inc", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("++skb->len")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+				asm.Add.Imm(asm.R8, 1),
+			})
+		})
+	})
+
+	t.Run("rsh", func(t *testing.T) {
+		t.Run("invalid left", func(t *testing.T) {
+			expr, err := cc.ParseExpr("not_found->xxx >> 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate left operand")
+		})
+
+		t.Run("invalid right", func(t *testing.T) {
+			expr, err := cc.ParseExpr("1 >> not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate right operand")
+		})
+
+		t.Run("rsh", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("skb->len >> 1")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 1),
+			})
+		})
+	})
+
+	t.Run("sub", func(t *testing.T) {
+		t.Run("invalid left", func(t *testing.T) {
+			expr, err := cc.ParseExpr("not_found->xxx - 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate left operand")
+		})
+
+		t.Run("invalid right", func(t *testing.T) {
+			expr, err := cc.ParseExpr("1 - not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate right operand")
+		})
+
+		t.Run("sub", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("skb->len - 2")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+				asm.Sub.Imm(asm.R8, 2),
+			})
+		})
+	})
+
+	t.Run("twid", func(t *testing.T) {
+		t.Run("invalid operand", func(t *testing.T) {
+			expr, err := cc.ParseExpr("~not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate operand")
+		})
+
+		t.Run("twid", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("~skb->len")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+				asm.Xor.Imm(asm.R8, -1),
+			})
+		})
+	})
+
+	t.Run("xor", func(t *testing.T) {
+		t.Run("invalid left", func(t *testing.T) {
+			expr, err := cc.ParseExpr("not_found->xxx ^ 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate left operand")
+		})
+
+		t.Run("invalid right", func(t *testing.T) {
+			expr, err := cc.ParseExpr("1 ^ not_found->xxx")
+			test.AssertNoErr(t, err)
+
+			_, err = c.eval(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to evaluate right operand")
+		})
+
+		t.Run("xor", func(t *testing.T) {
+			defer c.reset()
+
+			expr, err := cc.ParseExpr("skb->len ^ 1")
+			test.AssertNoErr(t, err)
+
+			unsignedInt, err := c.kernelBtf.AnyTypeByName("unsigned int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.eval(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.typ, evalValueTypeRegBtf)
+			test.AssertEqual(t, res.reg, asm.R8)
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, unsignedInt))
+			test.AssertEqualSlice(t, c.insns, asm.Instructions{
+				asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+				asm.Mov.Reg(asm.R3, asm.R8),
+				asm.Add.Imm(asm.R3, 112),
+				asm.Mov.Imm(asm.R2, 8),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -8),
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+				asm.LSh.Imm(asm.R8, 32),
+				asm.RSh.Imm(asm.R8, 32),
+				asm.Xor.Imm(asm.R8, 1),
+			})
+		})
+	})
+
+	t.Run("unsupported op", func(t *testing.T) {
+		expr, err := cc.ParseExpr("skb->len++")
+		test.AssertNoErr(t, err)
+
+		_, err = c.eval(expr)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "unsupported operator")
+	})
+}

--- a/internal/cc/expr.go
+++ b/internal/cc/expr.go
@@ -1,0 +1,143 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
+	"rsc.io/c2go/cc"
+)
+
+const (
+	argsReg = asm.R9
+)
+
+type compiler struct {
+	regalloc RegisterAllocator
+	insns    asm.Instructions
+
+	vars []string
+	btfs []btf.Type
+
+	kernelBtf *btf.Spec
+
+	labelExit     string
+	labelExitUsed bool
+
+	reservedStack int
+}
+
+type CompileExprOptions struct {
+	Expr          string
+	Params        []btf.FuncParam
+	Spec          *btf.Spec
+	LabelExit     string
+	ReservedStack int
+}
+
+func CompileFilterExpr(opts CompileExprOptions) (asm.Instructions, error) {
+	if opts.Expr == "" || opts.LabelExit == "" {
+		return nil, fmt.Errorf("expression and label exit cannot be empty")
+	}
+	if opts.Spec == nil {
+		return nil, fmt.Errorf("btf spec cannot be empty")
+	}
+
+	c := &compiler{
+		kernelBtf:     opts.Spec,
+		labelExit:     opts.LabelExit,
+		reservedStack: opts.ReservedStack,
+	}
+
+	c.vars = make([]string, len(opts.Params))
+	c.btfs = make([]btf.Type, len(opts.Params))
+	for i := range opts.Params {
+		c.vars[i] = opts.Params[i].Name
+		c.btfs[i] = opts.Params[i].Type
+	}
+
+	if c.reservedStack <= 0 {
+		c.reservedStack = 8
+	} else {
+		c.reservedStack = (c.reservedStack + 7) & -8 // align to 8 bytes
+	}
+
+	c.emit(asm.Mov.Reg(argsReg, asm.R1)) // cache args to r9
+	c.regalloc.registers[asm.R9] = true
+
+	if err := c.compile(opts.Expr); err != nil {
+		return nil, err
+	}
+
+	c.emit(asm.Return())
+
+	return c.insns, nil
+}
+
+func (c *compiler) compile(expr string) error {
+	e, err := cc.ParseExpr(expr)
+	if err != nil {
+		return fmt.Errorf("failed to parse expression: %w", err)
+	}
+
+	supportedOps := []cc.ExprOp{
+		cc.AndAnd,
+		cc.EqEq,
+		cc.Gt,
+		cc.GtEq,
+		cc.Lt,
+		cc.LtEq,
+		cc.Not,
+		cc.NotEq,
+		cc.OrOr,
+	}
+	if !slices.Contains(supportedOps, e.Op) {
+		return fmt.Errorf("top op '%s' of expression must be one of %v", e.Op, supportedOps)
+	}
+
+	val, err := c.eval(e)
+	if err != nil {
+		return fmt.Errorf("failed to evaluate expression: %w", err)
+	}
+	if val.typ == evalValueTypeNum {
+		return fmt.Errorf("disallow constant value (%d) expression: '%s'", val.num, expr)
+	}
+
+	if c.labelExitUsed {
+		c.insns[len(c.insns)-1] = c.insns[len(c.insns)-1].WithSymbol(c.labelExit)
+	}
+
+	if val.reg != asm.R0 {
+		c.emit(asm.Mov.Reg(asm.R0, val.reg))
+	}
+
+	return nil
+}
+
+func (c *compiler) emit(insn asm.Instruction) {
+	c.insns = append(c.insns, insn)
+}
+
+func (c *compiler) emitLoadArg(index int, dst asm.Register) {
+	c.emit(asm.LoadMem(dst, argsReg, int16(index*8), asm.DWord))
+}
+
+func (c *compiler) pushUsedCallerSavedRegs() {
+	for reg, i := asm.R0, 1; reg <= asm.R5; reg++ {
+		if c.regalloc.IsUsed(reg) {
+			c.emit(asm.StoreMem(asm.RFP, int16(-c.reservedStack-i*8), reg, asm.DWord))
+		}
+	}
+}
+
+func (c *compiler) popUsedCallerSavedRegs() {
+	for reg, i := asm.R0, 1; reg <= asm.R5; reg++ {
+		if c.regalloc.IsUsed(reg) {
+			c.emit(asm.LoadMem(reg, asm.RFP, int16(-c.reservedStack-i*8), asm.DWord))
+		}
+	}
+}

--- a/internal/cc/expr_test.go
+++ b/internal/cc/expr_test.go
@@ -1,0 +1,284 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import (
+	"bytes"
+	_ "embed"
+	"errors"
+	"log"
+	"testing"
+
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
+
+	"github.com/bpfsnoop/bpfsnoop/internal/test"
+)
+
+//go:embed testdata/vmlinux_v680_btf.o
+var btfFile []byte
+
+var testBtf *btf.Spec
+
+func init() {
+	spec, err := btf.LoadSpecFromReader(bytes.NewReader(btfFile))
+	if err != nil {
+		log.Fatalf("Failed to load btf spec: %v", err)
+	}
+
+	testBtf = spec
+}
+
+func getSkbBtf(t *testing.T) *btf.Pointer {
+	skb, err := testBtf.AnyTypeByName("sk_buff")
+	t.Helper()
+	test.AssertNoErr(t, err)
+	return &btf.Pointer{Target: skb}
+}
+
+func getBpfProgBtf(t *testing.T) *btf.Pointer {
+	bpfProg, err := testBtf.AnyTypeByName("bpf_prog")
+	t.Helper()
+	test.AssertNoErr(t, err)
+	return &btf.Pointer{Target: bpfProg}
+}
+
+func getBpfMapBtf(t *testing.T) *btf.Pointer {
+	bpfMap, err := testBtf.AnyTypeByName("bpf_map")
+	t.Helper()
+	test.AssertNoErr(t, err)
+	return &btf.Pointer{Target: bpfMap}
+}
+
+func getBpfProgTypeBtf(t *testing.T) *btf.Enum {
+	bpfProgType, err := testBtf.AnyTypeByName("bpf_prog_type")
+	t.Helper()
+	test.AssertNoErr(t, err)
+	return bpfProgType.(*btf.Enum)
+}
+
+func getU8Btf(t *testing.T) btf.Type {
+	u8, err := testBtf.AnyTypeByName("__u8")
+	t.Helper()
+	test.AssertNoErr(t, err)
+	return u8
+}
+
+func getU64Btf(t *testing.T) btf.Type {
+	u64, err := testBtf.AnyTypeByName("__u64")
+	t.Helper()
+	test.AssertNoErr(t, err)
+	return u64
+}
+
+func getFakeOpsBtf() *btf.Pointer {
+	return &btf.Pointer{
+		Target: &btf.Struct{
+			Name: "fake_ops",
+			Members: []btf.Member{
+				{
+					Name: "lookup_elem",
+					Type: &btf.Pointer{Target: &btf.FuncProto{}},
+				},
+				{
+					Name: "batch_lookup_elem",
+					Type: &btf.Array{
+						Type:   &btf.FuncProto{},
+						Nelems: 1,
+					},
+				},
+				{
+					Name: "data",
+					Type: &btf.Pointer{
+						Target: &btf.Void{},
+					},
+				},
+				{
+					Name: "arr",
+					Type: &btf.Array{
+						Type:   &btf.FuncProto{},
+						Nelems: 1,
+					},
+				},
+				{
+					Name: "fn",
+					Type: &btf.Pointer{
+						Target: &btf.FuncProto{},
+					},
+				},
+			},
+		},
+	}
+}
+
+func getBpfAttrBtf(t *testing.T) *btf.Pointer {
+	bpfAttr, err := testBtf.AnyTypeByName("bpf_attr")
+	t.Helper()
+	test.AssertNoErr(t, err)
+	bpfAttrPtr, ok := bpfAttr.(*btf.Union)
+	test.AssertTrue(t, ok)
+	return &btf.Pointer{
+		Target: bpfAttrPtr,
+	}
+}
+
+func prepareCompiler(t *testing.T) *compiler {
+	c := &compiler{
+		labelExit:     "__label_exit",
+		reservedStack: 8,
+		vars:          []string{"skb", "prog", "ops", "attr"},
+		btfs:          []btf.Type{getSkbBtf(t), getBpfProgBtf(t), getFakeOpsBtf(), getBpfAttrBtf(t)},
+		kernelBtf:     testBtf,
+	}
+	c.regalloc.registers[asm.R9] = true
+	return c
+}
+
+func (c *compiler) reset() {
+	c.insns = nil
+	c.labelExitUsed = false
+	c.regalloc.registers = [10]bool{}
+	c.regalloc.registers[asm.R9] = true
+	c.reservedStack = 8
+}
+
+func TestCompileFilterExpr(t *testing.T) {
+	t.Run("empty expr", func(t *testing.T) {
+		_, err := CompileFilterExpr(CompileExprOptions{
+			Expr:      "",
+			LabelExit: "__label_exit",
+			Spec:      testBtf,
+		})
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "expression and label exit cannot be empty")
+	})
+
+	t.Run("empty btf spec", func(t *testing.T) {
+		_, err := CompileFilterExpr(CompileExprOptions{
+			Expr:      "skb->len == 0",
+			LabelExit: "__label_exit",
+			Spec:      nil,
+		})
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "btf spec cannot be empty")
+	})
+
+	t.Run("compile expr failed", func(t *testing.T) {
+		_, err := CompileFilterExpr(CompileExprOptions{
+			Expr:      "not_found->xxx == 0",
+			LabelExit: "__label_exit",
+			Spec:      testBtf,
+			Params: []btf.FuncParam{
+				{
+					Name: "skb",
+					Type: getSkbBtf(t),
+				},
+				{
+					Name: "prog",
+					Type: getBpfProgBtf(t),
+				},
+			},
+		})
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+	})
+
+	t.Run("compile expr success", func(t *testing.T) {
+		insns, err := CompileFilterExpr(CompileExprOptions{
+			Expr:      "skb->len == 0",
+			LabelExit: "__label_exit",
+			Spec:      testBtf,
+			Params: []btf.FuncParam{
+				{
+					Name: "skb",
+					Type: getSkbBtf(t),
+				},
+				{
+					Name: "prog",
+					Type: getBpfProgBtf(t),
+				},
+			},
+			ReservedStack: 7,
+		})
+		test.AssertNoErr(t, err)
+		test.AssertEqualSlice(t, insns, []asm.Instruction{
+			asm.Mov.Reg(asm.R9, asm.R1),
+			asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+			asm.Mov.Reg(asm.R3, asm.R8),
+			asm.Add.Imm(asm.R3, 112),
+			asm.Mov.Imm(asm.R2, 8),
+			asm.Mov.Reg(asm.R1, asm.RFP),
+			asm.Add.Imm(asm.R1, -8),
+			asm.FnProbeReadKernel.Call(),
+			asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+			asm.LSh.Imm(asm.R8, 32),
+			asm.RSh.Imm(asm.R8, 32),
+			JmpOff(asm.JNE, asm.R8, 0, 2),
+			asm.Mov.Imm(asm.R8, 1),
+			Ja(1),
+			asm.Xor.Reg(asm.R8, asm.R8),
+			asm.Mov.Reg(asm.R0, asm.R8),
+			asm.Return(),
+		})
+	})
+}
+
+func TestCompile(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("invalid expr", func(t *testing.T) {
+		err := c.compile("1 * skb^^>len")
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "failed to parse expression")
+	})
+
+	t.Run("unsupported op", func(t *testing.T) {
+		err := c.compile("skb->len + skb->len")
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "top op 'Add' of expression")
+	})
+
+	t.Run("evaluate failed", func(t *testing.T) {
+		err := c.compile("not_found->xxx == 0")
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+		test.AssertStrPrefix(t, err.Error(), "failed to evaluate expression")
+	})
+
+	t.Run("constant value", func(t *testing.T) {
+		err := c.compile("1 > 2")
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "disallow constant value")
+	})
+
+	t.Run("skb->dev->ifindex == 11", func(t *testing.T) {
+		c.reset()
+		err := c.compile("skb->dev->ifindex == 11")
+		test.AssertNoErr(t, err)
+		test.AssertEqualSlice(t, c.insns, []asm.Instruction{
+			asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+			asm.Mov.Reg(asm.R3, asm.R8),
+			asm.Add.Imm(asm.R3, 16),
+			asm.Mov.Imm(asm.R2, 8),
+			asm.Mov.Reg(asm.R1, asm.RFP),
+			asm.Add.Imm(asm.R1, -8),
+			asm.FnProbeReadKernel.Call(),
+			asm.LoadMem(asm.R3, asm.RFP, -8, asm.DWord),
+			asm.JEq.Imm(asm.R3, 0, c.labelExit),
+			asm.Add.Imm(asm.R3, 224),
+			asm.Mov.Imm(asm.R2, 8),
+			asm.Mov.Reg(asm.R1, asm.RFP),
+			asm.Add.Imm(asm.R1, -8),
+			asm.FnProbeReadKernel.Call(),
+			asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+			asm.LSh.Imm(asm.R8, 32),
+			asm.RSh.Imm(asm.R8, 32),
+			JmpOff(asm.JNE, asm.R8, 11, 2),
+			asm.Mov.Imm(asm.R8, 1),
+			Ja(1),
+			asm.Xor.Reg(asm.R8, asm.R8).WithSymbol(c.labelExit),
+			asm.Mov.Reg(asm.R0, asm.R8),
+		})
+	})
+}

--- a/internal/cc/insn.go
+++ b/internal/cc/insn.go
@@ -1,0 +1,31 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import "github.com/cilium/ebpf/asm"
+
+func JmpOff(op asm.JumpOp, dst asm.Register, value int64, offset int16) asm.Instruction {
+	return asm.Instruction{
+		OpCode:   op.Op(asm.ImmSource),
+		Dst:      dst,
+		Offset:   offset,
+		Constant: value,
+	}
+}
+
+func JmpReg(op asm.JumpOp, dst, src asm.Register, offset int16) asm.Instruction {
+	return asm.Instruction{
+		OpCode: op.Op(asm.RegSource),
+		Dst:    dst,
+		Src:    src,
+		Offset: offset,
+	}
+}
+
+func Ja(offset int16) asm.Instruction {
+	return asm.Instruction{
+		OpCode: asm.Ja.Op(asm.ImmSource),
+		Offset: offset,
+	}
+}

--- a/internal/cc/memory_access.go
+++ b/internal/cc/memory_access.go
@@ -1,0 +1,492 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/Asphaltt/mybtf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
+	"rsc.io/c2go/cc"
+)
+
+type accessOffset struct {
+	offset  int64
+	address bool
+}
+
+type accessResult struct {
+	raw btf.Type
+	idx int
+
+	btf btf.Type
+	mem *btf.Member
+
+	offsets []accessOffset
+}
+
+// isMemberBitfield reports whether the member is a bitfield attribute.
+func isMemberBitfield(member *btf.Member) bool {
+	return member != nil && member.BitfieldSize != 0
+}
+
+func (c *compiler) accessMemory(expr *cc.Expr) (accessResult, error) {
+	switch expr.Op {
+	case cc.Name:
+		idx := slices.Index(c.vars, expr.Text)
+		if idx == -1 {
+			return accessResult{}, fmt.Errorf("variable %s: %w", expr.Text, ErrVarNotFound)
+		}
+
+		return accessResult{
+			raw: c.btfs[idx],
+			idx: idx,
+			btf: c.btfs[idx],
+		}, nil
+
+	case cc.Dot, cc.Arrow:
+		res, err := c.accessMemory(expr.Left)
+		if err != nil {
+			return accessResult{}, err
+		}
+		if isMemberBitfield(res.mem) {
+			return accessResult{}, fmt.Errorf("cannot access member of a bitfield type")
+		}
+
+		t := mybtf.UnderlyingType(res.btf)
+		ptr, useArrow := t.(*btf.Pointer)
+
+		var member *btf.Member
+		var offset uint32
+
+		if useArrow {
+			t = mybtf.UnderlyingType(ptr.Target)
+		}
+
+		switch v := t.(type) {
+		case *btf.Struct:
+			member, err = mybtf.FindStructMember(v, expr.Text)
+			if err == nil {
+				offset, err = mybtf.StructMemberOffset(v, expr.Text)
+			}
+		case *btf.Union:
+			member, err = mybtf.FindUnionMember(v, expr.Text)
+			if err == nil {
+				offset, err = mybtf.UnionMemberOffset(v, expr.Text)
+			}
+		default:
+			return accessResult{}, fmt.Errorf("unsupported type %T", v)
+		}
+		if err != nil {
+			return accessResult{}, fmt.Errorf("failed to find member %s: %w", expr.Text, err)
+		}
+
+		if !useArrow {
+			// access via .
+			if len(res.offsets) > 0 {
+				res.offsets[len(res.offsets)-1].offset += int64(offset)
+			} else {
+				return accessResult{}, fmt.Errorf("disallow accessing member %s of %s via dot", expr.Text, expr.Left.Text)
+			}
+		} else {
+			// access via ->
+			res.offsets = append(res.offsets, accessOffset{
+				offset: int64(offset),
+			})
+		}
+
+		t = mybtf.UnderlyingType(member.Type)
+		if _, ok := t.(*btf.Array); ok {
+			res.offsets[len(res.offsets)-1].address = true
+			res.btf = member.Type
+			res.mem = nil
+		} else {
+			res.btf = member.Type
+			res.mem = member
+		}
+
+		return res, nil
+
+	case cc.Add:
+		var (
+			err error
+			num int64
+			res accessResult
+		)
+		if expr.Left.Op == cc.Number {
+			num, err = parseNumber(expr.Left.Text)
+			if err != nil {
+				return accessResult{}, fmt.Errorf("failed to parse number of add.left: %w", err)
+			}
+
+			res, err = c.accessMemory(expr.Right)
+			if err != nil {
+				return accessResult{}, fmt.Errorf("failed to parse right of add: %w", err)
+			}
+		} else if expr.Right.Op == cc.Number {
+			num, err = parseNumber(expr.Right.Text)
+			if err != nil {
+				return accessResult{}, fmt.Errorf("failed to parse number of add.right: %w", err)
+			}
+
+			res, err = c.accessMemory(expr.Left)
+			if err != nil {
+				return accessResult{}, fmt.Errorf("failed to parse left of add: %w", err)
+			}
+		} else {
+			return accessResult{}, fmt.Errorf("number is required for add")
+		}
+
+		if isMemberBitfield(res.mem) {
+			return accessResult{}, fmt.Errorf("disallow using bitfield for add")
+		}
+
+		t := mybtf.UnderlyingType(res.btf)
+		if ptr, ok := t.(*btf.Pointer); ok {
+			if _, ok := mybtf.UnderlyingType(ptr.Target).(*btf.Void); ok { // void *
+				res.offsets = append(res.offsets, accessOffset{
+					offset:  int64(num),
+					address: true,
+				})
+			} else {
+				size, err := btf.Sizeof(ptr.Target)
+				if err != nil {
+					return res, fmt.Errorf("disallow type %v for adding", ptr.Target)
+				}
+
+				res.offsets = append(res.offsets, accessOffset{
+					offset:  int64(size * int(num)),
+					address: true,
+				})
+			}
+		} else if arr, ok := t.(*btf.Array); ok {
+			size, err := btf.Sizeof(arr.Type)
+			if err != nil {
+				return res, fmt.Errorf("disallow type %v for adding", arr.Type)
+			}
+
+			res.offsets = append(res.offsets, accessOffset{
+				offset:  int64(size * int(num)),
+				address: true,
+			})
+		} else {
+			return res, fmt.Errorf("disallow using non-{pointer,array} for add")
+		}
+
+		res.mem = nil
+		return res, nil
+
+	case cc.Addr:
+		// &skb->dev ==> skb ptr + offsetof(skb, dev)
+
+		res, err := c.accessMemory(expr.Left)
+		if err != nil {
+			return accessResult{}, fmt.Errorf("failed to access memory for addr: %w", err)
+		}
+
+		if len(res.offsets) == 0 {
+			return accessResult{}, fmt.Errorf("disallow address '%s'", expr.Left.Text)
+		}
+
+		res.offsets[len(res.offsets)-1].address = true
+		res.mem = nil
+		return res, nil
+
+	case cc.Cast:
+		res, err := c.accessMemory(expr.Left)
+		if err != nil {
+			return accessResult{}, fmt.Errorf("failed to access memory for cast: %w", err)
+		}
+
+		ccType := expr.Type
+		isPointer := ccType.Kind == cc.Ptr
+		if isPointer {
+			ccType = ccType.Base
+		}
+
+		var typ btf.Type
+
+		if ccType.Kind == cc.Struct {
+			typeName := ccType.Tag
+			typ, err = c.kernelBtf.AnyTypeByName(typeName)
+			if err != nil {
+				return accessResult{}, fmt.Errorf("failed to find type '%s': %w", typeName, err)
+			}
+
+			t := mybtf.UnderlyingType(typ)
+			_, isStruct := t.(*btf.Struct)
+			_, isUnion := t.(*btf.Union)
+			if !isStruct && !isUnion {
+				return accessResult{}, fmt.Errorf("expected struct/union type for cast, got %T", t)
+			}
+		} else {
+			typeName := ccType.String()
+			typ, err = c.kernelBtf.AnyTypeByName(typeName)
+			if err != nil {
+				return accessResult{}, fmt.Errorf("failed to find type '%s': %w", typeName, err)
+			}
+		}
+
+		if isPointer {
+			res.btf = &btf.Pointer{Target: typ}
+		} else {
+			res.btf = typ
+		}
+
+		res.mem = nil
+		return res, nil
+
+	case cc.Index:
+		// index of array is same as index of pointer
+		//
+		// skb->cb[3] ==> *(skb->cb + 3)
+
+		res, err := c.accessMemory(expr.Left)
+		if err != nil {
+			return accessResult{}, fmt.Errorf("failed to access memory for index: %w", err)
+		}
+		if isMemberBitfield(res.mem) {
+			return accessResult{}, fmt.Errorf("disallow using bitfield for index")
+		}
+
+		if expr.Right.Op != cc.Number {
+			return accessResult{}, fmt.Errorf("op of index expected number type, got %s", expr.Right.Op)
+		}
+
+		index, err := parseNumber(expr.Right.Text)
+		if err != nil {
+			return accessResult{}, fmt.Errorf("failed to parse number: %w", err)
+		}
+
+		var size int
+
+		t := mybtf.UnderlyingType(res.btf)
+		if ptr, ok := t.(*btf.Pointer); ok {
+			size, _ = btf.Sizeof(ptr.Target)
+			if size == 0 {
+				return accessResult{}, fmt.Errorf("disallow indexing pointer of type %v", t)
+			}
+
+			res.btf = ptr.Target
+		} else if arr, ok := t.(*btf.Array); ok {
+			size, _ = btf.Sizeof(arr.Type)
+			if size == 0 {
+				return accessResult{}, fmt.Errorf("disallow indexing array of type %v", t)
+			}
+
+			res.btf = arr.Type
+		} else {
+			return accessResult{}, fmt.Errorf("disallow indexing type %v", t)
+		}
+
+		res.offsets = append(res.offsets, accessOffset{
+			offset: int64(index * int64(size)),
+		})
+		res.mem = nil
+		return res, nil
+
+	case cc.Indir:
+		// *skb->dev ==> *(*(skb ptr + offsetof(skb, dev))
+
+		res, err := c.accessMemory(expr.Left)
+		if err != nil {
+			return accessResult{}, fmt.Errorf("failed to access memory for indir: %w", err)
+		}
+		if isMemberBitfield(res.mem) {
+			return accessResult{}, fmt.Errorf("disallow indirecting bitfield")
+		}
+
+		t := mybtf.UnderlyingType(res.btf)
+		ptr, ok := t.(*btf.Pointer)
+		if !ok {
+			return accessResult{}, fmt.Errorf("disallow indirecting type %v", t)
+		}
+
+		res.offsets = append(res.offsets, accessOffset{
+			offset: 0,
+		})
+		res.btf = ptr.Target
+		res.mem = nil
+		return res, nil
+
+	case cc.Paren:
+		return c.accessMemory(expr.Left)
+
+	case cc.Sub:
+		if expr.Right.Op != cc.Number {
+			return accessResult{}, fmt.Errorf("sub.right must be number")
+		}
+		num, err := parseNumber(expr.Right.Text)
+		if err != nil {
+			return accessResult{}, fmt.Errorf("failed to parse number of sub.right: %w", err)
+		}
+
+		res, err := c.accessMemory(expr.Left)
+		if err != nil {
+			return res, fmt.Errorf("failed to parse sub.left: %w", err)
+		}
+		if isMemberBitfield(res.mem) {
+			return res, fmt.Errorf("disallow using bitfield for sub")
+		}
+
+		t := mybtf.UnderlyingType(res.btf)
+		if ptr, ok := t.(*btf.Pointer); ok {
+			if _, ok := mybtf.UnderlyingType(ptr.Target).(*btf.Void); ok { // void *
+				res.offsets = append(res.offsets, accessOffset{
+					offset:  -int64(num),
+					address: true,
+				})
+			} else {
+				size, err := btf.Sizeof(ptr.Target)
+				if err != nil {
+					return res, fmt.Errorf("disallow type %v for subing", ptr.Target)
+				}
+
+				res.offsets = append(res.offsets, accessOffset{
+					offset:  -int64(size * int(num)),
+					address: true,
+				})
+			}
+		} else if arr, ok := t.(*btf.Array); ok {
+			size, err := btf.Sizeof(arr.Type)
+			if err != nil {
+				return res, fmt.Errorf("disallow type %v for subing", arr.Type)
+			}
+
+			res.offsets = append(res.offsets, accessOffset{
+				offset:  int64(-size * int(num)),
+				address: true,
+			})
+		} else {
+			return res, fmt.Errorf("disallow using non-{pointer,array} for sub")
+		}
+
+		res.mem = nil
+		return res, nil
+
+	}
+
+	return accessResult{}, fmt.Errorf("unsupported expression op %s", expr.Op)
+}
+
+func (c *compiler) access(expr *cc.Expr) (evalValue, error) {
+	res, err := c.accessMemory(expr)
+	if err != nil {
+		return evalValue{}, err
+	}
+
+	c.pushUsedCallerSavedRegs()
+	defer c.popUsedCallerSavedRegs()
+
+	var eval evalValue
+
+	reg, err := c.regalloc.Alloc()
+	if err != nil {
+		return eval, fmt.Errorf("failed to alloc register for memory access: %w", err)
+	}
+
+	eval.typ = evalValueTypeRegBtf
+	eval.btf = res.btf
+	eval.mem = res.mem
+	eval.reg = reg
+
+	c.emitLoadArg(res.idx, reg)
+	c.offset2insns(res.offsets, reg)
+	if isMemberBitfield(res.mem) {
+		c.bitfield2insns(res.mem, reg)
+	} else {
+		c.adjustRegisterBitwise(eval)
+	}
+
+	return eval, nil
+}
+
+func (c *compiler) offset2insns(offsets []accessOffset, reg asm.Register) {
+	if len(offsets) == 0 {
+		return
+	}
+
+	allAddress := offsets[0].address
+	for i := range offsets {
+		allAddress = allAddress && offsets[i].address
+	}
+	if allAddress {
+		for i := range offsets {
+			c.emit(asm.Add.Imm(reg, int32(offsets[i].offset)))
+		}
+		return
+	}
+
+	if reg != asm.R3 {
+		c.emit(asm.Mov.Reg(asm.R3, reg))
+	}
+
+	lastIndex := len(offsets) - 1
+	for i, offset := range offsets {
+		if offset.offset != 0 {
+			c.emit(asm.Add.Imm(asm.R3, int32(offset.offset)))
+		}
+		if offset.address {
+			if i == lastIndex && reg != asm.R3 {
+				c.emit(asm.Mov.Reg(reg, asm.R3))
+			}
+			continue
+		}
+
+		c.emit(asm.Mov.Imm(asm.R2, 8))       // r2 = 8; always read 8 bytes
+		c.emit(asm.Mov.Reg(asm.R1, asm.RFP)) // r1 = r10
+		c.emit(asm.Add.Imm(asm.R1, -8))      // r1 = r10 - 8
+		c.emit(asm.FnProbeReadKernel.Call()) // bpf_probe_read_kernel(r1, 8, r3)
+
+		if i != lastIndex {
+			c.labelExitUsed = true
+			c.emit(asm.LoadMem(asm.R3, asm.RFP, -8, asm.DWord)) // r3 = *(r10 - 8)
+			c.emit(asm.JEq.Imm(asm.R3, 0, c.labelExit))
+		} else {
+			c.emit(asm.LoadMem(reg, asm.RFP, -8, asm.DWord))
+		}
+	}
+}
+
+func (c *compiler) bitfield2insns(member *btf.Member, reg asm.Register) {
+	delta := member.Offset & 0x7
+	if delta != 0 {
+		c.emit(asm.RSh.Imm(reg, int32(delta))) // reg >>= delta
+	}
+
+	mask := (uint64(1) << uint64(member.BitfieldSize)) - 1
+	c.emit(asm.And.Imm(reg, int32(mask))) // reg &= mask
+}
+
+func (c *compiler) adjustRegisterBitwise(val evalValue) error {
+	if val.typ != evalValueTypeRegBtf {
+		return nil
+	}
+
+	size, err := btf.Sizeof(val.btf)
+	if err != nil {
+		return fmt.Errorf("failed to get size of %v: %w", val.btf, err)
+	}
+
+	switch size {
+	case 1:
+		c.emit(asm.And.Imm(val.reg, 0xFF))
+
+	case 2:
+		c.emit(asm.And.Imm(val.reg, 0xFFFF))
+
+	case 4:
+		c.emit(asm.LSh.Imm(val.reg, 32))
+		c.emit(asm.RSh.Imm(val.reg, 32))
+
+	case 8:
+
+	default:
+		return fmt.Errorf("unsupported size %d for %v", size, val.btf)
+	}
+
+	return nil
+}

--- a/internal/cc/memory_access_test.go
+++ b/internal/cc/memory_access_test.go
@@ -1,0 +1,975 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/bpfsnoop/bpfsnoop/internal/test"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
+	"rsc.io/c2go/cc"
+)
+
+func TestAccessMemory(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("name", func(t *testing.T) {
+		t.Run("not_found", func(t *testing.T) {
+			_, err := c.accessMemory(&cc.Expr{
+				Op:   cc.Name,
+				Text: "not_found",
+			})
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+		})
+
+		t.Run("prog", func(t *testing.T) {
+			res, err := c.accessMemory(&cc.Expr{
+				Op:   cc.Name,
+				Text: "prog",
+			})
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.idx, 1)
+		})
+	})
+
+	t.Run("dot,arrow", func(t *testing.T) {
+		t.Run(".not_found", func(t *testing.T) {
+			_, err := c.accessMemory(&cc.Expr{
+				Op: cc.Dot,
+				Left: &cc.Expr{
+					Op:   cc.Name,
+					Text: "not_found",
+				},
+			})
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+		})
+
+		t.Run("skb->pkt_type.a", func(t *testing.T) {
+			expr, err := cc.ParseExpr("skb->pkt_type.a")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertEqual(t, err.Error(), "cannot access member of a bitfield type")
+		})
+
+		t.Run("skb->len.a", func(t *testing.T) {
+			expr, err := cc.ParseExpr("skb->len.a")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "unsupported type")
+		})
+
+		t.Run("skb->not_found", func(t *testing.T) {
+			expr, err := cc.ParseExpr("skb->not_found")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "failed to find member")
+		})
+
+		t.Run("skb.len", func(t *testing.T) {
+			skb, err := testBtf.AnyTypeByName("sk_buff")
+			test.AssertNoErr(t, err)
+
+			expr, err := cc.ParseExpr("skb.len")
+			test.AssertNoErr(t, err)
+
+			c.btfs[0] = skb
+			defer func() { c.btfs[0] = getSkbBtf(t) }()
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "disallow accessing member len of skb via dot")
+		})
+
+		t.Run("skb->len", func(t *testing.T) {
+			expr, err := cc.ParseExpr("skb->len")
+			test.AssertNoErr(t, err)
+
+			res, err := c.accessMemory(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.idx, 0)
+			test.AssertEqualSlice(t, res.offsets, []accessOffset{{offset: 112}})
+		})
+
+		t.Run("skb->users.refs.counter", func(t *testing.T) {
+			expr, err := cc.ParseExpr("skb->users.refs.counter")
+			test.AssertNoErr(t, err)
+
+			res, err := c.accessMemory(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.idx, 0)
+			test.AssertEqualSlice(t, res.offsets, []accessOffset{{offset: 220}})
+		})
+
+		t.Run("skb->cb", func(t *testing.T) {
+			expr, err := cc.ParseExpr("skb->cb")
+			test.AssertNoErr(t, err)
+
+			res, err := c.accessMemory(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.idx, 0)
+			test.AssertEqualSlice(t, res.offsets, []accessOffset{{offset: 40, address: true}})
+		})
+
+		t.Run("attr->map_type", func(t *testing.T) {
+			expr, err := cc.ParseExpr("attr->map_type")
+			test.AssertNoErr(t, err)
+
+			res, err := c.accessMemory(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.idx, 3)
+			test.AssertEqualSlice(t, res.offsets, []accessOffset{{offset: 0}})
+		})
+	})
+
+	t.Run("add", func(t *testing.T) {
+		t.Run("number(not_found) + 1", func(t *testing.T) {
+			expr := &cc.Expr{
+				Op: cc.Add,
+				Left: &cc.Expr{
+					Op:   cc.Number,
+					Text: "not_found",
+				},
+			}
+
+			_, err := c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "failed to parse number of add.left")
+		})
+
+		t.Run("1 + skb->pkt_type.a", func(t *testing.T) {
+			rexpr, err := cc.ParseExpr("skb->pkt_type.a")
+			test.AssertNoErr(t, err)
+
+			expr := &cc.Expr{
+				Op: cc.Add,
+				Left: &cc.Expr{
+					Op:   cc.Number,
+					Text: "1",
+				},
+				Right: rexpr,
+			}
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "failed to parse right of add")
+		})
+
+		t.Run("skb->pkt_type.a + number(not_found)", func(t *testing.T) {
+			lexpr, err := cc.ParseExpr("skb->pkt_type.a")
+			test.AssertNoErr(t, err)
+
+			expr := &cc.Expr{
+				Op:   cc.Add,
+				Left: lexpr,
+				Right: &cc.Expr{
+					Op:   cc.Number,
+					Text: "not_found",
+				},
+			}
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "failed to parse number of add.right")
+		})
+
+		t.Run("skb->pkt_type.a + 1", func(t *testing.T) {
+			lexpr, err := cc.ParseExpr("skb->pkt_type.a")
+			test.AssertNoErr(t, err)
+
+			expr := &cc.Expr{
+				Op:   cc.Add,
+				Left: lexpr,
+				Right: &cc.Expr{
+					Op:   cc.Number,
+					Text: "1",
+				},
+			}
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "failed to parse left of add")
+		})
+
+		t.Run("skb->len + skb->head", func(t *testing.T) {
+			lexpr, err := cc.ParseExpr("skb->len")
+			test.AssertNoErr(t, err)
+
+			rexpr, err := cc.ParseExpr("skb->head")
+			test.AssertNoErr(t, err)
+
+			expr := &cc.Expr{
+				Op:    cc.Add,
+				Left:  lexpr,
+				Right: rexpr,
+			}
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "number is required for add")
+		})
+
+		t.Run("skb->pkt_type + 1", func(t *testing.T) {
+			expr, err := cc.ParseExpr("skb->pkt_type + 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "disallow using bitfield for add")
+		})
+
+		t.Run("ops->lookup_elem + 1", func(t *testing.T) {
+			expr, err := cc.ParseExpr("ops->lookup_elem + 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "disallow type")
+		})
+
+		t.Run("ops->batch_lookup_elem + 1", func(t *testing.T) {
+			expr, err := cc.ParseExpr("ops->batch_lookup_elem + 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "disallow type")
+		})
+
+		t.Run("skb->users + 1", func(t *testing.T) {
+			expr, err := cc.ParseExpr("skb->users + 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "disallow using non-{pointer,array} for add")
+		})
+
+		t.Run("skb + 1", func(t *testing.T) {
+			expr, err := cc.ParseExpr("skb + 1")
+			test.AssertNoErr(t, err)
+
+			res, err := c.accessMemory(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.idx, 0)
+			test.AssertEqualSlice(t, res.offsets, []accessOffset{{offset: 232, address: true}})
+		})
+
+		t.Run("prog->aux->jit_data + 1", func(t *testing.T) {
+			expr, err := cc.ParseExpr("prog->aux->jit_data + 1")
+			test.AssertNoErr(t, err)
+
+			res, err := c.accessMemory(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.idx, 1)
+			test.AssertEqualSlice(t, res.offsets, []accessOffset{{offset: 56}, {offset: 176}, {offset: 1, address: true}})
+		})
+
+		t.Run("skb->cb + 1", func(t *testing.T) {
+			expr, err := cc.ParseExpr("skb->cb + 1")
+			test.AssertNoErr(t, err)
+
+			res, err := c.accessMemory(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.idx, 0)
+			test.AssertEqualSlice(t, res.offsets, []accessOffset{{offset: 40, address: true}, {offset: 1, address: true}})
+		})
+	})
+
+	t.Run("addr", func(t *testing.T) {
+		t.Run("&not_found", func(t *testing.T) {
+			_, err := c.accessMemory(&cc.Expr{
+				Op: cc.Addr,
+				Left: &cc.Expr{
+					Op:   cc.Name,
+					Text: "not_found",
+				},
+			})
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to access memory for addr")
+		})
+
+		t.Run("&skb", func(t *testing.T) {
+			expr, err := cc.ParseExpr("&skb")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "disallow address")
+		})
+
+		t.Run("&skb->len", func(t *testing.T) {
+			expr, err := cc.ParseExpr("&skb->len")
+			test.AssertNoErr(t, err)
+
+			res, err := c.accessMemory(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.idx, 0)
+			test.AssertEqualSlice(t, res.offsets, []accessOffset{{offset: 112, address: true}})
+		})
+	})
+
+	t.Run("cast", func(t *testing.T) {
+		t.Run("not_found", func(t *testing.T) {
+			_, err := c.accessMemory(&cc.Expr{
+				Op: cc.Cast,
+				Left: &cc.Expr{
+					Op:   cc.Name,
+					Text: "not_found",
+				},
+			})
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to access memory for cast")
+		})
+
+		t.Run("(struct not_found *)(skb->head)", func(t *testing.T) {
+			expr, err := cc.ParseExpr("(struct not_found *)(skb->head)")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "failed to find type")
+		})
+
+		t.Run("(struct u64 *)(skb->head)", func(t *testing.T) {
+			expr, err := cc.ParseExpr("(struct u64 *)(skb->head)")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "expected struct/union type for cast")
+		})
+
+		t.Run("(union not_found *)(skb->head)", func(t *testing.T) {
+			expr, err := cc.ParseExpr("(union not_found *)(skb->head)")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "failed to find type")
+		})
+
+		t.Run("(union u64 *)(skb->head)", func(t *testing.T) {
+			expr, err := cc.ParseExpr("(union u64 *)(skb->head)")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "expected struct/union type for cast")
+		})
+
+		t.Run("(long long)skb->head", func(t *testing.T) {
+			expr, err := cc.ParseExpr("(long long)skb->head")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "failed to find type")
+		})
+
+		t.Run("(struct ethhdr *)(skb->head)", func(t *testing.T) {
+			expr, err := cc.ParseExpr("(struct ethhdr *)(skb->head)")
+			test.AssertNoErr(t, err)
+
+			eth, err := testBtf.AnyTypeByName("ethhdr")
+			test.AssertNoErr(t, err)
+
+			res, err := c.accessMemory(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.idx, 0)
+			test.AssertEqualSlice(t, res.offsets, []accessOffset{{offset: 200}})
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, &btf.Pointer{Target: eth}))
+		})
+
+		t.Run("(int)(skb->head)", func(t *testing.T) {
+			expr, err := cc.ParseExpr("(int)(skb->head)")
+			test.AssertNoErr(t, err)
+
+			u64, err := testBtf.AnyTypeByName("int")
+			test.AssertNoErr(t, err)
+
+			res, err := c.accessMemory(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.idx, 0)
+			test.AssertEqualSlice(t, res.offsets, []accessOffset{{offset: 200}})
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, u64))
+		})
+	})
+
+	t.Run("index", func(t *testing.T) {
+		t.Run("skb->cbx[3]", func(t *testing.T) {
+			expr, err := cc.ParseExpr("skb->cbx[3]")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "failed to access memory for index")
+		})
+
+		t.Run("skb->pkt_type[3]", func(t *testing.T) {
+			expr, err := cc.ParseExpr("skb->pkt_type[3]")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "disallow using bitfield for index")
+		})
+
+		t.Run("skb->cb[x]", func(t *testing.T) {
+			expr, err := cc.ParseExpr("skb->cb[x]")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "op of index expected number type")
+		})
+
+		t.Run("skb->cb[nan]", func(t *testing.T) {
+			expr, err := cc.ParseExpr("skb->cb[nan]")
+			test.AssertNoErr(t, err)
+
+			expr.Right.Op = cc.Number
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "failed to parse number")
+		})
+
+		t.Run("ops->data[0]", func(t *testing.T) {
+			expr, err := cc.ParseExpr("ops->data[0]")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "disallow indexing pointer of type")
+		})
+
+		t.Run("ops->arr[0]", func(t *testing.T) {
+			expr, err := cc.ParseExpr("ops->arr[0]")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "disallow indexing array of type")
+		})
+
+		t.Run("skb->len[3]", func(t *testing.T) {
+			expr, err := cc.ParseExpr("skb->len[3]")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "disallow indexing type")
+		})
+
+		t.Run("prog->aux->jit_data[0]", func(t *testing.T) {
+			expr, err := cc.ParseExpr("prog->aux->jit_data[0]")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "disallow indexing pointer of type")
+		})
+
+		t.Run("prog->aux->used_maps[1]", func(t *testing.T) {
+			expr, err := cc.ParseExpr("prog->aux->used_maps[1]")
+			test.AssertNoErr(t, err)
+
+			bpfMap, err := c.kernelBtf.AnyTypeByName("bpf_map")
+			test.AssertNoErr(t, err)
+
+			res, err := c.accessMemory(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.idx, 1)
+			test.AssertEqualSlice(t, res.offsets, []accessOffset{{offset: 56}, {offset: 824}, {offset: 8}})
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, &btf.Pointer{Target: bpfMap}))
+		})
+
+		t.Run("skb->cb[3]", func(t *testing.T) {
+			expr, err := cc.ParseExpr("skb->cb[3]")
+			test.AssertNoErr(t, err)
+
+			char, err := testBtf.AnyTypeByName("char")
+			test.AssertNoErr(t, err)
+
+			res, err := c.accessMemory(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.idx, 0)
+			test.AssertEqualSlice(t, res.offsets, []accessOffset{{offset: 40, address: true}, {offset: 3}})
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, char))
+		})
+	})
+
+	t.Run("indir", func(t *testing.T) {
+		t.Run("not_found", func(t *testing.T) {
+			_, err := c.accessMemory(&cc.Expr{
+				Op: cc.Indir,
+				Left: &cc.Expr{
+					Op:   cc.Name,
+					Text: "not_found",
+				},
+			})
+			test.AssertHaveErr(t, err)
+			test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+			test.AssertStrPrefix(t, err.Error(), "failed to access memory for indir")
+		})
+
+		t.Run("*(skb->pkt_type)", func(t *testing.T) {
+			expr, err := cc.ParseExpr("*(skb->pkt_type)")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "disallow indirecting bitfield")
+		})
+
+		t.Run("*(skb->len)", func(t *testing.T) {
+			expr, err := cc.ParseExpr("*(skb->len)")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "disallow indirecting type")
+		})
+
+		t.Run("*(skb->sk)", func(t *testing.T) {
+			expr, err := cc.ParseExpr("*(skb->sk)")
+			test.AssertNoErr(t, err)
+
+			sk, err := testBtf.AnyTypeByName("sock")
+			test.AssertNoErr(t, err)
+
+			res, err := c.accessMemory(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.idx, 0)
+			test.AssertEqualSlice(t, res.offsets, []accessOffset{{offset: 24}, {offset: 0}})
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, sk))
+		})
+	})
+
+	t.Run("sub", func(t *testing.T) {
+		t.Run("1 - skb->len", func(t *testing.T) {
+			expr, err := cc.ParseExpr("1 - skb->len")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "sub.right must be number")
+		})
+
+		t.Run("1 - nan", func(t *testing.T) {
+			expr, err := cc.ParseExpr("1 - nan")
+			test.AssertNoErr(t, err)
+
+			expr.Right.Op = cc.Number
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "failed to parse number of sub.right")
+		})
+
+		t.Run("1 - 1", func(t *testing.T) {
+			expr, err := cc.ParseExpr("1 - 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "failed to parse sub.left")
+		})
+
+		t.Run("skb->pkt_type - 1", func(t *testing.T) {
+			expr, err := cc.ParseExpr("skb->pkt_type - 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "disallow using bitfield for sub")
+		})
+
+		t.Run("ops->fn - 1", func(t *testing.T) {
+			expr, err := cc.ParseExpr("ops->fn - 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "disallow type")
+		})
+
+		t.Run("ops->arr - 1", func(t *testing.T) {
+			expr, err := cc.ParseExpr("ops->arr - 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "disallow type")
+		})
+
+		t.Run("skb->len - 1", func(t *testing.T) {
+			expr, err := cc.ParseExpr("skb->len - 1")
+			test.AssertNoErr(t, err)
+
+			_, err = c.accessMemory(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertStrPrefix(t, err.Error(), "disallow using non-{pointer,array} for sub")
+		})
+
+		t.Run("prog->aux->jit_data - 1", func(t *testing.T) {
+			expr, err := cc.ParseExpr("prog->aux->jit_data - 1")
+			test.AssertNoErr(t, err)
+
+			res, err := c.accessMemory(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.idx, 1)
+			test.AssertEqualSlice(t, res.offsets, []accessOffset{{offset: 56}, {offset: 176}, {offset: -1, address: true}})
+		})
+
+		t.Run("skb->cb - 1", func(t *testing.T) {
+			expr, err := cc.ParseExpr("skb->cb - 1")
+			test.AssertNoErr(t, err)
+
+			res, err := c.accessMemory(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.idx, 0)
+			test.AssertEqualSlice(t, res.offsets, []accessOffset{{offset: 40, address: true}, {offset: -1, address: true}})
+		})
+
+		t.Run("skb->sk - 1", func(t *testing.T) {
+			expr, err := cc.ParseExpr("skb->sk - 1")
+			test.AssertNoErr(t, err)
+
+			sk, err := testBtf.AnyTypeByName("sock")
+			test.AssertNoErr(t, err)
+			sizeofSk, _ := btf.Sizeof(sk)
+
+			res, err := c.accessMemory(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, res.idx, 0)
+			test.AssertEqualSlice(t, res.offsets, []accessOffset{{offset: 24}, {offset: -int64(sizeofSk), address: true}})
+			test.AssertTrue(t, reflect.DeepEqual(res.btf, &btf.Pointer{Target: sk}))
+		})
+	})
+
+	t.Run("skb->sk * 3", func(t *testing.T) {
+		expr, err := cc.ParseExpr("skb->sk * 3")
+		test.AssertNoErr(t, err)
+
+		_, err = c.accessMemory(expr)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "unsupported expression op")
+	})
+}
+
+func TestAccess(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("not_found->xxx", func(t *testing.T) {
+		expr, err := cc.ParseExpr("not_found->xxx")
+		test.AssertNoErr(t, err)
+
+		_, err = c.access(expr)
+		test.AssertTrue(t, errors.Is(err, ErrVarNotFound))
+	})
+
+	t.Run("skb->head no available register", func(t *testing.T) {
+		expr, err := cc.ParseExpr("skb->head")
+		test.AssertNoErr(t, err)
+
+		for i := range len(c.regalloc.registers) {
+			c.regalloc.registers[i] = true
+		}
+		defer c.reset()
+
+		_, err = c.access(expr)
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, ErrRegisterNotEnough))
+		test.AssertStrPrefix(t, err.Error(), "failed to alloc register")
+	})
+
+	t.Run("skb->head", func(t *testing.T) {
+		expr, err := cc.ParseExpr("skb->head")
+		test.AssertNoErr(t, err)
+
+		char, err := testBtf.AnyTypeByName("unsigned char")
+		test.AssertNoErr(t, err)
+
+		defer c.reset()
+
+		eval, err := c.access(expr)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, eval.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, eval.reg, asm.R8)
+		test.AssertTrue(t, reflect.DeepEqual(eval.btf, &btf.Pointer{Target: char}))
+		test.AssertFalse(t, isMemberBitfield(eval.mem))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+			asm.Mov.Reg(asm.R3, asm.R8),
+			asm.Add.Imm(asm.R3, 200),
+			asm.Mov.Imm(asm.R2, 8),
+			asm.Mov.Reg(asm.R1, asm.RFP),
+			asm.Add.Imm(asm.R1, -8),
+			asm.FnProbeReadKernel.Call(),
+			asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+		})
+	})
+
+	t.Run("skb->cb", func(t *testing.T) {
+		expr, err := cc.ParseExpr("skb->cb")
+		test.AssertNoErr(t, err)
+
+		char, err := testBtf.AnyTypeByName("char")
+		test.AssertNoErr(t, err)
+
+		intTyp, err := testBtf.AnyTypeByName("int")
+		test.AssertNoErr(t, err)
+
+		defer c.reset()
+
+		eval, err := c.access(expr)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, eval.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, eval.reg, asm.R8)
+		test.AssertTrue(t, reflect.DeepEqual(eval.btf, &btf.Array{
+			Index:  intTyp,
+			Type:   char,
+			Nelems: 48,
+		}))
+		test.AssertFalse(t, isMemberBitfield(eval.mem))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+			asm.Add.Imm(asm.R8, 40),
+		})
+	})
+
+	t.Run("skb->pkt_type", func(t *testing.T) {
+		expr, err := cc.ParseExpr("skb->pkt_type")
+		test.AssertNoErr(t, err)
+
+		defer c.reset()
+
+		eval, err := c.access(expr)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, eval.typ, evalValueTypeRegBtf)
+		test.AssertEqual(t, eval.reg, asm.R8)
+		test.AssertTrue(t, isMemberBitfield(eval.mem))
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.LoadMem(asm.R8, asm.R9, 0, asm.DWord),
+			asm.Mov.Reg(asm.R3, asm.R8),
+			asm.Add.Imm(asm.R3, 128),
+			asm.Mov.Imm(asm.R2, 8),
+			asm.Mov.Reg(asm.R1, asm.RFP),
+			asm.Add.Imm(asm.R1, -8),
+			asm.FnProbeReadKernel.Call(),
+			asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+			asm.And.Imm(asm.R8, 0x7),
+		})
+	})
+}
+
+func TestOffset2insns(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("no offsets", func(t *testing.T) {
+		c.offset2insns(nil, asm.R8)
+		test.AssertEmptySlice(t, c.insns)
+	})
+
+	t.Run("one offset with address", func(t *testing.T) {
+		defer c.reset()
+		c.offset2insns([]accessOffset{{offset: 4, address: true}}, asm.R8)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Add.Imm(asm.R8, 4),
+		})
+	})
+
+	t.Run("one offset", func(t *testing.T) {
+		defer c.reset()
+		c.offset2insns([]accessOffset{{offset: 4}}, asm.R8)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Mov.Reg(asm.R3, asm.R8),
+			asm.Add.Imm(asm.R3, 4),
+			asm.Mov.Imm(asm.R2, 8),
+			asm.Mov.Reg(asm.R1, asm.RFP),
+			asm.Add.Imm(asm.R1, -8),
+			asm.FnProbeReadKernel.Call(),
+			asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+		})
+	})
+
+	t.Run("multiple offsets", func(t *testing.T) {
+		defer c.reset()
+		c.offset2insns([]accessOffset{
+			{offset: 4},
+			{offset: 8},
+			{offset: 12, address: true},
+		}, asm.R8)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Mov.Reg(asm.R3, asm.R8),
+			asm.Add.Imm(asm.R3, 4),
+			asm.Mov.Imm(asm.R2, 8),
+			asm.Mov.Reg(asm.R1, asm.RFP),
+			asm.Add.Imm(asm.R1, -8),
+			asm.FnProbeReadKernel.Call(),
+			asm.LoadMem(asm.R3, asm.RFP, -8, asm.DWord),
+			asm.JEq.Imm(asm.R3, 0, c.labelExit),
+			asm.Add.Imm(asm.R3, 8),
+			asm.Mov.Imm(asm.R2, 8),
+			asm.Mov.Reg(asm.R1, asm.RFP),
+			asm.Add.Imm(asm.R1, -8),
+			asm.FnProbeReadKernel.Call(),
+			asm.LoadMem(asm.R3, asm.RFP, -8, asm.DWord),
+			asm.JEq.Imm(asm.R3, 0, c.labelExit),
+			asm.Add.Imm(asm.R3, 12),
+			asm.Mov.Reg(asm.R8, asm.R3),
+		})
+	})
+}
+
+func TestBitfield2insns(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("non-zero offset", func(t *testing.T) {
+		defer c.reset()
+		c.bitfield2insns(&btf.Member{
+			Offset:       4,
+			BitfieldSize: 3,
+		}, asm.R8)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.RSh.Imm(asm.R8, 4),
+			asm.And.Imm(asm.R8, 0x7),
+		})
+	})
+
+	t.Run("zero offset", func(t *testing.T) {
+		defer c.reset()
+		c.bitfield2insns(&btf.Member{
+			Offset:       0,
+			BitfieldSize: 3,
+		}, asm.R8)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.And.Imm(asm.R8, 0x7),
+		})
+	})
+}
+
+func TestAdjustRegisterBitwise(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("no btf", func(t *testing.T) {
+		var eval evalValue
+		eval.typ = evalValueTypeNum
+
+		err := c.adjustRegisterBitwise(eval)
+		test.AssertNoErr(t, err)
+		test.AssertEmptySlice(t, c.insns)
+	})
+
+	t.Run("invalid btf type", func(t *testing.T) {
+		var eval evalValue
+		eval.typ = evalValueTypeRegBtf
+		eval.btf = &btf.Func{}
+
+		err := c.adjustRegisterBitwise(eval)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "failed to get size of")
+		test.AssertEmptySlice(t, c.insns)
+	})
+
+	t.Run("char", func(t *testing.T) {
+		defer c.reset()
+
+		char, err := testBtf.AnyTypeByName("char")
+		test.AssertNoErr(t, err)
+
+		var eval evalValue
+		eval.typ = evalValueTypeRegBtf
+		eval.reg = asm.R8
+		eval.btf = char
+
+		err = c.adjustRegisterBitwise(eval)
+		test.AssertNoErr(t, err)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.And.Imm(asm.R8, 0xFF),
+		})
+	})
+
+	t.Run("u16", func(t *testing.T) {
+		defer c.reset()
+
+		u16, err := testBtf.AnyTypeByName("u16")
+		test.AssertNoErr(t, err)
+
+		var eval evalValue
+		eval.typ = evalValueTypeRegBtf
+		eval.reg = asm.R8
+		eval.btf = u16
+
+		err = c.adjustRegisterBitwise(eval)
+		test.AssertNoErr(t, err)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.And.Imm(asm.R8, 0xFFFF),
+		})
+	})
+
+	t.Run("u32", func(t *testing.T) {
+		defer c.reset()
+
+		u32, err := testBtf.AnyTypeByName("u32")
+		test.AssertNoErr(t, err)
+
+		var eval evalValue
+		eval.typ = evalValueTypeRegBtf
+		eval.reg = asm.R8
+		eval.btf = u32
+
+		err = c.adjustRegisterBitwise(eval)
+		test.AssertNoErr(t, err)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.LSh.Imm(asm.R8, 32),
+			asm.RSh.Imm(asm.R8, 32),
+		})
+	})
+
+	t.Run("u64", func(t *testing.T) {
+		defer c.reset()
+
+		u64, err := testBtf.AnyTypeByName("u64")
+		test.AssertNoErr(t, err)
+
+		var eval evalValue
+		eval.typ = evalValueTypeRegBtf
+		eval.reg = asm.R8
+		eval.btf = u64
+
+		err = c.adjustRegisterBitwise(eval)
+		test.AssertNoErr(t, err)
+		test.AssertEmptySlice(t, c.insns)
+	})
+
+	t.Run("unsupported size", func(t *testing.T) {
+		defer c.reset()
+
+		skb, err := testBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+
+		var eval evalValue
+		eval.typ = evalValueTypeRegBtf
+		eval.reg = asm.R8
+		eval.btf = skb
+
+		err = c.adjustRegisterBitwise(eval)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "unsupported size")
+		test.AssertEmptySlice(t, c.insns)
+	})
+}

--- a/internal/cc/number.go
+++ b/internal/cc/number.go
@@ -21,6 +21,13 @@ func parseUnsigned(text string) (uint64, error) {
 	if strings.HasPrefix(text, "0") && len(text) > 1 {
 		return strconv.ParseUint(text[1:], 8, 64)
 	}
+	if strings.HasPrefix(text, "'") {
+		if len(text) != 3 || text[2] != '\'' {
+			return 0, strconv.ErrSyntax
+		}
+
+		return uint64(text[1]), nil
+	}
 	return strconv.ParseUint(text, 10, 64)
 }
 

--- a/internal/cc/number.go
+++ b/internal/cc/number.go
@@ -1,0 +1,44 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import (
+	"strconv"
+	"strings"
+)
+
+func parseUnsigned(text string) (uint64, error) {
+	if strings.HasPrefix(text, "0x") {
+		return strconv.ParseUint(text[2:], 16, 64)
+	}
+	if strings.HasPrefix(text, "0o") {
+		return strconv.ParseUint(text[2:], 8, 64)
+	}
+	if strings.HasPrefix(text, "0b") {
+		return strconv.ParseUint(text[2:], 2, 64)
+	}
+	if strings.HasPrefix(text, "0") && len(text) > 1 {
+		return strconv.ParseUint(text[1:], 8, 64)
+	}
+	return strconv.ParseUint(text, 10, 64)
+}
+
+func parseNumber(text string) (int64, error) {
+	isMinus := strings.HasPrefix(text, "-")
+	if isMinus {
+		text = text[1:]
+	}
+	if strings.HasPrefix(text, "+") {
+		text = text[1:]
+	}
+
+	n, err := parseUnsigned(text)
+	if err != nil {
+		return 0, err
+	}
+	if isMinus {
+		return -int64(n), nil
+	}
+	return int64(n), nil
+}

--- a/internal/cc/number_test.go
+++ b/internal/cc/number_test.go
@@ -1,0 +1,64 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import (
+	"errors"
+	"strconv"
+	"testing"
+
+	"github.com/bpfsnoop/bpfsnoop/internal/test"
+)
+
+func TestParseUnsigned(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected uint64
+	}{
+		{"0x1", 1},
+		{"0o1", 1},
+		{"0b1", 1},
+		{"01", 1},
+		{"1", 1},
+		{"'a'", 97},
+		{"'A'", 65},
+	}
+
+	for _, tt := range tests {
+		result, err := parseUnsigned(tt.input)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, result, tt.expected)
+	}
+
+	t.Run("'a", func(t *testing.T) {
+		_, err := parseUnsigned("'a")
+		test.AssertHaveErr(t, err)
+		test.AssertTrue(t, errors.Is(err, strconv.ErrSyntax))
+	})
+}
+
+func TestParseNumber(t *testing.T) {
+	t.Run("-1", func(t *testing.T) {
+		result, err := parseNumber("-1")
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, result, -1)
+	})
+
+	t.Run("+1", func(t *testing.T) {
+		result, err := parseNumber("+1")
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, result, 1)
+	})
+
+	t.Run("1", func(t *testing.T) {
+		result, err := parseNumber("1")
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, result, 1)
+	})
+
+	t.Run("0xl", func(t *testing.T) {
+		_, err := parseNumber("0xl")
+		test.AssertHaveErr(t, err)
+	})
+}

--- a/internal/cc/register.go
+++ b/internal/cc/register.go
@@ -1,0 +1,39 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf/asm"
+)
+
+type RegisterAllocator struct {
+	registers [10]bool // r0 - r9
+}
+
+func (ra *RegisterAllocator) Alloc() (asm.Register, error) {
+	for i := int(asm.R8); i >= int(asm.R0); i-- {
+		if !ra.registers[i] {
+			ra.registers[i] = true
+			return asm.Register(i), nil
+		}
+	}
+
+	return asm.R0, ErrRegisterNotEnough
+}
+
+func (ra *RegisterAllocator) Free(reg asm.Register) {
+	if reg >= asm.R0 && reg <= asm.R9 {
+		ra.registers[reg] = false
+	}
+}
+
+func (ra *RegisterAllocator) IsUsed(reg asm.Register) bool {
+	if reg >= asm.R0 && reg <= asm.R9 {
+		return ra.registers[reg]
+	}
+
+	panic(fmt.Sprintf("register %d is out of range", reg))
+}

--- a/internal/cc/register_test.go
+++ b/internal/cc/register_test.go
@@ -1,0 +1,45 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import (
+	"testing"
+
+	"github.com/bpfsnoop/bpfsnoop/internal/test"
+	"github.com/cilium/ebpf/asm"
+)
+
+func (ra *RegisterAllocator) reset() {
+	for i := 0; i < len(ra.registers); i++ {
+		ra.registers[i] = false
+	}
+}
+
+func TestRegister(t *testing.T) {
+	var ra RegisterAllocator
+
+	t.Run("Free", func(t *testing.T) {
+		defer ra.reset()
+
+		ra.registers[asm.R9] = true
+		ra.Free(asm.R9)
+		test.AssertFalse(t, ra.registers[asm.R9])
+	})
+
+	t.Run("IsUsed", func(t *testing.T) {
+		defer ra.reset()
+
+		ra.registers[asm.R9] = true
+		test.AssertTrue(t, ra.IsUsed(asm.R9))
+		test.AssertFalse(t, ra.IsUsed(asm.R8))
+	})
+
+	t.Run("IsUsed panic", func(t *testing.T) {
+		defer ra.reset()
+
+		test.AssertPanic(t, func() {
+			ra.IsUsed(asm.R10)
+		})
+	})
+}

--- a/internal/cc/types.go
+++ b/internal/cc/types.go
@@ -1,0 +1,11 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+func bool2int(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/internal/cc/variable.go
+++ b/internal/cc/variable.go
@@ -1,0 +1,31 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import (
+	"fmt"
+
+	"golang.org/x/exp/slices"
+	"rsc.io/c2go/cc"
+)
+
+func ExtractVarNames(expr string) ([]string, error) {
+	e, err := cc.ParseExpr(expr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse expression: %w", err)
+	}
+
+	var names []string
+	cc.Walk(e, func(node cc.Syntax) {
+		if v, ok := node.(*cc.Expr); ok {
+			if v.Op == cc.Name {
+				names = append(names, v.Text)
+			}
+		}
+	}, func(node cc.Syntax) {})
+
+	slices.Sort(names)
+	names = slices.Compact(names)
+	return names, nil
+}

--- a/internal/cc/variable_test.go
+++ b/internal/cc/variable_test.go
@@ -1,0 +1,36 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import (
+	"testing"
+
+	"github.com/bpfsnoop/bpfsnoop/internal/test"
+)
+
+func TestExtractVarNames(t *testing.T) {
+	t.Run("parse expr", func(t *testing.T) {
+		_, err := ExtractVarNames("a ^^ b")
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "failed to parse expression")
+	})
+
+	t.Run("no var", func(t *testing.T) {
+		names, err := ExtractVarNames("1 > 2")
+		test.AssertNoErr(t, err)
+		test.AssertEmptySlice(t, names)
+	})
+
+	t.Run("one var", func(t *testing.T) {
+		names, err := ExtractVarNames("a > 2")
+		test.AssertNoErr(t, err)
+		test.AssertEqualSlice(t, names, []string{"a"})
+	})
+
+	t.Run("two vars", func(t *testing.T) {
+		names, err := ExtractVarNames("a > b")
+		test.AssertNoErr(t, err)
+		test.AssertEqualSlice(t, names, []string{"a", "b"})
+	})
+}

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -1,0 +1,89 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func AssertEqual[T comparable](t *testing.T, got, want T) {
+	t.Helper()
+	if got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func AssertEqualSlice[T comparable](t *testing.T, got, want []T) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	for i := range got {
+		if i >= len(want) {
+			break
+		}
+		if !reflect.DeepEqual(got[i], want[i]) {
+			t.Errorf("idx %d: got %v, want %v", i, got[i], want[i])
+			break
+		}
+	}
+}
+
+func AssertEmptySlice[T any](t *testing.T, got []T) {
+	t.Helper()
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty", got)
+	}
+}
+
+func AssertStrPrefix(t *testing.T, got, prefix string) {
+	t.Helper()
+	if !strings.HasPrefix(got, prefix) {
+		t.Errorf("got %v, want prefix %v", got, prefix)
+	}
+}
+
+func AssertTrue(t *testing.T, got bool) {
+	t.Helper()
+	if !got {
+		t.Errorf("got false, want true")
+	}
+}
+
+func AssertFalse(t *testing.T, got bool) {
+	t.Helper()
+	if got {
+		t.Errorf("got true, want false")
+	}
+}
+
+func AssertNoErr(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+		t.FailNow()
+	}
+}
+
+func AssertHaveErr(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Errorf("expected error, but got nil")
+		t.FailNow()
+	}
+}
+
+func AssertPanic(t *testing.T, f func()) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic, but got nil")
+		}
+	}()
+
+	f()
+}


### PR DESCRIPTION

It is to support complex C expression syntax in order to support complex filter condition.

The supported expression syntax includes:

1. Limited support for memory access via '.', '->', 'array[idx]',
   '& (get addr)' and '* (access data of pointer)'.
2. Bitwise and '&'.
3. Bool and '&&'.
4. Ternary condition '?:'.
5. Math div '/'.
6. Bool equal '=='.
7. Bool greater than '>'.
8. Bool greater than or equal '>='.
9. Bitwise left shift '<<'.
10. Bool less than '<'.
11. Bool less than or equal '<='.
12. Unary minus '-'.
13. Math mod '%'.
14. Math multi '*'.
15. Internal constants 'true', 'false' and 'NULL'.
16. Variable from function's arguments.
17. Unary bool not '!'.
18. Bool not equal '!='.
19. Constant number.
20. Bitwise or '|'.
21. Bool or '||'.
22. Parentheses '()'.
23. Unary plus '+'.
24. Pre-decrement '--'.
25. Pre-increment '++'.
26. Bitwise right shift '>>'.
27. Math sub '-'.
28. Bitwise twid '~'.
29. Bitwise xor '^'.

The priority of the operators follows the basic C syntax.