### PR TITLE
cc: Use fastcall bpf_rdonly_cast()

### DIFF
--- a/internal/cc/compiler.go
+++ b/internal/cc/compiler.go
@@ -1,0 +1,85 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
+)
+
+const (
+	kfuncBpfRdonlyCast = "bpf_rdonly_cast"
+	kfuncFastcall      = "bpf_fastcall"
+)
+
+type compiler struct {
+	regalloc RegisterAllocator
+	insns    asm.Instructions
+
+	vars []string
+	btfs []btf.Type
+
+	kernelBtf *btf.Spec
+
+	labelExit     string
+	labelExitUsed bool
+
+	reservedStack int
+
+	memMode MemoryReadMode
+
+	rdonlyCastTypeID   btf.TypeID
+	rdonlyCastFastcall bool
+}
+
+func newCompiler(opts CompileExprOptions) (*compiler, error) {
+	if opts.Expr == "" || opts.LabelExit == "" {
+		return nil, fmt.Errorf("expression and label exit cannot be empty")
+	}
+	if opts.Spec == nil {
+		return nil, fmt.Errorf("btf spec cannot be empty")
+	}
+
+	c := &compiler{
+		kernelBtf:     opts.Spec,
+		labelExit:     opts.LabelExit,
+		reservedStack: opts.ReservedStack,
+		memMode:       opts.MemoryReadMode,
+	}
+
+	c.vars = make([]string, len(opts.Params))
+	c.btfs = make([]btf.Type, len(opts.Params))
+	for i := range opts.Params {
+		c.vars[i] = opts.Params[i].Name
+		c.btfs[i] = opts.Params[i].Type
+	}
+
+	if c.reservedStack <= 0 {
+		c.reservedStack = 8
+	} else {
+		c.reservedStack = (c.reservedStack + 7) & -8 // align to 8 bytes
+	}
+
+	typ, err := opts.Spec.AnyTypeByName(kfuncBpfRdonlyCast)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find kfunc %s: %w", kfuncBpfRdonlyCast, err)
+	}
+	fn, ok := typ.(*btf.Func)
+	if !ok {
+		return nil, fmt.Errorf("%s should be a function", kfuncBpfRdonlyCast)
+	}
+
+	rdonlyCastID, err := opts.Spec.TypeID(fn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get type ID for kfunc %s: %w", kfuncBpfRdonlyCast, err)
+	}
+
+	c.rdonlyCastFastcall = slices.Contains(fn.Tags, kfuncFastcall)
+	c.rdonlyCastTypeID = rdonlyCastID
+
+	return c, nil
+}

--- a/internal/cc/compiler_test.go
+++ b/internal/cc/compiler_test.go
@@ -1,0 +1,144 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import (
+	"encoding/binary"
+	"errors"
+	"sync"
+	"testing"
+	"unsafe"
+
+	"github.com/bpfsnoop/bpfsnoop/internal/test"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
+)
+
+// immutableTypes is a set of types which musn't be changed.
+type immutableTypes struct {
+	// All types contained by the spec, not including types from the base in
+	// case the spec was parsed from split BTF.
+	types []btf.Type
+
+	// Type IDs indexed by type.
+	typeIDs map[btf.Type]btf.TypeID
+
+	// The ID of the first type in types.
+	firstTypeID btf.TypeID
+
+	// Types indexed by essential name.
+	// Includes all struct flavors and types with the same name.
+	namedTypes map[string][]btf.TypeID
+
+	// Byte order of the types. This affects things like struct member order
+	// when using bitfields.
+	byteOrder binary.ByteOrder
+}
+
+// mutableTypes is a set of types which may be changed.
+type mutableTypes struct {
+	imm           immutableTypes
+	mu            sync.RWMutex            // protects copies below
+	copies        map[btf.Type]btf.Type   // map[orig]copy
+	copiedTypeIDs map[btf.Type]btf.TypeID // map[copy]origID
+}
+
+// Spec allows querying a set of Types and loading the set into the
+// kernel.
+type Spec struct {
+	*mutableTypes
+
+	// String table from ELF.
+	strings uintptr
+}
+
+func TestNewCompiler(t *testing.T) {
+	const reg = asm.R8
+
+	opts := CompileExprOptions{
+		Expr:      "skb->len == 0",
+		LabelExit: "__label_exit",
+		Spec:      testBtf,
+	}
+
+	t.Run("empty expr", func(t *testing.T) {
+		_, err := newCompiler(CompileExprOptions{
+			Expr:      "",
+			LabelExit: "__label_exit",
+			Spec:      testBtf,
+		})
+		test.AssertHaveErr(t, err)
+		test.AssertErrorPrefix(t, err, "expression and label exit cannot be empty")
+	})
+
+	t.Run("empty btf spec", func(t *testing.T) {
+		_, err := newCompiler(CompileExprOptions{
+			Expr:      "skb->len == 0",
+			LabelExit: "__label_exit",
+			Spec:      nil,
+		})
+		test.AssertHaveErr(t, err)
+		test.AssertErrorPrefix(t, err, "btf spec cannot be empty")
+	})
+
+	t.Run("bpf_rdonly_cast not found", func(t *testing.T) {
+		_, err := testBtf.AnyTypeByName(kfuncBpfRdonlyCast)
+		test.AssertNoErr(t, err)
+
+		spec := (*Spec)(unsafe.Pointer(testBtf))
+		ids := spec.mutableTypes.imm.namedTypes[kfuncBpfRdonlyCast]
+		delete(spec.mutableTypes.imm.namedTypes, kfuncBpfRdonlyCast)
+		defer func() { spec.mutableTypes.imm.namedTypes[kfuncBpfRdonlyCast] = ids }()
+
+		_, err = newCompiler(opts)
+		test.AssertHaveErr(t, err)
+		test.AssertErrorPrefix(t, err, "failed to find kfunc bpf_rdonly_cast")
+		test.AssertTrue(t, errors.Is(err, btf.ErrNotFound))
+	})
+
+	t.Run("bpf_rdonly_cast not a function", func(t *testing.T) {
+		_, err := testBtf.AnyTypeByName(kfuncBpfRdonlyCast)
+		test.AssertNoErr(t, err)
+
+		u64 := getU64Btf(t)
+		test.AssertNoErr(t, err)
+		u64ID, err := testBtf.TypeID(u64)
+		test.AssertNoErr(t, err)
+		u64Ptr := &btf.Struct{
+			Name: "bpf_rdonly_cast",
+		}
+
+		spec := (*Spec)(unsafe.Pointer(testBtf))
+		ids := spec.mutableTypes.imm.namedTypes[kfuncBpfRdonlyCast]
+		spec.mutableTypes.imm.namedTypes[kfuncBpfRdonlyCast] = []btf.TypeID{u64ID}
+		spec.mutableTypes.imm.types[u64ID] = u64Ptr
+		defer func() {
+			spec.mutableTypes.imm.namedTypes[kfuncBpfRdonlyCast] = ids
+			spec.mutableTypes.imm.types[u64ID] = u64
+		}()
+
+		_, err = newCompiler(opts)
+		test.AssertHaveErr(t, err)
+		test.AssertErrorPrefix(t, err, "bpf_rdonly_cast should be a function")
+	})
+
+	t.Run("bpf_rdonly_cast type ID not found", func(t *testing.T) {
+		rdonlyCast, err := testBtf.AnyTypeByName(kfuncBpfRdonlyCast)
+		test.AssertNoErr(t, err)
+
+		spec := (*Spec)(unsafe.Pointer(testBtf))
+		id := spec.mutableTypes.copiedTypeIDs[rdonlyCast]
+		delete(spec.mutableTypes.copiedTypeIDs, rdonlyCast)
+		defer func() { spec.mutableTypes.copiedTypeIDs[rdonlyCast] = id }()
+
+		_, err = newCompiler(opts)
+		test.AssertHaveErr(t, err)
+		test.AssertErrorPrefix(t, err, "failed to get type ID for kfunc bpf_rdonly_cast")
+		test.AssertTrue(t, errors.Is(err, btf.ErrNotFound))
+	})
+
+	c, err := newCompiler(opts)
+	test.AssertNoErr(t, err)
+	test.AssertFalse(t, c.rdonlyCastFastcall)
+}


### PR DESCRIPTION
Since torvalds/linux@da7d71b ("bpf: Use KF_FASTCALL to mark kfuncs supporting fastcall contract"), `bpf_rdonly_cast()` kfunc has been marked with flag `KF_FASTCALL`, which means the unused registers R3, R4 and R5 won't be volatile after calling `bpf_rdonly_cast()` kfunc.