### PR TITLE
fnarg: Output Ethernet, IPv4 and IPv6 address

### DIFF
--- a/internal/bpfsnoop/output_arg.go
+++ b/internal/bpfsnoop/output_arg.go
@@ -48,6 +48,8 @@ type funcArgumentOutput struct {
 	isString bool
 	isPkt    bool
 	pktType  string
+	isAddr   bool
+	addrType string
 }
 
 type argDataOutput struct {
@@ -268,11 +270,14 @@ func (arg *funcArgumentOutput) compile(params []btf.FuncParam, spec *btf.Spec, o
 		arg.isDeref = true
 		offset, err = arg.genDerefInsns(&res, offset, size, labelExit)
 
-	case cc.EvalResultTypeBuf, cc.EvalResultTypePkt, cc.EvalResultTypeString:
+	case cc.EvalResultTypeBuf, cc.EvalResultTypeString, cc.EvalResultTypePkt,
+		cc.EvalResultTypeAddr:
 		arg.isBuf = res.Type == cc.EvalResultTypeBuf
 		arg.isString = res.Type == cc.EvalResultTypeString
 		arg.isPkt = res.Type == cc.EvalResultTypePkt
 		arg.pktType = res.Pkt
+		arg.isAddr = res.Type == cc.EvalResultTypeAddr
+		arg.addrType = res.Addr
 		offset, err = arg.genBufInsns(&res, offset, size, labelExit)
 
 	default:

--- a/internal/cc/expr.go
+++ b/internal/cc/expr.go
@@ -102,6 +102,7 @@ const (
 	EvalResultTypeBuf
 	EvalResultTypeString
 	EvalResultTypePkt
+	EvalResultTypeAddr
 )
 
 type EvalResult struct {
@@ -113,6 +114,7 @@ type EvalResult struct {
 	Size  int
 	Off   int
 	Pkt   string // pkt type, e.g. "eth", "ip4", "ip6", "icmp", "icmp6", "tcp" and "udp"
+	Addr  string // addr type, e.g. "eth", "eth2", "ip4", "ip42", "ip6", "ip62"
 
 	LabelUsed bool
 }
@@ -158,6 +160,7 @@ func CompileEvalExpr(opts CompileExprOptions) (EvalResult, error) {
 
 		res.Type = val.typ
 		res.Pkt = val.pkt
+		res.Addr = val.addr
 		dataSize = val.dataSize
 		dataOffset = val.dataOffset
 		evaluatingExpr = val.expr
@@ -219,7 +222,7 @@ func CompileEvalExpr(opts CompileExprOptions) (EvalResult, error) {
 		res.Size = int(dataSize)
 		res.Btf = t
 
-	case EvalResultTypePkt:
+	case EvalResultTypePkt, EvalResultTypeAddr:
 		t := mybtf.UnderlyingType(val.btf)
 		_, isPtr := t.(*btf.Pointer)
 		if !isPtr {

--- a/internal/cc/expr_func_test.go
+++ b/internal/cc/expr_func_test.go
@@ -284,6 +284,92 @@ func TestCompileFuncCall(t *testing.T) {
 		})
 	})
 
+	t.Run("addr", func(t *testing.T) {
+		t.Run("eth(skb->data, 0xFFULL)", func(t *testing.T) {
+			expr, err := cc.ParseExpr("eth(skb->data, 0xFFULL)")
+			test.AssertNoErr(t, err)
+
+			_, err = compileFuncCall(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertErrorPrefix(t, err, "eth() second argument must be a number")
+		})
+
+		t.Run("eth(skb->data, 14, 20)", func(t *testing.T) {
+			expr, err := cc.ParseExpr("eth(skb->data, 14, 20)")
+			test.AssertNoErr(t, err)
+
+			_, err = compileFuncCall(expr)
+			test.AssertHaveErr(t, err)
+			test.AssertErrorPrefix(t, err, "eth() must have 1 or 2 arguments")
+		})
+
+		t.Run("eth(skb->data)", func(t *testing.T) {
+			expr, err := cc.ParseExpr("eth(skb->data)")
+			test.AssertNoErr(t, err)
+
+			val, err := compileFuncCall(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, val.typ, EvalResultTypeAddr)
+			test.AssertEqual(t, val.addr, AddrTypeEth)
+			test.AssertEqual(t, val.dataSize, EthAddrSize)
+		})
+
+		t.Run("eth2(skb->data)", func(t *testing.T) {
+			expr, err := cc.ParseExpr("eth2(skb->data)")
+			test.AssertNoErr(t, err)
+
+			val, err := compileFuncCall(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, val.typ, EvalResultTypeAddr)
+			test.AssertEqual(t, val.addr, AddrTypeEth2)
+			test.AssertEqual(t, val.dataSize, EthAddrSize*2)
+		})
+
+		t.Run("ip4(skb->data)", func(t *testing.T) {
+			expr, err := cc.ParseExpr("ip4(skb->data)")
+			test.AssertNoErr(t, err)
+
+			val, err := compileFuncCall(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, val.typ, EvalResultTypeAddr)
+			test.AssertEqual(t, val.addr, AddrTypeIP4)
+			test.AssertEqual(t, val.dataSize, IP4AddrSize)
+		})
+
+		t.Run("ip42(skb->data)", func(t *testing.T) {
+			expr, err := cc.ParseExpr("ip42(skb->data)")
+			test.AssertNoErr(t, err)
+
+			val, err := compileFuncCall(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, val.typ, EvalResultTypeAddr)
+			test.AssertEqual(t, val.addr, AddrTypeIP42)
+			test.AssertEqual(t, val.dataSize, IP4AddrSize*2)
+		})
+
+		t.Run("ip6(skb->data)", func(t *testing.T) {
+			expr, err := cc.ParseExpr("ip6(skb->data)")
+			test.AssertNoErr(t, err)
+
+			val, err := compileFuncCall(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, val.typ, EvalResultTypeAddr)
+			test.AssertEqual(t, val.addr, AddrTypeIP6)
+			test.AssertEqual(t, val.dataSize, IP6AddrSize)
+		})
+
+		t.Run("ip62(skb->data)", func(t *testing.T) {
+			expr, err := cc.ParseExpr("ip62(skb->data)")
+			test.AssertNoErr(t, err)
+
+			val, err := compileFuncCall(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, val.typ, EvalResultTypeAddr)
+			test.AssertEqual(t, val.addr, AddrTypeIP62)
+			test.AssertEqual(t, val.dataSize, IP6AddrSize*2)
+		})
+	})
+
 	t.Run("unsupported func call", func(t *testing.T) {
 		expr, err := cc.ParseExpr("unsupported(skb->cb)")
 		test.AssertNoErr(t, err)

--- a/t/cc.txt
+++ b/t/cc.txt
@@ -23,7 +23,7 @@ trigger: ping -c 1 -s 64 127.0.0.1
 
 # buf()
 name: cc::buf
-tag: cc,ptr-deref,pkt,tp
+tag: cc,pkt,tp
 test: -t netif_receive_skb --filter-pkt 'host 127.0.0.1 and icmp' --output-arg 'buf(skb->head + skb->mac_header, 34)' --output-arg 'buf(skb->cb, 4, 4)' --output-arg 'skb->mac_header' --output-arg 'skb->network_header'
 match: 0x7f,0x00,0x00,0x01,0x7f,0x00,0x00,0x01
 trigger: ping -c 1 -s 64 127.0.0.1
@@ -32,7 +32,16 @@ trigger: ping -c 1 -s 64 127.0.0.1
 
 # pkt()
 name: cc::pkt
-tag: cc,ptr-deref,pkt,tp
+tag: cc,pkt,tp
 test: -t netif_receive_skb --filter-pkt 'host 127.0.0.1 and icmp' --output-arg 'pkt(skb->head + skb->mac_header, 34)'
 match: SrcIP=127.0.0.1 DstIP=127.0.0.1
+trigger: ping -c 1 -s 64 127.0.0.1
+
+---
+
+# addr
+name: cc::addr
+tag: cc,addr,tp
+test: -t netif_receive_skb --filter-pkt 'host 127.0.0.1 and icmp' --output-arg 'ip42(skb->head + skb->network_header, 12)'
+match: (unsigned char *)'ip42(skb->head + skb->network_header, 12)'=[127.0.0.1,127.0.0.1]
 trigger: ping -c 1 -s 64 127.0.0.1


### PR DESCRIPTION
Output kernel buffer as address, like:

```bash
$ sudo ./bpfsnoop -t netif_receive_skb --filter-pkt 'host 127.0.0.1 and icmp' --output-arg 'ip42(skb->head + skb->network_header, 12)'
2025/06/25 16:24:30 bpfsnoop is running..
netif_receive_skb[tp] args=((struct sk_buff *)skb=0xffff8f75d8f34b00) cpu=4 process=(152686:ping)
Arg attrs: (unsigned char *)'ip42(skb->head + skb->network_header, 12)'=[127.0.0.1,127.0.0.1]
```