### PR TITLE
bpfsnoop: Fix running both entry and exit mode

### DIFF
--- a/internal/bpfsnoop/bpf_prog_info.go
+++ b/internal/bpfsnoop/bpf_prog_info.go
@@ -28,7 +28,8 @@ type bpfProgFuncInfo struct {
 	funcParams []FuncParamFlags
 	retParam   FuncParamFlags
 	funcArgs   []funcArgumentOutput
-	argsBufSz  int
+	argEntrySz int
+	argExitSz  int
 	argDataSz  int
 	isRetStr   bool
 	pktOutput  bool

--- a/internal/bpfsnoop/bpf_tracing.go
+++ b/internal/bpfsnoop/bpf_tracing.go
@@ -346,7 +346,11 @@ func (t *bpfTracing) traceProg(spec *ebpf.CollectionSpec, reusedMaps map[string]
 	if err != nil {
 		return fmt.Errorf("failed to inject output func args: %w", err)
 	}
-	bprogs.funcs[info.funcIP].argsBufSz = fnArgsBufSize
+	if fexit {
+		bprogs.funcs[info.funcIP].argExitSz = fnArgsBufSize
+	} else {
+		bprogs.funcs[info.funcIP].argEntrySz = fnArgsBufSize
+	}
 
 	if err := setBpfsnoopConfig(spec, uint64(info.funcIP), len(info.params), fnArgsBufSize, argDataSize, false, fexit); err != nil {
 		return fmt.Errorf("failed to set bpfsnoop config: %w", err)
@@ -424,7 +428,11 @@ func (t *bpfTracing) traceFunc(spec *ebpf.CollectionSpec, reusedMaps map[string]
 	if err != nil {
 		return fmt.Errorf("failed to inject output func args: %w", err)
 	}
-	fn.Farg = fnArgsBufSize
+	if isExit {
+		fn.Exit = fnArgsBufSize
+	} else {
+		fn.Ent = fnArgsBufSize
+	}
 
 	if err := setBpfsnoopConfig(spec, fn.Ksym.addr, len(fn.Prms), fnArgsBufSize, argDataSize, bothEntryExit, withRet); err != nil {
 		return fmt.Errorf("failed to set bpfsnoop config: %w", err)

--- a/internal/bpfsnoop/bpfsnoop.go
+++ b/internal/bpfsnoop/bpfsnoop.go
@@ -136,9 +136,13 @@ func Run(reader *ringbuf.Reader, helpers *Helpers, maps map[string]*ebpf.Map, w 
 		}
 
 		withRetval := event.Type == eventTypeFuncExit
-		if fnInfo.argsBuf != 0 {
-			outputFnArgs(&sb, fnInfo, helpers, data[:fnInfo.argsBuf], findSymbol, withRetval)
-			data = data[fnInfo.argsBuf:]
+		argSz := fnInfo.argEntry
+		if withRetval {
+			argSz = fnInfo.argExit
+		}
+		if argSz != 0 {
+			outputFnArgs(&sb, fnInfo, helpers, data[:argSz], findSymbol, withRetval)
+			data = data[argSz:]
 		} else {
 			fmt.Fprint(&sb, "=()")
 			if withRetval {

--- a/internal/bpfsnoop/bpfsnoop_func.go
+++ b/internal/bpfsnoop/bpfsnoop_func.go
@@ -16,7 +16,8 @@ type funcInfo struct {
 	args     []funcArgumentOutput
 	params   []FuncParamFlags
 	retParam FuncParamFlags
-	argsBuf  int
+	argEntry int
+	argExit  int
 	argData  int
 	insnMode bool
 	pktTuple bool
@@ -36,7 +37,8 @@ func getFuncInfo(event *Event, helpers *Helpers) *funcInfo {
 		info.retParam = progInfo.retParam
 		info.pktTuple = progInfo.pktOutput
 		info.isProg = true
-		info.argsBuf = progInfo.argsBufSz
+		info.argEntry = progInfo.argEntrySz
+		info.argExit = progInfo.argExitSz
 		info.argData = progInfo.argDataSz
 		info.progType = progInfo.progType
 		return &info
@@ -60,7 +62,8 @@ func getFuncInfo(event *Event, helpers *Helpers) *funcInfo {
 	info.retParam = fn.Ret
 	info.insnMode = fn.Insn
 	info.pktTuple = fn.Pkt
-	info.argsBuf = fn.Farg
+	info.argEntry = fn.Ent
+	info.argExit = fn.Exit
 	info.argData = fn.Data
 
 	if fn.IsTp {

--- a/internal/bpfsnoop/kernel_functions.go
+++ b/internal/bpfsnoop/kernel_functions.go
@@ -54,7 +54,8 @@ type KFunc struct {
 	Args []funcArgumentOutput
 	Prms []FuncParamFlags
 	Ret  FuncParamFlags
-	Farg int // fn args buffer size
+	Ent  int // fn args buffer size for fentry
+	Exit int // fn args buffer size for fexit
 	Data int // arg output data size
 	Insn bool
 	IsTp bool


### PR DESCRIPTION
The issue was introduced by commit https://github.com/bpfsnoop/bpfsnoop/commit/dd42c0bdf772c7ad5976621252fafff367855510 ("bpfsnoop: Run both entry and exit mode").

The event data outputting logic of fexit was broken when run both entry
and exit mode, like `-m 'entry,exit'`, because the data of retval may not
be handled.

To fix it, separate the data size of func args to entry and exit.

Show the duration between `entry` and `exit`, BTW.