### PR TITLE
test: Fix building xdpcrc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,8 @@ testcc:
 $(LOCALTEST_OBJ): $(LOCALTEST_SRC)
 	$(GOBUILD) -o $(LOCALTEST_OBJ) ./cmd/localtest
 
-$(XDPCRC_OBJ):
-	$(BPF2GO) xdpcrc $(XDPCRC_DIR)/xdp.c -- $(BPF2GO_EXTRA_FLAGS)
+$(XDPCRC_OBJ): $(XDPCRC_SRC)
+	$(BPF2GO) xdp $(XDPCRC_DIR)/xdp.c -- $(BPF2GO_EXTRA_FLAGS) && mv ./xdp_bpf* $(XDPCRC_DIR)
 	$(GOBUILD) -o $(XDPCRC_OBJ) $(XDPCRC_DIR)
 
 .PHONY: testlocal

--- a/cmd/xdpcrc/xdp.c
+++ b/cmd/xdpcrc/xdp.c
@@ -94,3 +94,5 @@ int crc(struct xdp_md *ctx)
 
     return XDP_PASS;
 }
+
+char __license[] SEC("license") = "GPL";


### PR DESCRIPTION
The previous building objects were copied from `learn-by-example` repo. It would fail to build objects if remove them.

Fix then test by `./localtest --test-file ./t/xdp.txt --name 'xdp::entry_exit'`.