### PR TITLE
fnarg: Use insns from compiling result when output arg data

### DIFF
--- a/internal/bpfsnoop/output_arg.go
+++ b/internal/bpfsnoop/output_arg.go
@@ -81,8 +81,6 @@ func prepareFuncArgOutput(exprs []string) argDataOutput {
 }
 
 func (arg *funcArgumentOutput) compile(params []btf.FuncParam, spec *btf.Spec, offset int) (int, error) {
-	var insns asm.Instructions
-
 	res, err := cc.CompileEvalExpr(cc.CompileExprOptions{
 		Expr:          arg.expr,
 		Params:        params,
@@ -109,8 +107,9 @@ func (arg *funcArgumentOutput) compile(params []btf.FuncParam, spec *btf.Spec, o
 	}
 
 	dataSize := 16
+	insns := res.Insns
 	if !arg.isStr {
-		insns = append(res.Insns,
+		insns = append(insns,
 			asm.StoreMem(dataReg, int16(offset), res.Reg, asm.DWord),
 		)
 
@@ -135,7 +134,7 @@ func (arg *funcArgumentOutput) compile(params []btf.FuncParam, spec *btf.Spec, o
 			)
 		}
 		offset = 2 * maxOutputArgCnt * 8
-		insns = append(res.Insns,
+		insns = append(insns,
 			// R3 is ready to be used as a pointer to the string
 			asm.Mov.Imm(asm.R2, maxOutputStrLen),
 			asm.Mov.Reg(asm.R1, dataReg),

--- a/internal/bpfsnoop/output_arg.go
+++ b/internal/bpfsnoop/output_arg.go
@@ -83,7 +83,7 @@ func prepareFuncArgOutput(exprs []string) argDataOutput {
 func (arg *funcArgumentOutput) compile(params []btf.FuncParam, spec *btf.Spec, offset int) (int, error) {
 	var insns asm.Instructions
 
-	res, err := cc.EvalExpr(cc.CompileExprOptions{
+	res, err := cc.CompileEvalExpr(cc.CompileExprOptions{
 		Expr:          arg.expr,
 		Params:        params,
 		Spec:          spec,

--- a/internal/cc/expr.go
+++ b/internal/cc/expr.go
@@ -128,7 +128,7 @@ type EvalResult struct {
 	LabelUsed bool
 }
 
-func EvalExpr(opts CompileExprOptions) (EvalResult, error) {
+func CompileEvalExpr(opts CompileExprOptions) (EvalResult, error) {
 	var res EvalResult
 
 	if opts.Expr == "" || opts.LabelExit == "" {

--- a/internal/cc/expr_test.go
+++ b/internal/cc/expr_test.go
@@ -285,13 +285,13 @@ func TestCompile(t *testing.T) {
 
 func TestEvalExpr(t *testing.T) {
 	t.Run("empty expr", func(t *testing.T) {
-		_, err := EvalExpr(CompileExprOptions{})
+		_, err := CompileEvalExpr(CompileExprOptions{})
 		test.AssertHaveErr(t, err)
 		test.AssertStrPrefix(t, err.Error(), "expression and label exit cannot be empty")
 	})
 
 	t.Run("empty btf spec", func(t *testing.T) {
-		_, err := EvalExpr(CompileExprOptions{
+		_, err := CompileEvalExpr(CompileExprOptions{
 			Expr:      "skb->len == 0",
 			LabelExit: "__label_exit",
 			Spec:      nil,
@@ -301,7 +301,7 @@ func TestEvalExpr(t *testing.T) {
 	})
 
 	t.Run("compile expr failed", func(t *testing.T) {
-		_, err := EvalExpr(CompileExprOptions{
+		_, err := CompileEvalExpr(CompileExprOptions{
 			Expr:      "a ^^ b",
 			LabelExit: "__label_exit",
 			Spec:      testBtf,
@@ -321,7 +321,7 @@ func TestEvalExpr(t *testing.T) {
 	})
 
 	t.Run("eval failed", func(t *testing.T) {
-		_, err := EvalExpr(CompileExprOptions{
+		_, err := CompileEvalExpr(CompileExprOptions{
 			Expr:      "not_found->xxx == 0",
 			LabelExit: "__label_exit",
 			Spec:      testBtf,
@@ -342,7 +342,7 @@ func TestEvalExpr(t *testing.T) {
 	})
 
 	t.Run("constant value", func(t *testing.T) {
-		_, err := EvalExpr(CompileExprOptions{
+		_, err := CompileEvalExpr(CompileExprOptions{
 			Expr:          "1 > 2",
 			LabelExit:     "__label_exit",
 			Spec:          testBtf,
@@ -353,7 +353,7 @@ func TestEvalExpr(t *testing.T) {
 	})
 
 	t.Run("skb->len", func(t *testing.T) {
-		res, err := EvalExpr(CompileExprOptions{
+		res, err := CompileEvalExpr(CompileExprOptions{
 			Expr:          "skb->len",
 			LabelExit:     "__label_exit",
 			Spec:          testBtf,


### PR DESCRIPTION
It's to fix a code bug that ignore compiling result's insns when result's register is different from `asm.R3`.