### PR TITLE
bpfsnoop: Run both entry and exit mode

### DIFF
--- a/internal/bpfsnoop/bpf_tail_call.go
+++ b/internal/bpfsnoop/bpf_tail_call.go
@@ -144,10 +144,6 @@ func ProbeTailcallIssue(spec, tailcallSpec, readSpec *ebpf.CollectionSpec) error
 	clearFilterArgSubprog(prog)
 
 	attachType := ebpf.AttachTraceFExit
-	if mode == TracingModeEntry {
-		attachType = ebpf.AttachTraceFEntry
-	}
-
 	prog.AttachTarget = tcProg
 	prog.AttachTo = tcProgName
 	prog.AttachType = attachType

--- a/internal/bpfsnoop/bpfsnoop.go
+++ b/internal/bpfsnoop/bpfsnoop.go
@@ -122,11 +122,18 @@ func Run(reader *ringbuf.Reader, helpers *Helpers, maps map[string]*ebpf.Map, w 
 			}
 		}
 
+		fnName := fnInfo.name
+		if event.Type == eventTypeFuncExit {
+			fnName += "[ex]"
+		} else if event.Type == eventTypeFuncEntry && !fnInfo.isTp {
+			fnName += "[en]"
+		}
+
 		if colorfulOutput {
-			color.New(color.FgYellow, color.Bold).Fprint(&sb, fnInfo.name, " ")
+			color.New(color.FgYellow, color.Bold).Fprint(&sb, fnName, " ")
 			color.New(color.FgBlue).Fprintf(&sb, "args")
 		} else {
-			fmt.Fprint(&sb, fnInfo.name, " args")
+			fmt.Fprint(&sb, fnName, " args")
 		}
 
 		withRetval := event.Type == eventTypeFuncExit

--- a/internal/bpfsnoop/bpfsnoop_lbr.go
+++ b/internal/bpfsnoop/bpfsnoop_lbr.go
@@ -37,7 +37,7 @@ func (s *lbrStack) get(funcIP uintptr, lbrData *LbrData, helpers *Helpers) bool 
 					break
 				}
 			}
-		} else if mode == TracingModeExit {
+		} else if hasModeExit() {
 			for i := range entries {
 				if progInfo.contains(entries[i].From) || progInfo.contains(entries[i].To) {
 					entries = entries[i:]

--- a/internal/bpfsnoop/kernel_functions.go
+++ b/internal/bpfsnoop/kernel_functions.go
@@ -165,7 +165,7 @@ func searchKernelFuncs(funcs, kmods []string, ksyms *Kallsyms, maxArgs int) (KFu
 		return nil, err
 	}
 
-	if mode != TracingModeExit {
+	if !hasModeExit() {
 		return kfuncs, nil
 	}
 

--- a/internal/bpfsnoop/kernel_functions_max_arg.go
+++ b/internal/bpfsnoop/kernel_functions_max_arg.go
@@ -36,10 +36,6 @@ func DetectSupportedMaxArg(traceableSpec, spec *ebpf.CollectionSpec, ksyms *Kall
 	clearFilterArgSubprog(prog)
 
 	attachType := ebpf.AttachTraceFExit
-	if mode == TracingModeEntry {
-		attachType = ebpf.AttachTraceFEntry
-	}
-
 	kfunc := maps.Values(kfuncs)[0]
 	prog.AttachTo = kfunc.Ksym.name
 	prog.AttachType = attachType

--- a/main.go
+++ b/main.go
@@ -6,11 +6,9 @@ package main
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log"
 	"os"
 	"os/signal"
-	"slices"
 	"syscall"
 	"time"
 
@@ -46,10 +44,6 @@ func main() {
 		bpfsnoop.ShowFuncProto(flags, tpSpec, tpModSpec)
 		return
 	}
-
-	mode := flags.Mode()
-	assert.True(slices.Contains([]string{bpfsnoop.TracingModeEntry, bpfsnoop.TracingModeExit}, mode),
-		fmt.Sprintf("Mode (%s) must be exit or entry", mode))
 
 	progs, err := flags.ParseProgs()
 	assert.NoErr(err, "Failed to parse bpf prog infos: %v")


### PR DESCRIPTION
As for `-p` and `-k`, it will be useful to trace the target(s) with both fentry and fexit.

e.g.

```bash
$ sudo ./bpfsnoop -k 'icmp_rcv' --filter-pkt 'host 1.1.1.1' --output-pkt --output-arg 'skb->dev->name' -m 'entry,exit'
2025/06/18 16:25:09 bpfsnoop is running..
icmp_rcv[en] args=((struct sk_buff *)skb=0xffff8f75c8efd300) cpu=6 process=(0:swapper/6)
Pkt tuple: 1.1.1.1 -> 192.168.241.133 (ICMP)
Arg attrs: (array(char[16]))'skb->dev->name'="ens33"

icmp_rcv[ex] args=((struct sk_buff *)skb=0xffff8f75c8efd300) retval=(int)0 cpu=6 process=(0:swapper/6)
Pkt tuple: 1.1.1.1 -> 192.168.241.133 (ICMP)
Arg attrs: (array(char[16]))'skb->dev->name'="ens33"
```