### PR TITLE
fnarg: Output TCP/UDP port 

### DIFF
--- a/internal/bpfsnoop/bpfsnoop_arg.go
+++ b/internal/bpfsnoop/bpfsnoop_arg.go
@@ -55,81 +55,93 @@ func outputFuncArgAttrs(sb *strings.Builder, info *funcInfo, data []byte, f btfx
 			continue
 		}
 
-		if arg.isDeref || arg.isBuf || arg.isString || arg.isPkt || arg.isAddr {
-			var (
-				s   string
-				err error
-			)
+		var (
+			s   string
+			err error
+		)
 
-			switch {
-			case arg.isDeref:
-				s, err = mybtf.DumpData(arg.t, data[:arg.trueDataSize])
-				if err != nil {
-					return fmt.Errorf("failed to dump deref data: %w", err)
-				}
-
-				s = fmt.Sprintf("(%s)'%s'=%s", btfx.Repr(arg.t), arg.expr, s)
-
-			case arg.isBuf:
-				s = fmt.Sprintf("(%s)'%s'=%s", btfx.Repr(arg.t), arg.expr,
-					dumpOutputArgBuf(data[:arg.trueDataSize]))
-
-			case arg.isString:
-				s = fmt.Sprintf(`(%s)'%s'="%s"`, btfx.Repr(arg.t), arg.expr,
-					strx.NullTerminated(data[:arg.trueDataSize]))
-
-			case arg.isPkt:
-				layer := layers.LayerTypeEthernet
-				switch arg.pktType {
-				case cc.PktTypeEth:
-					layer = layers.LayerTypeEthernet
-				case cc.PktTypeIP, cc.PktTypeIP4:
-					layer = layers.LayerTypeIPv4
-				case cc.PktTypeIP6:
-					layer = layers.LayerTypeIPv6
-				case cc.PktTypeICMP:
-					layer = layers.LayerTypeICMPv4
-				case cc.PktTypeICMP6:
-					layer = layers.LayerTypeICMPv6
-				case cc.PktTypeTCP:
-					layer = layers.LayerTypeTCP
-				case cc.PktTypeUDP:
-					layer = layers.LayerTypeUDP
-				}
-				pkt := gopacket.NewPacket(data[:arg.trueDataSize], layer, gopacket.NoCopy)
-				s = fmt.Sprintf("(%s)'%s'=%v", btfx.Repr(arg.t), arg.expr, pkt)
-
-			case arg.isAddr:
-				switch arg.addrType {
-				case cc.AddrTypeEth:
-					s = fmt.Sprintf("(%s)'%s'=%s", btfx.Repr(arg.t), arg.expr,
-						net.HardwareAddr(data[:cc.EthAddrSize]))
-
-				case cc.AddrTypeEth2:
-					s = fmt.Sprintf("(%s)'%s'=[%s,%s]", btfx.Repr(arg.t), arg.expr,
-						net.HardwareAddr(data[:cc.EthAddrSize]),
-						net.HardwareAddr(data[cc.EthAddrSize:cc.EthAddrSize*2]))
-
-				case cc.AddrTypeIP4:
-					s = fmt.Sprintf("(%s)'%s'=%s", btfx.Repr(arg.t), arg.expr,
-						net.IP(data[:cc.IP4AddrSize]))
-
-				case cc.AddrTypeIP42:
-					s = fmt.Sprintf("(%s)'%s'=[%s,%s]", btfx.Repr(arg.t), arg.expr,
-						net.IP(data[:cc.IP4AddrSize]),
-						net.IP(data[cc.IP4AddrSize:cc.IP4AddrSize*2]))
-
-				case cc.AddrTypeIP6:
-					s = fmt.Sprintf("(%s)'%s'=%s", btfx.Repr(arg.t), arg.expr,
-						net.IP(data[:cc.IP6AddrSize]))
-
-				case cc.AddrTypeIP62:
-					s = fmt.Sprintf("(%s)'%s'=[%s,%s]", btfx.Repr(arg.t), arg.expr,
-						net.IP(data[:cc.IP6AddrSize]),
-						net.IP(data[cc.IP6AddrSize:cc.IP6AddrSize*2]))
-				}
+		switch {
+		case arg.isDeref:
+			s, err = mybtf.DumpData(arg.t, data[:arg.trueDataSize])
+			if err != nil {
+				return fmt.Errorf("failed to dump deref data: %w", err)
 			}
 
+			s = fmt.Sprintf("(%s)'%s'=%s", btfx.Repr(arg.t), arg.expr, s)
+
+		case arg.isBuf:
+			s = fmt.Sprintf("(%s)'%s'=%s", btfx.Repr(arg.t), arg.expr,
+				dumpOutputArgBuf(data[:arg.trueDataSize]))
+
+		case arg.isString:
+			s = fmt.Sprintf(`(%s)'%s'="%s"`, btfx.Repr(arg.t), arg.expr,
+				strx.NullTerminated(data[:arg.trueDataSize]))
+
+		case arg.isPkt:
+			layer := layers.LayerTypeEthernet
+			switch arg.pktType {
+			case cc.PktTypeEth:
+				layer = layers.LayerTypeEthernet
+			case cc.PktTypeIP, cc.PktTypeIP4:
+				layer = layers.LayerTypeIPv4
+			case cc.PktTypeIP6:
+				layer = layers.LayerTypeIPv6
+			case cc.PktTypeICMP:
+				layer = layers.LayerTypeICMPv4
+			case cc.PktTypeICMP6:
+				layer = layers.LayerTypeICMPv6
+			case cc.PktTypeTCP:
+				layer = layers.LayerTypeTCP
+			case cc.PktTypeUDP:
+				layer = layers.LayerTypeUDP
+			}
+			pkt := gopacket.NewPacket(data[:arg.trueDataSize], layer, gopacket.NoCopy)
+			s = fmt.Sprintf("(%s)'%s'=%v", btfx.Repr(arg.t), arg.expr, pkt)
+
+		case arg.isAddr:
+			switch arg.addrType {
+			case cc.AddrTypeEth:
+				s = fmt.Sprintf("(%s)'%s'=%s", btfx.Repr(arg.t), arg.expr,
+					net.HardwareAddr(data[:cc.EthAddrSize]))
+
+			case cc.AddrTypeEth2:
+				s = fmt.Sprintf("(%s)'%s'=[%s,%s]", btfx.Repr(arg.t), arg.expr,
+					net.HardwareAddr(data[:cc.EthAddrSize]),
+					net.HardwareAddr(data[cc.EthAddrSize:cc.EthAddrSize*2]))
+
+			case cc.AddrTypeIP4:
+				s = fmt.Sprintf("(%s)'%s'=%s", btfx.Repr(arg.t), arg.expr,
+					net.IP(data[:cc.IP4AddrSize]))
+
+			case cc.AddrTypeIP42:
+				s = fmt.Sprintf("(%s)'%s'=[%s,%s]", btfx.Repr(arg.t), arg.expr,
+					net.IP(data[:cc.IP4AddrSize]),
+					net.IP(data[cc.IP4AddrSize:cc.IP4AddrSize*2]))
+
+			case cc.AddrTypeIP6:
+				s = fmt.Sprintf("(%s)'%s'=%s", btfx.Repr(arg.t), arg.expr,
+					net.IP(data[:cc.IP6AddrSize]))
+
+			case cc.AddrTypeIP62:
+				s = fmt.Sprintf("(%s)'%s'=[%s,%s]", btfx.Repr(arg.t), arg.expr,
+					net.IP(data[:cc.IP6AddrSize]),
+					net.IP(data[cc.IP6AddrSize:cc.IP6AddrSize*2]))
+			}
+
+		case arg.isPort:
+			switch arg.portType {
+			case cc.Port:
+				s = fmt.Sprintf("(%s)'%s'=%d", btfx.Repr(arg.t), arg.expr,
+					be.Uint16(data[:cc.PortSize]))
+
+			case cc.Port2:
+				s = fmt.Sprintf("(%s)'%s'=[%d,%d]", btfx.Repr(arg.t), arg.expr,
+					be.Uint16(data[:cc.PortSize]),
+					be.Uint16(data[cc.PortSize:cc.PortSize*2]))
+			}
+		}
+
+		if s != "" {
 			if colorfulOutput {
 				gray.Fprint(sb, s)
 			} else {
@@ -151,7 +163,7 @@ func outputFuncArgAttrs(sb *strings.Builder, info *funcInfo, data []byte, f btfx
 			}
 		}
 
-		s := btfx.ReprExprType(arg.expr, arg.t, arg.mem, arg.isStr, arg.isNumPtr, argVal, argVal2, 0, argStr, f)
+		s = btfx.ReprExprType(arg.expr, arg.t, arg.mem, arg.isStr, arg.isNumPtr, argVal, argVal2, 0, argStr, f)
 		if colorfulOutput {
 			gray.Fprint(sb, s)
 		} else {

--- a/internal/bpfsnoop/output_arg.go
+++ b/internal/bpfsnoop/output_arg.go
@@ -50,6 +50,8 @@ type funcArgumentOutput struct {
 	pktType  string
 	isAddr   bool
 	addrType string
+	isPort   bool
+	portType string
 }
 
 type argDataOutput struct {
@@ -271,13 +273,15 @@ func (arg *funcArgumentOutput) compile(params []btf.FuncParam, spec *btf.Spec, o
 		offset, err = arg.genDerefInsns(&res, offset, size, labelExit)
 
 	case cc.EvalResultTypeBuf, cc.EvalResultTypeString, cc.EvalResultTypePkt,
-		cc.EvalResultTypeAddr:
+		cc.EvalResultTypeAddr, cc.EvalResultTypePort:
 		arg.isBuf = res.Type == cc.EvalResultTypeBuf
 		arg.isString = res.Type == cc.EvalResultTypeString
 		arg.isPkt = res.Type == cc.EvalResultTypePkt
 		arg.pktType = res.Pkt
 		arg.isAddr = res.Type == cc.EvalResultTypeAddr
 		arg.addrType = res.Addr
+		arg.isPort = res.Type == cc.EvalResultTypePort
+		arg.portType = res.Port
 		offset, err = arg.genBufInsns(&res, offset, size, labelExit)
 
 	default:

--- a/internal/cc/expr.go
+++ b/internal/cc/expr.go
@@ -103,6 +103,7 @@ const (
 	EvalResultTypeString
 	EvalResultTypePkt
 	EvalResultTypeAddr
+	EvalResultTypePort
 )
 
 type EvalResult struct {
@@ -115,6 +116,7 @@ type EvalResult struct {
 	Off   int
 	Pkt   string // pkt type, e.g. "eth", "ip4", "ip6", "icmp", "icmp6", "tcp" and "udp"
 	Addr  string // addr type, e.g. "eth", "eth2", "ip4", "ip42", "ip6", "ip62"
+	Port  string // port type, e.g. "port", "port2"
 
 	LabelUsed bool
 }
@@ -161,6 +163,7 @@ func CompileEvalExpr(opts CompileExprOptions) (EvalResult, error) {
 		res.Type = val.typ
 		res.Pkt = val.pkt
 		res.Addr = val.addr
+		res.Port = val.port
 		dataSize = val.dataSize
 		dataOffset = val.dataOffset
 		evaluatingExpr = val.expr
@@ -222,7 +225,7 @@ func CompileEvalExpr(opts CompileExprOptions) (EvalResult, error) {
 		res.Size = int(dataSize)
 		res.Btf = t
 
-	case EvalResultTypePkt, EvalResultTypeAddr:
+	case EvalResultTypePkt, EvalResultTypeAddr, EvalResultTypePort:
 		t := mybtf.UnderlyingType(val.btf)
 		_, isPtr := t.(*btf.Pointer)
 		if !isPtr {

--- a/internal/cc/expr_func.go
+++ b/internal/cc/expr_func.go
@@ -28,12 +28,17 @@ const (
 	AddrTypeIP42 = "ip42"
 	AddrTypeIP6  = "ip6"
 	AddrTypeIP62 = "ip62"
+
+	Port  = "port"
+	Port2 = "port2"
 )
 
 const (
 	EthAddrSize = 6
 	IP4AddrSize = 4
 	IP6AddrSize = 16
+
+	PortSize = 2 // TCP/UDP port size
 )
 
 type funcCallValue struct {
@@ -43,6 +48,7 @@ type funcCallValue struct {
 	dataSize   int64
 	pkt        string
 	addr       string
+	port       string
 }
 
 func parseExprNumber(expr *cc.Expr) (int64, error) {
@@ -191,7 +197,8 @@ func compileFuncCall(expr *cc.Expr) (funcCallValue, error) {
 
 	case AddrTypeEth, AddrTypeEth2,
 		AddrTypeIP4, AddrTypeIP42,
-		AddrTypeIP6, AddrTypeIP62:
+		AddrTypeIP6, AddrTypeIP62,
+		Port, Port2:
 		switch len(expr.List) {
 		case 1:
 			break
@@ -230,9 +237,20 @@ func compileFuncCall(expr *cc.Expr) (funcCallValue, error) {
 		case AddrTypeIP62:
 			val.dataSize = IP6AddrSize * 2 // IPv6 address size * 2
 			val.addr = AddrTypeIP62
+
+		case Port:
+			val.dataSize = PortSize // TCP/UDP port size
+			val.port = Port
+
+		case Port2:
+			val.dataSize = PortSize * 2 // TCP/UDP port size * 2
+			val.port = Port2
 		}
 
 		val.typ = EvalResultTypeAddr
+		if fnName == Port || fnName == Port2 {
+			val.typ = EvalResultTypePort
+		}
 
 	default:
 		return val, fmt.Errorf("unknown function call: %s", fnName)

--- a/internal/cc/expr_func_test.go
+++ b/internal/cc/expr_func_test.go
@@ -370,6 +370,30 @@ func TestCompileFuncCall(t *testing.T) {
 		})
 	})
 
+	t.Run("port", func(t *testing.T) {
+		t.Run("port(skb->data + 14 + 20)", func(t *testing.T) {
+			expr, err := cc.ParseExpr("port(skb->data + 14 + 20)")
+			test.AssertNoErr(t, err)
+
+			val, err := compileFuncCall(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, val.typ, EvalResultTypePort)
+			test.AssertEqual(t, val.port, Port)
+			test.AssertEqual(t, val.dataSize, PortSize)
+		})
+
+		t.Run("port2(skb->data + 14 + 20)", func(t *testing.T) {
+			expr, err := cc.ParseExpr("port2(skb->data + 14 + 20)")
+			test.AssertNoErr(t, err)
+
+			val, err := compileFuncCall(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, val.typ, EvalResultTypePort)
+			test.AssertEqual(t, val.port, Port2)
+			test.AssertEqual(t, val.dataSize, PortSize*2)
+		})
+	})
+
 	t.Run("unsupported func call", func(t *testing.T) {
 		expr, err := cc.ParseExpr("unsupported(skb->cb)")
 		test.AssertNoErr(t, err)

--- a/t/cc.txt
+++ b/t/cc.txt
@@ -45,3 +45,13 @@ tag: cc,addr,tp
 test: -t netif_receive_skb --filter-pkt 'host 127.0.0.1 and icmp' --output-arg 'ip42(skb->head + skb->network_header, 12)'
 match: (unsigned char *)'ip42(skb->head + skb->network_header, 12)'=[127.0.0.1,127.0.0.1]
 trigger: ping -c 1 -s 64 127.0.0.1
+
+---
+
+# port
+name: cc::port
+tag: cc,port,tp
+test: -t netif_receive_skb --filter-pkt 'host 127.0.0.1 and tcp' --output-arg 'port(skb->head + skb->transport_header)'
+match: (unsigned char *)'port(skb->head + skb->transport_header)'=8081
+prerequisite: python3 -m http.server 8081
+trigger: curl -s http://127.0.0.1:8081 --output /dev/null


### PR DESCRIPTION
Instead of dumping the whole IP header and TCP/UDP header, we can dump IP addresses and TCP/UDP ports in order to catch the key info when tracing.

```bash
$ sudo ./bpfsnoop -t netif_receive_skb --filter-pkt 'host 1.1.1.1 and tcp' --output-arg 'ip42(skb->head + skb->network_header + 12)' --output-arg 'port2(skb->head + skb->transport_header)'
2025/06/26 12:34:51 bpfsnoop is running..
netif_receive_skb[tp] args=((struct sk_buff *)skb=0xffff8f75dafe0f00) cpu=6 process=(0:swapper/6)
Arg attrs: (unsigned char *)'ip42(skb->head + skb->network_header + 12)'=[1.1.1.1,192.168.241.133], (unsigned char *)'port2(skb->head + skb->transport_header)'=[443,53928]
```