### PR TITLE
disasm: Parsing vmlinux dbgsym and bpf progs info concurrently

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,10 +11,11 @@ require (
 	github.com/cilium/ebpf v0.17.4-0.20250310175843-23a70a77897a
 	github.com/fatih/color v1.18.0
 	github.com/gobwas/glob v0.2.3
-	github.com/hashicorp/golang-lru/v2 v2.0.7
+	github.com/goccy/go-json v0.10.5
 	github.com/jschwinger233/elibpcap v1.0.1
 	github.com/klauspost/compress v1.17.11
 	github.com/spf13/pflag v1.0.5
+	github.com/ulikunitz/xz v0.5.12
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	golang.org/x/sync v0.8.0
 	rsc.io/c2go v0.0.0-20170620140410-520c22818a08

--- a/go.sum
+++ b/go.sum
@@ -14,10 +14,10 @@ github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6 h1:teYtXy9B7y5
 github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
+github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
+github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
-github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/ianlancetaylor/demangle v0.0.0-20240912202439-0a2b6291aafd h1:EVX1s+XNss9jkRW9K6XGJn2jL2lB1h5H804oKPsxOec=
 github.com/ianlancetaylor/demangle v0.0.0-20240912202439-0a2b6291aafd/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
 github.com/josharian/native v1.1.0 h1:uuaP0hAbW7Y4l0ZRQ6C9zfb7Mg1mbFKry/xzDAfmtLA=
@@ -47,6 +47,8 @@ github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/ulikunitz/xz v0.5.12 h1:37Nm15o69RwBkXM0J6A5OlE67RZTfzUxTj8fB3dfcsc=
+github.com/ulikunitz/xz v0.5.12/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c h1:7dEasQXItcW1xKJ2+gg5VOiBnqWrJc+rq0DPKyvvdbY=
 golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c/go.mod h1:NQtJDoLvd6faHhE7m4T/1IY708gDefGGjR/iUW8yQQ8=
 golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=

--- a/internal/bpfsnoop/addr2line_cache.go
+++ b/internal/bpfsnoop/addr2line_cache.go
@@ -1,0 +1,142 @@
+// Copyright 2024 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package bpfsnoop
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"github.com/Asphaltt/addr2line"
+	"github.com/goccy/go-json"
+	"github.com/ulikunitz/xz"
+)
+
+const (
+	dbgsymCacheFile = "dbgsym.json.xz"
+
+	cacheBatchLimit = 30
+)
+
+type dbgsymCacheData struct {
+	Entries map[uintptr]*addr2line.Addr2LineEntry `json:"entries"`
+}
+
+type dbgsymCache struct {
+	newEntriesCnt int
+
+	cacheFile string
+
+	cache map[uintptr]*addr2line.Addr2LineEntry
+}
+
+func newDbgsymCache() (*dbgsymCache, error) {
+	user, err := user.Current()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current user: %w", err)
+	}
+
+	var d dbgsymCache
+	cacheDir := filepath.Join(user.HomeDir, ".cache", "bpfsnoop")
+	_ = os.MkdirAll(cacheDir, 0x666)
+	d.cacheFile = filepath.Join(cacheDir, dbgsymCacheFile)
+
+	err = d.loadFile()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load dbgsym cache: %w", err)
+	}
+
+	return &d, nil
+}
+
+func (d *dbgsymCache) loadFile() error {
+	if !fileExists(d.cacheFile) {
+		d.cache = make(map[uintptr]*addr2line.Addr2LineEntry)
+		return nil
+	}
+
+	fd, err := os.Open(d.cacheFile)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", d.cacheFile, err)
+	}
+	defer fd.Close()
+
+	r, err := xz.NewReader(fd)
+	if err != nil {
+		return fmt.Errorf("failed to new xz reader: %w", err)
+	}
+
+	var entries dbgsymCacheData
+	err = json.NewDecoder(r).Decode(&entries)
+	if err != nil {
+		return fmt.Errorf("failed to json decode: %w", err)
+	}
+
+	d.cache = entries.Entries
+	return nil
+}
+
+func (d *dbgsymCache) saveFile() error {
+	entries := dbgsymCacheData{
+		Entries: d.cache,
+	}
+
+	fd, err := os.CreateTemp(filepath.Dir(d.cacheFile), "dbgsym-*.json.xz")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer os.Remove(fd.Name()) // ignore error as it has been renamed.
+	defer fd.Close()
+
+	w, err := xz.NewWriter(fd)
+	if err != nil {
+		return fmt.Errorf("failed to new xz writer: %w", err)
+	}
+
+	err = json.NewEncoder(w).Encode(entries)
+	if err != nil {
+		return fmt.Errorf("failed to json encode: %w", err)
+	}
+
+	err = w.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close xz writer: %w", err)
+	}
+
+	err = fd.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close file: %w", err)
+	}
+
+	err = os.Rename(fd.Name(), d.cacheFile)
+	if err != nil {
+		return fmt.Errorf("failed to rename temp file to %s: %w", d.cacheFile, err)
+	}
+
+	return nil
+}
+
+func (d *dbgsymCache) get(addr uintptr) (*addr2line.Addr2LineEntry, bool) {
+	entry, ok := d.cache[addr]
+	return entry, ok
+}
+
+func (d *dbgsymCache) add(addr uintptr, entry *addr2line.Addr2LineEntry) error {
+	if _, ok := d.cache[addr]; ok {
+		return nil
+	}
+
+	d.cache[addr] = entry
+	d.newEntriesCnt++
+
+	if d.newEntriesCnt%cacheBatchLimit == 0 {
+		err := d.saveFile()
+		if err != nil {
+			return fmt.Errorf("failed to save dbgsym cache: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/bpfsnoop/bpf_prog.go
+++ b/internal/bpfsnoop/bpf_prog.go
@@ -8,9 +8,15 @@ import (
 
 	"github.com/cilium/ebpf"
 	"golang.org/x/exp/maps"
+
+	"github.com/bpfsnoop/bpfsnoop/internal/assert"
 )
 
 type bpfProgs struct {
+	ready bool
+	err   error
+	done  chan struct{}
+
 	progs map[ebpf.ProgramID]*ebpf.Program     // ID -> prog
 	infos map[ebpf.ProgramID]*ebpf.ProgramInfo // ID -> prog info
 	funcs map[uintptr]*bpfProgFuncInfo         // func IP -> prog func info
@@ -22,8 +28,9 @@ type bpfProgs struct {
 	disasm bool // disassemble BPF programs instead of tracing them
 }
 
-func NewBPFProgs(pflags []ProgFlag, onlyPrepare, disasm bool) (*bpfProgs, error) {
+func NewBPFProgs(pflags []ProgFlag, noParseProgs, disasm bool) (*bpfProgs, error) {
 	var progs bpfProgs
+	progs.done = make(chan struct{})
 	progs.progs = make(map[ebpf.ProgramID]*ebpf.Program, len(pflags))
 	progs.infos = make(map[ebpf.ProgramID]*ebpf.ProgramInfo, len(pflags))
 	progs.funcs = make(map[uintptr]*bpfProgFuncInfo, len(pflags))
@@ -47,17 +54,23 @@ func NewBPFProgs(pflags []ProgFlag, onlyPrepare, disasm bool) (*bpfProgs, error)
 		return nil, fmt.Errorf("failed to prepare BPF program infos: %w", err)
 	}
 
-	if onlyPrepare {
-		return &progs, nil
-	}
-
-	for id, prog := range progs.progs {
-		if err := progs.addProg(prog, id, nil, false); err != nil {
-			return nil, err
-		}
+	if !noParseProgs {
+		go progs.parseProgs()
 	}
 
 	return &progs, nil
+}
+
+func (b *bpfProgs) parseProgs() {
+	for id, prog := range b.progs {
+		if err := b.addProg(prog, id, nil, false); err != nil {
+			b.err = err
+			break
+		}
+	}
+
+	close(b.done)
+	b.ready = true
 }
 
 func (b *bpfProgs) addProg(prog *ebpf.Program, id ebpf.ProgramID, info *ebpf.ProgramInfo, isBpfsnoop bool) error {
@@ -104,7 +117,20 @@ func (b *bpfProgs) Tracings() []bpfTracingInfo {
 	return maps.Values(b.tracings)
 }
 
+func (b *bpfProgs) wait() error {
+	if !b.ready {
+		<-b.done
+	}
+
+	return b.err
+}
+
 func (b *bpfProgs) get(addr uintptr) (*bpfProgLineInfo, bool) {
+	if err := b.wait(); err != nil {
+		assert.NoErr(err, "Failed to parse bpf progs info: %w")
+		return nil, false
+	}
+
 	for _, info := range b.funcs {
 		if li, ok := info.get(addr); ok {
 			return li, true
@@ -115,6 +141,11 @@ func (b *bpfProgs) get(addr uintptr) (*bpfProgLineInfo, bool) {
 }
 
 func (b *bpfProgs) contains(addr uintptr) bool {
+	if err := b.wait(); err != nil {
+		assert.NoErr(err, "Failed to parse bpf progs info: %w")
+		return false
+	}
+
 	for _, info := range b.funcs {
 		if info.contains(addr) {
 			return true

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -4,6 +4,7 @@
 package test
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -89,6 +90,21 @@ func AssertHaveErr(t *testing.T, err error) {
 	if err == nil {
 		t.Errorf("expected error, but got nil")
 		t.FailNow()
+	}
+}
+
+func AssertIsErr(t *testing.T, err, want error) {
+	t.Helper()
+	if err == nil {
+		t.Errorf("expected error, but got nil")
+		return
+	}
+	if want == nil {
+		t.Errorf("expected non-nil error, but got %v", err)
+		return
+	}
+	if !errors.Is(err, want) {
+		t.Errorf("got %v, want %v", err, want)
 	}
 }
 

--- a/makefiles/variables.mk
+++ b/makefiles/variables.mk
@@ -25,7 +25,7 @@ BPFSNOOP_BPF_OBJ := bpfsnoop_bpfel.o bpfsnoop_bpfeb.o
 BPFSNOOP_BPF_SRC := bpf/bpfsnoop.c $(wildcard bpf/*.h) $(wildcard bpf/headers/*.h)
 
 INSN_BPF_OBJ := insn_bpfel.o insn_bpfeb.o
-INSN_BPF_SRC := bpf/bpfsnoop_insn.c
+INSN_BPF_SRC := bpf/bpfsnoop_insn.c bpf/bpfsnoop_event.h bpf/bpfsnoop_sess.h
 
 FEAT_BPF_OBJ := feat_bpfel.o feat_bpfeb.o
 FEAT_BPF_SRC := bpf/feature.c


### PR DESCRIPTION
It's to accelerate starting `bpfsnoop`.

## vmlinux dbgsym

1. Parse vmlinux ELF file in a standalone goroutine.
2. Cache the queried addr2line entries to local file `$HOME/.cache/bpfsnoop/dbgsym.json.xz`.

## bpf progs info

1. Parse bpf prog info in standalone goroutine for each bpf prog.