### PR TITLE
fnarg: Use bpf_rdonly_cast() for 6.x+ kernels

### DIFF
--- a/internal/bpfsnoop/filter_arg.go
+++ b/internal/bpfsnoop/filter_arg.go
@@ -97,11 +97,18 @@ func (arg *funcArgument) matchParams(params []btf.FuncParam) bool {
 }
 
 func (arg *funcArgument) inject(prog *ebpf.ProgramSpec, spec *btf.Spec, params []btf.FuncParam) error {
+	mode := cc.MemoryReadModeProbeRead
+	if _, err := spec.AnyTypeByName("bpf_rdonly_cast"); err == nil {
+		mode = cc.MemoryReadModeCoreRead
+	}
+
 	insns, err := cc.CompileFilterExpr(cc.CompileExprOptions{
 		Expr:      arg.expr,
 		Params:    params,
 		Spec:      spec,
 		LabelExit: "__label_cc_exit",
+
+		MemoryReadMode: mode,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to compile expr '%s': %w", arg.expr, err)

--- a/internal/btfx/types.go
+++ b/internal/btfx/types.go
@@ -329,9 +329,9 @@ func reprValue(sb *strings.Builder, t btf.Type, isStr, isNumberPtr bool, data, d
 func ReprExprType(expr string, t btf.Type, mem *btf.Member, isStr, isNumberPtr bool, data, data2, dataNext uint64, s string, f FindSymbol) string {
 	var sb strings.Builder
 
-	fmt.Fprintf(&sb, "(%v)'%s'=", Repr(t), expr)
+	fmt.Fprintf(&sb, "(%s)'%s'=", Repr(t), expr)
 
-	if mem != nil {
+	if mem != nil && mem.BitfieldSize != 0 {
 		var memData [24]byte
 		*(*uint64)(unsafe.Pointer(&memData[0])) = data
 		*(*uint64)(unsafe.Pointer(&memData[8])) = data2

--- a/internal/cc/bpf_btf.go
+++ b/internal/cc/bpf_btf.go
@@ -4,7 +4,10 @@
 package cc
 
 import (
+	"fmt"
+
 	"github.com/Asphaltt/mybtf"
+	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/btf"
 )
 
@@ -15,5 +18,51 @@ func canCalculate(t btf.Type) bool {
 
 	default:
 		return false
+	}
+}
+
+func getPointerTypeID(spec *btf.Spec, t btf.Type, isStruct, isUnion bool) (btf.TypeID, error) {
+	if id, err := spec.TypeID(t); err == nil {
+		return id, nil
+	}
+
+	var typeName string
+	if isStruct {
+		typeName = t.(*btf.Struct).Name
+	} else if isUnion {
+		typeName = t.(*btf.Union).Name
+	}
+
+	iter := spec.Iterate()
+	for iter.Next() {
+		typ := iter.Type
+		if s, ok := typ.(*btf.Struct); ok && s.Name == typeName {
+			return spec.TypeID(typ)
+		}
+		if u, ok := typ.(*btf.Union); ok && u.Name == typeName {
+			return spec.TypeID(typ)
+		}
+	}
+
+	return 0, fmt.Errorf("failed to find pointer type for %v: %w", t, ErrBtfNotFound)
+}
+
+func sizeof(t btf.Type) (asm.Size, error) {
+	size, err := btf.Sizeof(t)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get size of %v: %w", t, err)
+	}
+
+	switch size {
+	case 1:
+		return asm.Byte, nil
+	case 2:
+		return asm.Half, nil
+	case 4:
+		return asm.Word, nil
+	case 8:
+		return asm.DWord, nil
+	default:
+		return asm.DWord, nil
 	}
 }

--- a/internal/cc/bpf_btf_test.go
+++ b/internal/cc/bpf_btf_test.go
@@ -1,0 +1,98 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import (
+	"testing"
+
+	"github.com/bpfsnoop/bpfsnoop/internal/test"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
+)
+
+func TestGetPointerTypeID(t *testing.T) {
+	t.Run("skb", func(t *testing.T) {
+		skb, err := testBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+		skbID, err := testBtf.TypeID(skb)
+		test.AssertNoErr(t, err)
+
+		id, err := getPointerTypeID(testBtf, skb, false, false)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, id, skbID)
+	})
+
+	t.Run("struct", func(t *testing.T) {
+		skb := &btf.Struct{
+			Name: "sk_buff",
+		}
+
+		__skb, err := testBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+		skbID, err := testBtf.TypeID(__skb)
+		test.AssertNoErr(t, err)
+
+		id, err := getPointerTypeID(testBtf, skb, true, false)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, id, skbID)
+	})
+
+	t.Run("union", func(t *testing.T) {
+		attr := &btf.Union{
+			Name: "bpf_attr",
+		}
+
+		__attr, err := testBtf.AnyTypeByName("bpf_attr")
+		test.AssertNoErr(t, err)
+		attrID, err := testBtf.TypeID(__attr)
+		test.AssertNoErr(t, err)
+
+		id, err := getPointerTypeID(testBtf, attr, false, true)
+		test.AssertNoErr(t, err)
+		test.AssertEqual(t, id, attrID)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		notFound := &btf.Struct{
+			Name: "not_found",
+		}
+
+		_, err := getPointerTypeID(testBtf, notFound, true, false)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "failed to find pointer type for")
+	})
+}
+
+func TestSizeof(t *testing.T) {
+	t.Run("failed to get size", func(t *testing.T) {
+		typ := &btf.FuncProto{}
+
+		_, err := sizeof(typ)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "failed to get size of")
+	})
+
+	u128, err := testBtf.AnyTypeByName("__u128")
+	test.AssertNoErr(t, err)
+
+	tests := []struct {
+		n string
+		t btf.Type
+		s asm.Size
+	}{
+		{"__u8", getU8Btf(t), asm.Byte},
+		{"__u16", getU16Btf(t), asm.Half},
+		{"__u32", getU32Btf(t), asm.Word},
+		{"__u64", getU64Btf(t), asm.DWord},
+		{"__u128", u128, asm.DWord},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.n, func(t *testing.T) {
+			s, err := sizeof(tt.t)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, s, tt.s)
+		})
+	}
+}

--- a/internal/cc/bpf_core_read.go
+++ b/internal/cc/bpf_core_read.go
@@ -1,0 +1,133 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import (
+	"fmt"
+
+	"github.com/Asphaltt/mybtf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
+)
+
+const kfuncBpfRdonlyCast = "bpf_rdonly_cast"
+
+func canRdonlyCast(spec *btf.Spec, t btf.Type) (bool, btf.TypeID, error) {
+	t = mybtf.UnderlyingType(t)
+	ptr, ok := t.(*btf.Pointer)
+	if !ok {
+		return false, 0, nil
+	}
+
+	t = mybtf.UnderlyingType(ptr.Target)
+	_, isStruct := t.(*btf.Struct)
+	_, isUnion := t.(*btf.Union)
+	if !isStruct && !isUnion {
+		return false, 0, nil
+	}
+
+	typID, err := getPointerTypeID(spec, t, isStruct, isUnion)
+	return err == nil, typID, err
+}
+
+func canReadByRdonlyCast(t btf.Type) bool {
+	switch mybtf.UnderlyingType(t).(type) {
+	case *btf.Pointer, *btf.Int, *btf.Enum:
+		return true
+	default:
+		return false
+	}
+}
+
+func bpfKfuncCall(id btf.TypeID) asm.Instruction {
+	return asm.Instruction{
+		OpCode:   asm.Call.Op(asm.ImmSource),
+		Src:      asm.PseudoKfuncCall,
+		Constant: int64(id),
+	}
+}
+
+func (c *compiler) coreReadOffsets(offsets []accessOffset, reg asm.Register) error {
+	typ, err := c.kernelBtf.AnyTypeByName(kfuncBpfRdonlyCast)
+	if err != nil {
+		return fmt.Errorf("failed to find kfunc %s: %w", kfuncBpfRdonlyCast, err)
+	}
+	fn, ok := typ.(*btf.Func)
+	if !ok {
+		return fmt.Errorf("%s should be a function", kfuncBpfRdonlyCast)
+	}
+
+	rdonlyCastID, err := c.kernelBtf.TypeID(fn)
+	if err != nil {
+		return fmt.Errorf("failed to get type ID for kfunc %s: %w", kfuncBpfRdonlyCast, err)
+	}
+
+	c.pushUsedCallerSavedRegs()
+	defer c.popUsedCallerSavedRegs()
+
+	immReg := asm.R1
+	if reg != immReg {
+		c.emit(asm.Mov.Reg(immReg, reg))
+	}
+
+	lastIdx := len(offsets) - 1
+	for i, offset := range offsets {
+		if offset.address {
+			if offset.offset != 0 {
+				c.emit(asm.Add.Imm(immReg, int32(offset.offset)))
+			}
+			if i == lastIdx && reg != immReg {
+				c.emit(asm.Mov.Reg(reg, immReg))
+			}
+			continue
+		}
+
+		canCast, typID, err := canRdonlyCast(c.kernelBtf, offset.prev)
+		if err != nil {
+			return fmt.Errorf("failed to check if %v can be bpf_rdonly_cast: %w", offset.prev, err)
+		}
+		if !canCast {
+			return fmt.Errorf("type %v cannot be bpf_rdonly_cast", offset.prev)
+		}
+
+		size, err := sizeof(offset.btf)
+		if err != nil {
+			return fmt.Errorf("failed to get size of btf type %v: %w", offset.btf, err)
+		}
+
+		if !canReadByRdonlyCast(offset.btf) || offset.inArray {
+			resReg := immReg
+			if i == lastIdx && reg != immReg {
+				resReg = reg
+			}
+			c.emit(
+				asm.Mov.Reg(asm.R3, immReg),  // r3 = r1
+				asm.Mov.Imm(asm.R2, 8),       // r2 = 8
+				asm.Mov.Reg(asm.R1, asm.RFP), // r1 = rfp
+				asm.Add.Imm(asm.R1, -8),      // r1 -= 8
+				asm.FnProbeReadKernel.Call(),
+				asm.LoadMem(resReg, asm.RFP, -8, asm.DWord), // immReg = *(u64 *)(rfp - 8)
+			)
+			continue
+		}
+
+		if i != lastIdx {
+			c.emit(
+				asm.Mov.Imm(asm.R2, int32(typID)), // r2 = type ID
+				bpfKfuncCall(rdonlyCastID),        // bpf_rdonly_cast(r1, r2)
+				asm.LoadMem(immReg, asm.R0, int16(offset.offset), size),
+				asm.JEq.Imm(immReg, 0, c.labelExit),
+			)
+			c.labelExitUsed = true
+		} else {
+			c.emit(
+				asm.Mov.Imm(asm.R2, int32(typID)), // r2 = type ID
+				bpfKfuncCall(rdonlyCastID),        // bpf_rdonly_cast(r1, r2)
+				asm.LoadMem(reg, asm.R0, int16(offset.offset), size),
+			)
+		}
+	}
+
+	return nil
+}

--- a/internal/cc/bpf_core_read_test.go
+++ b/internal/cc/bpf_core_read_test.go
@@ -1,0 +1,340 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import (
+	"encoding/binary"
+	"errors"
+	"sync"
+	"testing"
+	"unsafe"
+
+	"github.com/bpfsnoop/bpfsnoop/internal/test"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
+	"rsc.io/c2go/cc"
+)
+
+// immutableTypes is a set of types which musn't be changed.
+type immutableTypes struct {
+	// All types contained by the spec, not including types from the base in
+	// case the spec was parsed from split BTF.
+	types []btf.Type
+
+	// Type IDs indexed by type.
+	typeIDs map[btf.Type]btf.TypeID
+
+	// The ID of the first type in types.
+	firstTypeID btf.TypeID
+
+	// Types indexed by essential name.
+	// Includes all struct flavors and types with the same name.
+	namedTypes map[string][]btf.TypeID
+
+	// Byte order of the types. This affects things like struct member order
+	// when using bitfields.
+	byteOrder binary.ByteOrder
+}
+
+// mutableTypes is a set of types which may be changed.
+type mutableTypes struct {
+	imm           immutableTypes
+	mu            sync.RWMutex            // protects copies below
+	copies        map[btf.Type]btf.Type   // map[orig]copy
+	copiedTypeIDs map[btf.Type]btf.TypeID // map[copy]origID
+}
+
+// Spec allows querying a set of Types and loading the set into the
+// kernel.
+type Spec struct {
+	*mutableTypes
+
+	// String table from ELF.
+	strings uintptr
+}
+
+func TestCanRdonlyCast(t *testing.T) {
+	t.Run("int", func(t *testing.T) {
+		intTyp, err := testBtf.AnyTypeByName("int")
+		test.AssertNoErr(t, err)
+
+		ok, id, err := canRdonlyCast(testBtf, intTyp)
+		test.AssertFalse(t, ok)
+		test.AssertEqual(t, id, 0)
+		test.AssertNoErr(t, err)
+	})
+
+	t.Run("int *", func(t *testing.T) {
+		intTyp, err := testBtf.AnyTypeByName("int")
+		test.AssertNoErr(t, err)
+		intPtr := &btf.Pointer{Target: intTyp}
+
+		ok, id, err := canRdonlyCast(testBtf, intPtr)
+		test.AssertFalse(t, ok)
+		test.AssertEqual(t, id, 0)
+		test.AssertNoErr(t, err)
+	})
+
+	t.Run("struct sk_buff *", func(t *testing.T) {
+		skbTyp, err := testBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+		skbPtr := &btf.Pointer{Target: skbTyp}
+		skbID, err := testBtf.TypeID(skbTyp)
+		test.AssertNoErr(t, err)
+
+		ok, id, err := canRdonlyCast(testBtf, skbPtr)
+		test.AssertTrue(t, ok)
+		test.AssertEqual(t, id, skbID)
+		test.AssertNoErr(t, err)
+	})
+}
+
+func TestCanReadByRdonlyCast(t *testing.T) {
+	t.Run("fn", func(t *testing.T) {
+		fnTyp, err := testBtf.AnyTypeByName("bpf_rdonly_cast")
+		test.AssertNoErr(t, err)
+
+		ok := canReadByRdonlyCast(fnTyp)
+		test.AssertFalse(t, ok)
+	})
+
+	t.Run("int", func(t *testing.T) {
+		intTyp, err := testBtf.AnyTypeByName("int")
+		test.AssertNoErr(t, err)
+
+		ok := canReadByRdonlyCast(intTyp)
+		test.AssertTrue(t, ok)
+	})
+
+	t.Run("int *", func(t *testing.T) {
+		intTyp, err := testBtf.AnyTypeByName("int")
+		test.AssertNoErr(t, err)
+		intPtr := &btf.Pointer{Target: intTyp}
+
+		ok := canReadByRdonlyCast(intPtr)
+		test.AssertTrue(t, ok)
+	})
+
+	t.Run("struct sk_buff *", func(t *testing.T) {
+		skbTyp, err := testBtf.AnyTypeByName("sk_buff")
+		test.AssertNoErr(t, err)
+		skbPtr := &btf.Pointer{Target: skbTyp}
+
+		ok := canReadByRdonlyCast(skbPtr)
+		test.AssertTrue(t, ok)
+	})
+}
+
+func TestCoreReadOffsets(t *testing.T) {
+	c := prepareCompiler(t)
+
+	const reg = asm.R8
+
+	t.Run("bpf_rdonly_cast not found", func(t *testing.T) {
+		defer c.reset()
+
+		_, err := testBtf.AnyTypeByName(kfuncBpfRdonlyCast)
+		test.AssertNoErr(t, err)
+
+		spec := (*Spec)(unsafe.Pointer(c.kernelBtf))
+		ids := spec.mutableTypes.imm.namedTypes[kfuncBpfRdonlyCast]
+		delete(spec.mutableTypes.imm.namedTypes, kfuncBpfRdonlyCast)
+		defer func() { spec.mutableTypes.imm.namedTypes[kfuncBpfRdonlyCast] = ids }()
+
+		offsets := []accessOffset{
+			{address: false, offset: 4},
+			{address: false, offset: 8},
+		}
+
+		err = c.coreReadOffsets(offsets, reg)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "failed to find kfunc bpf_rdonly_cast")
+		test.AssertTrue(t, errors.Is(err, btf.ErrNotFound))
+	})
+
+	t.Run("bpf_rdonly_cast not a function", func(t *testing.T) {
+		defer c.reset()
+
+		_, err := testBtf.AnyTypeByName(kfuncBpfRdonlyCast)
+		test.AssertNoErr(t, err)
+
+		u64 := getU64Btf(t)
+		test.AssertNoErr(t, err)
+		u64ID, err := testBtf.TypeID(u64)
+		test.AssertNoErr(t, err)
+		u64Ptr := &btf.Struct{
+			Name: "bpf_rdonly_cast",
+		}
+
+		spec := (*Spec)(unsafe.Pointer(c.kernelBtf))
+		ids := spec.mutableTypes.imm.namedTypes[kfuncBpfRdonlyCast]
+		spec.mutableTypes.imm.namedTypes[kfuncBpfRdonlyCast] = []btf.TypeID{u64ID}
+		spec.mutableTypes.imm.types[u64ID] = u64Ptr
+		defer func() {
+			spec.mutableTypes.imm.namedTypes[kfuncBpfRdonlyCast] = ids
+			spec.mutableTypes.imm.types[u64ID] = u64
+		}()
+
+		offsets := []accessOffset{
+			{address: false, offset: 4},
+			{address: false, offset: 8},
+		}
+
+		err = c.coreReadOffsets(offsets, reg)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "bpf_rdonly_cast should be a function")
+	})
+
+	t.Run("bpf_rdonly_cast type ID not found", func(t *testing.T) {
+		defer c.reset()
+
+		rdonlyCast, err := testBtf.AnyTypeByName(kfuncBpfRdonlyCast)
+		test.AssertNoErr(t, err)
+
+		spec := (*Spec)(unsafe.Pointer(c.kernelBtf))
+		id := spec.mutableTypes.copiedTypeIDs[rdonlyCast]
+		delete(spec.mutableTypes.copiedTypeIDs, rdonlyCast)
+		defer func() { spec.mutableTypes.copiedTypeIDs[rdonlyCast] = id }()
+
+		offsets := []accessOffset{
+			{address: false, offset: 4},
+			{address: false, offset: 8},
+		}
+
+		err = c.coreReadOffsets(offsets, reg)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "failed to get type ID for kfunc bpf_rdonly_cast")
+		test.AssertTrue(t, errors.Is(err, btf.ErrNotFound))
+	})
+
+	t.Run("not_found btf", func(t *testing.T) {
+		defer c.reset()
+
+		notFound := &btf.Pointer{
+			Target: &btf.Struct{
+				Name: "not_found",
+			},
+		}
+		uintTyp, err := testBtf.AnyTypeByName("unsigned int")
+		test.AssertNoErr(t, err)
+
+		offsets := []accessOffset{
+			{prev: notFound, address: false, offset: 4},
+			{prev: uintTyp, address: false, offset: 8},
+		}
+
+		err = c.coreReadOffsets(offsets, reg)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "failed to check if")
+	})
+
+	t.Run("can't cast", func(t *testing.T) {
+		defer c.reset()
+
+		u64 := getU64Btf(t)
+
+		offsets := []accessOffset{
+			{prev: u64, address: false, offset: 4},
+		}
+
+		err := c.coreReadOffsets(offsets, reg)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), `type Typedef:"__u64"[Int:"long long unsigned int"] cannot be bpf_rdonly_cast`)
+	})
+
+	t.Run("skb->cb[2]", func(t *testing.T) {
+		defer c.reset()
+
+		expr, err := cc.ParseExpr("skb->cb[2]")
+		test.AssertNoErr(t, err)
+
+		res, err := c.accessMemory(expr)
+		test.AssertNoErr(t, err)
+
+		err = c.coreReadOffsets(res.offsets, reg)
+		test.AssertNoErr(t, err)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Mov.Reg(asm.R1, reg),
+			asm.Add.Imm(asm.R1, 40),
+			asm.Mov.Reg(asm.R3, asm.R1),
+			asm.Mov.Imm(asm.R2, 8),
+			asm.Mov.Reg(asm.R1, asm.RFP),
+			asm.Add.Imm(asm.R1, -8),
+			asm.FnProbeReadKernel.Call(),
+			asm.LoadMem(reg, asm.RFP, -8, asm.DWord),
+		})
+	})
+
+	t.Run("bad size", func(t *testing.T) {
+		defer c.reset()
+
+		skb := getSkbBtf(t)
+		fn := &btf.Func{
+			Name: "bpf_rdonly_cast",
+		}
+
+		offsets := []accessOffset{
+			{prev: skb, btf: fn, address: false, offset: 4},
+		}
+
+		err := c.coreReadOffsets(offsets, reg)
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "failed to get size of btf type")
+	})
+
+	t.Run("last is address", func(t *testing.T) {
+		defer c.reset()
+
+		skb := getSkbBtf(t)
+		dev := getNetDeviceBtf(t)
+		u64 := getU64Btf(t)
+
+		offsets := []accessOffset{
+			{prev: skb, btf: dev, address: false, offset: 4},
+			{prev: dev, btf: u64, address: true, offset: 8},
+		}
+
+		err := c.coreReadOffsets(offsets, reg)
+		test.AssertNoErr(t, err)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Mov.Reg(asm.R1, reg),
+			asm.Mov.Imm(asm.R2, 1875),
+			bpfKfuncCall(41126),
+			asm.LoadMem(asm.R1, asm.R0, 4, asm.DWord),
+			asm.JEq.Imm(asm.R1, 0, c.labelExit),
+			asm.Add.Imm(asm.R1, 8),
+			asm.Mov.Reg(reg, asm.R1),
+		})
+	})
+
+	t.Run("last is u64", func(t *testing.T) {
+		defer c.reset()
+
+		c.regalloc.registers[asm.R1] = true
+
+		skb := getSkbBtf(t)
+		dev := getNetDeviceBtf(t)
+		u64 := getU64Btf(t)
+
+		offsets := []accessOffset{
+			{prev: skb, btf: dev, address: false, offset: 4},
+			{prev: dev, btf: u64, address: false, offset: 8},
+		}
+
+		err := c.coreReadOffsets(offsets, reg)
+		test.AssertNoErr(t, err)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.StoreMem(asm.RFP, -16, asm.R1, asm.DWord),
+			asm.Mov.Reg(asm.R1, reg),
+			asm.Mov.Imm(asm.R2, 1875),
+			bpfKfuncCall(41126),
+			asm.LoadMem(asm.R1, asm.R0, 4, asm.DWord),
+			asm.JEq.Imm(asm.R1, 0, c.labelExit),
+			asm.Mov.Imm(asm.R2, 6973),
+			bpfKfuncCall(41126),
+			asm.LoadMem(reg, asm.R0, 8, asm.DWord),
+			asm.LoadMem(asm.R1, asm.RFP, -16, asm.DWord),
+		})
+	})
+}

--- a/internal/cc/bpf_direct_read.go
+++ b/internal/cc/bpf_direct_read.go
@@ -1,0 +1,26 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import "github.com/cilium/ebpf/asm"
+
+func (c *compiler) directReadOffsets(offsets []accessOffset, reg asm.Register) {
+	lastIdx := len(offsets) - 1
+	for i, offset := range offsets {
+		if offset.address {
+			if offset.offset != 0 {
+				c.emit(asm.Add.Imm(reg, int32(offset.offset)))
+			}
+		} else {
+			c.emit(
+				asm.LoadMem(reg, reg, int16(offset.offset), asm.DWord), // reg = *(reg + offset)
+			)
+			if i != lastIdx {
+				c.emit(
+					asm.JEq.Imm(reg, 0, c.labelExit), // if reg == 0 goto exit
+				)
+			}
+		}
+	}
+}

--- a/internal/cc/bpf_direct_read_test.go
+++ b/internal/cc/bpf_direct_read_test.go
@@ -1,0 +1,37 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf/asm"
+
+	"github.com/bpfsnoop/bpfsnoop/internal/test"
+)
+
+func TestDirectReadOffsets(t *testing.T) {
+	c := prepareCompiler(t)
+
+	const reg = asm.R8
+	c.directReadOffsets([]accessOffset{
+		{
+			offset:  4,
+			address: true,
+		},
+		{
+			offset: 8,
+		},
+		{
+			offset: 12,
+		},
+	}, reg)
+
+	test.AssertEqualSlice(t, c.insns, asm.Instructions{
+		asm.Add.Imm(reg, 4),
+		asm.LoadMem(reg, reg, 8, asm.DWord),
+		asm.JEq.Imm(reg, 0, c.labelExit),
+		asm.LoadMem(reg, reg, 12, asm.DWord),
+	})
+}

--- a/internal/cc/bpf_probe_read.go
+++ b/internal/cc/bpf_probe_read.go
@@ -1,0 +1,56 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import "github.com/cilium/ebpf/asm"
+
+func (c *compiler) probeReadOffsets(offsets []accessOffset, reg asm.Register) {
+	allAddress := offsets[0].address
+	for i := range offsets {
+		allAddress = allAddress && offsets[i].address
+	}
+	if allAddress {
+		for i := range offsets {
+			c.emit(asm.Add.Imm(reg, int32(offsets[i].offset)))
+		}
+		return
+	}
+
+	c.pushUsedCallerSavedRegs()
+	defer c.popUsedCallerSavedRegs()
+
+	if reg != asm.R3 {
+		c.emit(asm.Mov.Reg(asm.R3, reg))
+	}
+
+	lastIndex := len(offsets) - 1
+	for i, offset := range offsets {
+		if offset.offset != 0 {
+			c.emit(asm.Add.Imm(asm.R3, int32(offset.offset)))
+		}
+		if offset.address {
+			if i == lastIndex && reg != asm.R3 {
+				c.emit(asm.Mov.Reg(reg, asm.R3))
+			}
+			continue
+		}
+
+		c.emit(
+			asm.Mov.Imm(asm.R2, 8),       // r2 = 8; always read 8 bytes
+			asm.Mov.Reg(asm.R1, asm.RFP), // r1 = r10
+			asm.Add.Imm(asm.R1, -8),      // r1 = r10 - 8
+			asm.FnProbeReadKernel.Call(), // bpf_probe_read_kernel(r1, 8, r3)
+		)
+
+		if i != lastIndex {
+			c.labelExitUsed = true
+			c.emit(
+				asm.LoadMem(asm.R3, asm.RFP, -8, asm.DWord), // r3 = *(r10 - 8)
+				asm.JEq.Imm(asm.R3, 0, c.labelExit),
+			)
+		} else {
+			c.emit(asm.LoadMem(reg, asm.RFP, -8, asm.DWord))
+		}
+	}
+}

--- a/internal/cc/bpf_probe_read_test.go
+++ b/internal/cc/bpf_probe_read_test.go
@@ -1,0 +1,65 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import (
+	"testing"
+
+	"github.com/bpfsnoop/bpfsnoop/internal/test"
+	"github.com/cilium/ebpf/asm"
+)
+
+func TestProbeReadOffsets(t *testing.T) {
+	c := prepareCompiler(t)
+
+	t.Run("one offset with address", func(t *testing.T) {
+		defer c.reset()
+		c.probeReadOffsets([]accessOffset{{offset: 4, address: true}}, asm.R8)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Add.Imm(asm.R8, 4),
+		})
+	})
+
+	t.Run("one offset", func(t *testing.T) {
+		defer c.reset()
+		c.probeReadOffsets([]accessOffset{{offset: 4}}, asm.R8)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Mov.Reg(asm.R3, asm.R8),
+			asm.Add.Imm(asm.R3, 4),
+			asm.Mov.Imm(asm.R2, 8),
+			asm.Mov.Reg(asm.R1, asm.RFP),
+			asm.Add.Imm(asm.R1, -8),
+			asm.FnProbeReadKernel.Call(),
+			asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
+		})
+	})
+
+	t.Run("multiple offsets", func(t *testing.T) {
+		defer c.reset()
+		c.probeReadOffsets([]accessOffset{
+			{offset: 4},
+			{offset: 8},
+			{offset: 12, address: true},
+		}, asm.R8)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.Mov.Reg(asm.R3, asm.R8),
+			asm.Add.Imm(asm.R3, 4),
+			asm.Mov.Imm(asm.R2, 8),
+			asm.Mov.Reg(asm.R1, asm.RFP),
+			asm.Add.Imm(asm.R1, -8),
+			asm.FnProbeReadKernel.Call(),
+			asm.LoadMem(asm.R3, asm.RFP, -8, asm.DWord),
+			asm.JEq.Imm(asm.R3, 0, c.labelExit),
+			asm.Add.Imm(asm.R3, 8),
+			asm.Mov.Imm(asm.R2, 8),
+			asm.Mov.Reg(asm.R1, asm.RFP),
+			asm.Add.Imm(asm.R1, -8),
+			asm.FnProbeReadKernel.Call(),
+			asm.LoadMem(asm.R3, asm.RFP, -8, asm.DWord),
+			asm.JEq.Imm(asm.R3, 0, c.labelExit),
+			asm.Add.Imm(asm.R3, 12),
+			asm.Mov.Reg(asm.R8, asm.R3),
+		})
+	})
+}

--- a/internal/cc/error.go
+++ b/internal/cc/error.go
@@ -9,4 +9,5 @@ var (
 	ErrNotImplemented    = errors.New("not implemented")
 	ErrRegisterNotEnough = errors.New("not enough registers")
 	ErrVarNotFound       = errors.New("not found variable")
+	ErrBtfNotFound       = errors.New("not found btf type")
 )

--- a/internal/cc/eval.go
+++ b/internal/cc/eval.go
@@ -43,9 +43,11 @@ func (v evalValue) String() string {
 }
 
 func (c *compiler) emitReg2bool(reg asm.Register) {
-	c.emit(asm.Mov.Imm(reg, 1))
-	c.emit(Ja(1))
-	c.emit(asm.Xor.Reg(reg, reg))
+	c.emit(
+		asm.Mov.Imm(reg, 1),
+		Ja(1),
+		asm.Xor.Reg(reg, reg),
+	)
 }
 
 func (c *compiler) extractEnum(typ btf.Type, enum string) (int, error) {

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -33,6 +33,18 @@ func AssertEqualSlice[T comparable](t *testing.T, got, want []T) {
 	}
 }
 
+func AssertEqualSliceFn[T any](t *testing.T, got, want []T, fn func(t *testing.T, got, want T)) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("got %v, want %v", got, want)
+		return
+	}
+
+	for i := range got {
+		fn(t, got[i], want[i])
+	}
+}
+
 func AssertEmptySlice[T any](t *testing.T, got []T) {
 	t.Helper()
 	if len(got) != 0 {
@@ -86,4 +98,18 @@ func AssertPanic(t *testing.T, f func()) {
 	}()
 
 	f()
+}
+
+func AssertNil(t *testing.T, got any) {
+	t.Helper()
+	if got != nil {
+		t.Errorf("got %v, want nil", got)
+	}
+}
+
+func AssertNotNil(t *testing.T, got any) {
+	t.Helper()
+	if got == nil {
+		t.Errorf("got nil, want not nil")
+	}
 }


### PR DESCRIPTION
When `bpf_rdonly_cast()` kfunc is usable on 6.x+ kernels, it will be
used to replace `bpf_probe_read_kernel()` helper.

e.g. `--filter 'skb->dev->ifindex == 2'`, bpfsnoop is able to access `dev`
and `ifindex` directly.

```bash
$ echo "bpf_rdonly_cast() version"
$ bpftool p d x n bpfsnoop_fn
bool filter_arg(__u64 * args):
; filter_arg(__u64 *args)
 215: (bf) r9 = r1
 216: (79) r8 = *(u64 *)(r9 +0)
 217: (bf) r1 = r8
 218: (b7) r2 = 1875
 219: (bf) r0 = r1
 220: (79) r1 = *(u64 *)(r0 +16)
 221: (15) if r1 == 0x0 goto pc+8
 222: (b7) r2 = 6973
 223: (bf) r0 = r1
 224: (61) r8 = *(u32 *)(r0 +224)
 225: (67) r8 <<= 32
 226: (77) r8 >>= 32
 227: (55) if r8 != 0x2 goto pc+2
 228: (b7) r8 = 1
 229: (05) goto pc+1
 230: (af) r8 ^= r8
 231: (bf) r0 = r8
 232: (95) exit

$ echo "bpf_probe_read_kernel() version"
$ bpftool p d x n bpfsnoop_fn
bool filter_arg(__u64 * args):
; filter_arg(__u64 *args)
 215: (bf) r9 = r1
 216: (79) r8 = *(u64 *)(r9 +0)
 217: (bf) r3 = r8
 218: (07) r3 += 16
 219: (b7) r2 = 8
 220: (bf) r1 = r10
 221: (07) r1 += -8
 222: (85) call bpf_probe_read_kernel#-125280
 223: (79) r3 = *(u64 *)(r10 -8)
 224: (15) if r3 == 0x0 goto pc+11
 225: (07) r3 += 224
 226: (b7) r2 = 8
 227: (bf) r1 = r10
 228: (07) r1 += -8
 229: (85) call bpf_probe_read_kernel#-125280
 230: (79) r8 = *(u64 *)(r10 -8)
 231: (67) r8 <<= 32
 232: (77) r8 >>= 32
 233: (55) if r8 != 0x2 goto pc+2
 234: (b7) r8 = 1
 235: (05) goto pc+1
 236: (af) r8 ^= r8
 237: (bf) r0 = r8
 238: (95) exit
```