### PR TITLE
fnarg: Output slice of type

### DIFF
--- a/internal/bpfsnoop/output_arg.go
+++ b/internal/bpfsnoop/output_arg.go
@@ -52,6 +52,7 @@ type funcArgumentOutput struct {
 	addrType string
 	isPort   bool
 	portType string
+	isSlice  bool
 }
 
 type argDataOutput struct {
@@ -273,7 +274,7 @@ func (arg *funcArgumentOutput) compile(params []btf.FuncParam, spec *btf.Spec, o
 		offset, err = arg.genDerefInsns(&res, offset, size, labelExit)
 
 	case cc.EvalResultTypeBuf, cc.EvalResultTypeString, cc.EvalResultTypePkt,
-		cc.EvalResultTypeAddr, cc.EvalResultTypePort:
+		cc.EvalResultTypeAddr, cc.EvalResultTypePort, cc.EvalResultTypeSlice:
 		arg.isBuf = res.Type == cc.EvalResultTypeBuf
 		arg.isString = res.Type == cc.EvalResultTypeString
 		arg.isPkt = res.Type == cc.EvalResultTypePkt
@@ -282,6 +283,7 @@ func (arg *funcArgumentOutput) compile(params []btf.FuncParam, spec *btf.Spec, o
 		arg.addrType = res.Addr
 		arg.isPort = res.Type == cc.EvalResultTypePort
 		arg.portType = res.Port
+		arg.isSlice = res.Type == cc.EvalResultTypeSlice
 		offset, err = arg.genBufInsns(&res, offset, size, labelExit)
 
 	default:

--- a/internal/cc/expr.go
+++ b/internal/cc/expr.go
@@ -103,6 +103,7 @@ const (
 	EvalResultTypePkt
 	EvalResultTypeAddr
 	EvalResultTypePort
+	EvalResultTypeSlice
 )
 
 type EvalResult struct {

--- a/t/cc.txt
+++ b/t/cc.txt
@@ -55,3 +55,12 @@ test: -t netif_receive_skb --filter-pkt 'host 127.0.0.1 and tcp' --output-arg 'p
 match: (unsigned char *)'port(skb->head + skb->transport_header)'=8081
 prerequisite: python3 -m http.server 8081
 trigger: curl -s http://127.0.0.1:8081 --output /dev/null
+
+---
+
+# slice()
+name: cc::slice
+tag: cc,slice
+test: -k dev_xdp_install --output-arg 'slice(prog->aux->used_maps, 1)'
+match: (struct bpf_map *)'slice(prog->aux->used_maps, 1)'=[0xffff
+trigger: ./xdpcrc -d lo


### PR DESCRIPTION
Dump kernel buffer as a slice of BTF type:

```bash
$ sudo ./bpfsnoop -k dev_xdp_install --output-arg 'slice(prog->aux->used_maps, 1)'
2025/06/26 15:10:17 bpfsnoop is running..
dev_xdp_install[ex] args=((struct net_device *)dev=0xffff8f75c2514000, (enum bpf_xdp_mode)mode=XDP_MODE_SKB, (bpf_op_t)bpf_op=0xffffffffa0f021f0(generic_xdp_install), (struct netlink_ext_ack *)extack=0xffffae0781083cf0, (u32)flags=0x0/0, (struct bpf_prog *)prog=0xffffae0780557000) retval=(int)0 cpu=4 process=(156070:xdpcrc)
Arg attrs: (struct bpf_map *)'slice(prog->aux->used_maps, 1)'=[0xffffae0780095ef0]
```