### PR TITLE
makefile: Avoid building capstone,libpcap always

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,18 +5,17 @@ include makefiles/variables.mk
 
 .DEFAULT_GOAL := $(BPFSNOOP_OBJ)
 
-.PHONY: git_submodules
-git_submodules:
-	@if [[ ! -d .git/modules ]]; then git submodule update --init --force --recursive; fi
+$(GIT_MODULES_DIR):
+	@$(CMD_GIT_MODULES) update --init --force --recursive
 
 # Build libcapstone for static linking
-$(LIBCAPSTONE_OBJ): git_submodules
+$(LIBCAPSTONE_OBJ): $(GIT_MODULES_DIR)
 	cd lib/capstone && \
 		CC=$(CMD_CC) CXX=$(CMD_CXX) cmake -B build -DCMAKE_BUILD_TYPE=Release -DCAPSTONE_ARCHITECTURE_DEFAULT=1 -DCAPSTONE_BUILD_CSTOOL=0 -DCMAKE_C_FLAGS="-Qunused-arguments" && \
 		cmake --build build
 
 # Build libpcap for static linking
-$(LIBPCAP_OBJ): git_submodules
+$(LIBPCAP_OBJ): $(GIT_MODULES_DIR)
 	cd lib/libpcap && \
 		./autogen.sh && \
 		CC=$(CMD_CC) CXX=$(CMD_CXX) ./configure --disable-rdma --disable-shared --disable-usb --disable-netmap --disable-bluetooth --disable-dbus --without-libnl && \
@@ -49,7 +48,7 @@ $(INSN_BPF_OBJ): $(INSN_BPF_SRC) $(VMLINUX_OBJ)
 $(BPFSNOOP_BPF_OBJ): $(BPFSNOOP_BPF_SRC) $(VMLINUX_OBJ)
 	$(BPF2GO) bpfsnoop bpf/bpfsnoop.c -- $(BPF2GO_EXTRA_FLAGS)
 
-$(BPFSNOOP_OBJ): $(BPF_OBJS) $(BPFSNOOP_SRC) $(LIBCAPSTONE_OBJ) $(LIBPCAP_OBJ) git_submodules
+$(BPFSNOOP_OBJ): $(BPF_OBJS) $(BPFSNOOP_SRC) $(LIBCAPSTONE_OBJ) $(LIBPCAP_OBJ)
 	$(GOBUILD_CGO_CFLAGS) $(GOBUILD_CGO_LDFLAGS) $(GOBUILD)
 
 .PHONY: local_release

--- a/makefiles/variables.mk
+++ b/makefiles/variables.mk
@@ -11,6 +11,8 @@ CMD_CXX ?= clang++
 CMD_GH ?= gh
 CMD_MV ?= mv
 CMD_TAR ?= tar
+CMD_GIT ?= git
+CMD_GIT_MODULES ?= $(CMD_GIT) submodule
 
 DIR_BIN := ./bin
 
@@ -64,3 +66,5 @@ LIBCAPSTONE_OBJ := lib/capstone/build/libcapstone.a
 LIBPCAP_OBJ := lib/libpcap/libpcap.a
 
 VMLINUX_OBJ := $(CURDIR)/bpf/headers/vmlinux.h
+
+GIT_MODULES_DIR := .git/modules


### PR DESCRIPTION
The issue, building capstone and libpcap for every time no matter whether they are updated, was introduced by
commit 7338d326d2a0 ("makefile: Update git submodules on demand").