### PR TITLE
kfuncs: Try to find kmods 

### DIFF
--- a/internal/bpfsnoop/bpf_feature.go
+++ b/internal/bpfsnoop/bpf_feature.go
@@ -32,6 +32,9 @@ func DetectBPFFeatures(spec *ebpf.CollectionSpec) error {
 		Program:    prog,
 		AttachType: ebpf.AttachTraceFEntry,
 	})
+	if err != nil {
+		return fmt.Errorf("failed to fentry nanosleep: %w", err)
+	}
 	defer l.Close()
 
 	nanosleep()

--- a/internal/bpfsnoop/bpf_kfuncs.go
+++ b/internal/bpfsnoop/bpf_kfuncs.go
@@ -56,6 +56,9 @@ func detectTraceable(spec *ebpf.CollectionSpec, addrs []uintptr) ([]uintptr, err
 		Program:    prog,
 		AttachType: ebpf.AttachTraceFEntry,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fentry nanosleep: %w", err)
+	}
 	defer l.Close()
 
 	nanosleep()

--- a/internal/bpfsnoop/bpf_prog.go
+++ b/internal/bpfsnoop/bpf_prog.go
@@ -136,7 +136,7 @@ func (b *bpfProgs) wait() error {
 
 func (b *bpfProgs) get(addr uintptr) (*bpfProgLineInfo, bool) {
 	if err := b.wait(); err != nil {
-		assert.NoErr(err, "Failed to parse bpf progs info: %w")
+		assert.NoErr(err, "Failed to parse bpf progs info: %v")
 		return nil, false
 	}
 
@@ -151,7 +151,7 @@ func (b *bpfProgs) get(addr uintptr) (*bpfProgLineInfo, bool) {
 
 func (b *bpfProgs) contains(addr uintptr) bool {
 	if err := b.wait(); err != nil {
-		assert.NoErr(err, "Failed to parse bpf progs info: %w")
+		assert.NoErr(err, "Failed to parse bpf progs info: %v")
 		return false
 	}
 

--- a/internal/bpfsnoop/bpf_read_kernel.go
+++ b/internal/bpfsnoop/bpf_read_kernel.go
@@ -49,6 +49,9 @@ func readKernel(spec *ebpf.CollectionSpec, addr uint64, size uint32) ([]byte, er
 		Program:    prog,
 		AttachType: ebpf.AttachTraceFEntry,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fentry nanosleep: %w", err)
+	}
 	defer l.Close()
 
 	nanosleep()

--- a/internal/bpfsnoop/bpf_read_kernel.go
+++ b/internal/bpfsnoop/bpf_read_kernel.go
@@ -64,8 +64,8 @@ func readKernel(spec *ebpf.CollectionSpec, addr uint64, size uint32) ([]byte, er
 		return nil, errors.New("reading kernel was not triggered")
 	}
 
-	if err := coll.Variables["buff"].Get(&buff); err != nil {
-		return nil, fmt.Errorf("failed to get buff: %w", err)
+	if err := coll.Maps[".data.buff"].Lookup(uint32(0), buff); err != nil {
+		return nil, fmt.Errorf("failed to lookup .data.buff: %w", err)
 	}
 
 	return buff[:size], nil

--- a/internal/bpfsnoop/bpf_tracepoints.go
+++ b/internal/bpfsnoop/bpf_tracepoints.go
@@ -56,6 +56,9 @@ func probeTracepointInfos(spec *ebpf.CollectionSpec, start uint64, cnt uint32) (
 		Program:    prog,
 		AttachType: ebpf.AttachTraceFEntry,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fentry nanosleep: %w", err)
+	}
 	defer l.Close()
 
 	nanosleep()

--- a/internal/bpfsnoop/bpf_tracepoints_module.go
+++ b/internal/bpfsnoop/bpf_tracepoints_module.go
@@ -58,7 +58,7 @@ func probeTracepointModuleInfos(spec, tpSpec *ebpf.CollectionSpec, head, start u
 		AttachType: ebpf.AttachTraceFEntry,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach tracing: %w", err)
+		return nil, fmt.Errorf("failed to fentry nanosleep: %w", err)
 	}
 	defer l.Close()
 

--- a/internal/bpfsnoop/disasm.go
+++ b/internal/bpfsnoop/disasm.go
@@ -121,8 +121,15 @@ func parseDisasmKfunc(kfunc string, kmods []string, ksyms *Kallsyms, a2l *Addr2L
 		return entry.addr, entry.name
 	}
 
+	if ksym, ok := ksyms.findBySymbol(kfunc); ok && ksym.mod != "" {
+		kmods = []string{ksym.mod}
+	} else {
+		kmods, err = inferenceKfuncKmods([]string{kfunc}, kfuncKmods, ksyms)
+		assert.NoErr(err, "Failed to inference kernel modules for kfunc %s: %v", kfunc)
+	}
+
 	// kfunc may be a glob filter
-	kfuncs, _ := FindKernelFuncs([]string{kfunc}, ksyms, 0xFF)
+	kfuncs, _ := searchKernelFuncs([]string{kfunc}, kmods, ksyms, 0xFF)
 	if len(kfuncs) != 0 {
 		// grab the very first one sorted by name
 		values := maps.Values(kfuncs)

--- a/internal/bpfsnoop/disasm.go
+++ b/internal/bpfsnoop/disasm.go
@@ -79,7 +79,7 @@ func findDisasmKfuncInKmods(kfunc string, kaddr uint64, kmods []string, a2l *Add
 
 	for _, kmodName := range kmods {
 		err := a2l.addKmod(kmodName)
-		assert.NoErr(err, "Failed to parse addr2line of kmod %s: %v", kmodName, err)
+		assert.NoErr(err, "Failed to parse addr2line of kmod %s: %v", kmodName)
 
 		kmod := a2l.kmods[kmodName]
 		var entry *addr2line.Addr2LineEntry
@@ -171,7 +171,7 @@ func dumpKfunc(kfunc string, kmods []string, bytes uint, readSpec *ebpf.Collecti
 	bytes = guessBytes(uintptr(kaddr), kallsyms, bytes)
 	assert.False(bytes > readLimit, "Disasm bytes %d is larger than limit %d", bytes, readLimit)
 	data, err := readKernel(readSpec, kaddr, uint32(bytes))
-	assert.NoErr(err, "Failed to read kernel memory: %v", err)
+	assert.NoErr(err, "Failed to read kernel memory: %v")
 
 	data = trimTailingInsns(data)
 	log.Printf("Disassembling %s at %s (%d bytes) ..",
@@ -179,7 +179,7 @@ func dumpKfunc(kfunc string, kmods []string, bytes uint, readSpec *ebpf.Collecti
 		color.New(color.FgBlue).Sprintf("%#x", kaddr), len(data))
 
 	engine, err := createGapstoneEngine()
-	assert.NoErr(err, "Failed to create gapstone engine: %v", err)
+	assert.NoErr(err, "Failed to create gapstone engine: %v")
 	defer engine.Close()
 
 	VerboseLog("Disassembling bpf progs ..")

--- a/internal/bpfsnoop/func_proto.go
+++ b/internal/bpfsnoop/func_proto.go
@@ -80,9 +80,8 @@ func ShowFuncProto(f *Flags, tpSpec, tpModSpec *ebpf.CollectionSpec) {
 			keys := maps.Keys(progs.tracings)
 			sort.Strings(keys)
 
-			listParams := f.listFuncParams && len(f.progs) == 1
 			for _, k := range keys {
-				printFuncProto(&sb, progs.tracings[k].fn, yellow, listParams)
+				printFuncProto(&sb, progs.tracings[k].fn, yellow, f.listFuncParams)
 			}
 
 			printNewline = true
@@ -106,9 +105,8 @@ func ShowFuncProto(f *Flags, tpSpec, tpModSpec *ebpf.CollectionSpec) {
 		keys := maps.Keys(kfuncs)
 		slices.Sort(keys)
 
-		listParams := f.listFuncParams && len(f.kfuncs) == 1
 		for _, k := range keys {
-			printFuncProto(&sb, kfuncs[k].Func, yellow, listParams)
+			printFuncProto(&sb, kfuncs[k].Func, yellow, f.listFuncParams)
 		}
 
 		printNewline = true
@@ -131,9 +129,8 @@ func ShowFuncProto(f *Flags, tpSpec, tpModSpec *ebpf.CollectionSpec) {
 		keys := maps.Keys(ktps)
 		slices.Sort(keys)
 
-		listParams := f.listFuncParams && len(f.ktps) == 1
 		for _, k := range keys {
-			printFuncProto(&sb, ktps[k].Func, yellow, listParams)
+			printFuncProto(&sb, ktps[k].Func, yellow, f.listFuncParams)
 		}
 	}
 

--- a/internal/bpfsnoop/func_proto.go
+++ b/internal/bpfsnoop/func_proto.go
@@ -96,7 +96,15 @@ func ShowFuncProto(f *Flags, tpSpec, tpModSpec *ebpf.CollectionSpec) {
 			fmt.Fprintln(&sb)
 		}
 
-		kfuncs, err := findKernelFuncs(f.kfuncs, kallsyms, MAX_BPF_FUNC_ARGS, false, true)
+		var kmods []string
+		if ksym, ok := kallsyms.findBySymbol(f.kfuncs[0]); ok && ksym.mod != "" {
+			kmods = []string{ksym.mod}
+		} else {
+			kmods, err = inferenceKfuncKmods(f.kfuncs, kfuncKmods, kallsyms)
+			assert.NoErr(err, "Failed to inference kernel module names for kernel functions: %v")
+		}
+
+		kfuncs, err := findKernelFuncs(f.kfuncs, kmods, kallsyms, MAX_BPF_FUNC_ARGS, false, true)
 		assert.NoErr(err, "Failed to find kernel functions: %v")
 
 		fmt.Fprint(&sb, "Kernel functions:")

--- a/internal/bpfsnoop/kernel_btf.go
+++ b/internal/bpfsnoop/kernel_btf.go
@@ -11,9 +11,13 @@ import (
 	"github.com/cilium/ebpf/btf"
 )
 
-func iterateKernelBtfs(iter func(*btf.Spec)) error {
+const (
+	kernelBTFPath = "/sys/kernel/btf"
+)
+
+func iterateKernelBtfs(kmods []string, iter func(*btf.Spec)) error {
 	if kfuncAllKmods {
-		files, err := os.ReadDir("/sys/kernel/btf")
+		files, err := os.ReadDir(kernelBTFPath)
 		if err != nil {
 			return fmt.Errorf("failed to read /sys/kernel/btf: %w", err)
 		}
@@ -26,8 +30,7 @@ func iterateKernelBtfs(iter func(*btf.Spec)) error {
 
 			iter(kmodBtf)
 		}
-	} else if len(kfuncKmods) != 0 {
-		kmods := slices.Clone(kfuncKmods)
+	} else if len(kmods) != 0 {
 		kmods = append(kmods, "vmlinux")
 		slices.Sort(kmods)
 		kmods = slices.Compact(kmods)

--- a/internal/bpfsnoop/kernel_functions_max_arg.go
+++ b/internal/bpfsnoop/kernel_functions_max_arg.go
@@ -12,7 +12,7 @@ import (
 )
 
 func DetectSupportedMaxArg(traceableSpec, spec *ebpf.CollectionSpec, ksyms *Kallsyms) (int, error) {
-	kfuncs, err := findKernelFuncs([]string{"ip_*", "tcp_*"}, ksyms, MAX_BPF_FUNC_ARGS, true, true)
+	kfuncs, err := findKernelFuncs([]string{"ip_*", "tcp_*"}, nil, ksyms, MAX_BPF_FUNC_ARGS, true, true)
 	if err != nil {
 		return 0, fmt.Errorf("failed to find kernel functions with many args: %w", err)
 	}


### PR DESCRIPTION
If to disasm/trace/show-func-proto kernel module's funcs, try to find their kmod if `--kfunc-kmods` is not specified.

