### PR TITLE
fnarg: Output buffer using builtin hex() 

### DIFF
--- a/internal/bpfsnoop/bpfsnoop_arg.go
+++ b/internal/bpfsnoop/bpfsnoop_arg.go
@@ -4,6 +4,7 @@
 package bpfsnoop
 
 import (
+	"encoding/hex"
 	"fmt"
 	"net"
 	"strings"
@@ -161,6 +162,10 @@ func outputFuncArgAttrs(sb *strings.Builder, info *funcInfo, data []byte, f btfx
 			sb.WriteString("]")
 
 			s = sb.String()
+
+		case arg.isHex:
+			s = fmt.Sprintf("(%s)'%s'=%s", btfx.Repr(arg.t), arg.expr,
+				hex.EncodeToString(data[:arg.trueDataSize]))
 		}
 
 		if s != "" {

--- a/internal/bpfsnoop/output_arg.go
+++ b/internal/bpfsnoop/output_arg.go
@@ -53,6 +53,7 @@ type funcArgumentOutput struct {
 	isPort   bool
 	portType string
 	isSlice  bool
+	isHex    bool
 }
 
 type argDataOutput struct {
@@ -274,7 +275,8 @@ func (arg *funcArgumentOutput) compile(params []btf.FuncParam, spec *btf.Spec, o
 		offset, err = arg.genDerefInsns(&res, offset, size, labelExit)
 
 	case cc.EvalResultTypeBuf, cc.EvalResultTypeString, cc.EvalResultTypePkt,
-		cc.EvalResultTypeAddr, cc.EvalResultTypePort, cc.EvalResultTypeSlice:
+		cc.EvalResultTypeAddr, cc.EvalResultTypePort, cc.EvalResultTypeSlice,
+		cc.EvalResultTypeHex:
 		arg.isBuf = res.Type == cc.EvalResultTypeBuf
 		arg.isString = res.Type == cc.EvalResultTypeString
 		arg.isPkt = res.Type == cc.EvalResultTypePkt
@@ -284,6 +286,7 @@ func (arg *funcArgumentOutput) compile(params []btf.FuncParam, spec *btf.Spec, o
 		arg.isPort = res.Type == cc.EvalResultTypePort
 		arg.portType = res.Port
 		arg.isSlice = res.Type == cc.EvalResultTypeSlice
+		arg.isHex = res.Type == cc.EvalResultTypeHex
 		offset, err = arg.genBufInsns(&res, offset, size, labelExit)
 
 	default:

--- a/internal/cc/expr.go
+++ b/internal/cc/expr.go
@@ -104,6 +104,7 @@ const (
 	EvalResultTypeAddr
 	EvalResultTypePort
 	EvalResultTypeSlice
+	EvalResultTypeHex
 )
 
 type EvalResult struct {

--- a/internal/cc/expr_func.go
+++ b/internal/cc/expr_func.go
@@ -76,7 +76,7 @@ func compileFuncCall(expr *cc.Expr) (funcCallValue, error) {
 
 	fnName := expr.Left.Text
 	switch fnName {
-	case "buf", "slice":
+	case "buf", "slice", "hex":
 		switch len(expr.List) {
 		case 2, 3:
 			val.dataSize, err = parseExprNumber(expr.List[1])
@@ -102,8 +102,12 @@ func compileFuncCall(expr *cc.Expr) (funcCallValue, error) {
 		}
 
 		val.typ = EvalResultTypeBuf
-		if fnName == "slice" {
+		switch fnName {
+		case "slice":
 			val.typ = EvalResultTypeSlice
+
+		case "hex":
+			val.typ = EvalResultTypeHex
 		}
 
 	case "str":
@@ -285,7 +289,7 @@ func postCheckFuncCall(res *EvalResult, val evalValue, dataOffset, dataSize int6
 		res.Btf = ptr.Target
 		res.Size = size
 
-	case EvalResultTypeBuf:
+	case EvalResultTypeBuf, EvalResultTypeHex:
 		t := mybtf.UnderlyingType(val.btf)
 		_, isPtr := t.(*btf.Pointer)
 		_, isArray := t.(*btf.Array)

--- a/internal/cc/expr_func_test.go
+++ b/internal/cc/expr_func_test.go
@@ -419,6 +419,19 @@ func TestCompileFuncCall(t *testing.T) {
 		})
 	})
 
+	t.Run("hex", func(t *testing.T) {
+		t.Run("hex(skb->cb, 14)", func(t *testing.T) {
+			expr, err := cc.ParseExpr("hex(skb->cb, 14)")
+			test.AssertNoErr(t, err)
+
+			val, err := compileFuncCall(expr)
+			test.AssertNoErr(t, err)
+			test.AssertEqual(t, val.typ, EvalResultTypeHex)
+			test.AssertEqual(t, val.dataSize, 14)
+			test.AssertEqual(t, val.dataOffset, 0)
+		})
+	})
+
 	t.Run("unsupported func call", func(t *testing.T) {
 		expr, err := cc.ParseExpr("unsupported(skb->cb)")
 		test.AssertNoErr(t, err)

--- a/t/cc.txt
+++ b/t/cc.txt
@@ -64,3 +64,12 @@ tag: cc,slice
 test: -k dev_xdp_install --output-arg 'slice(prog->aux->used_maps, 1)'
 match: (struct bpf_map *)'slice(prog->aux->used_maps, 1)'=[0xffff
 trigger: ./xdpcrc -d lo
+
+---
+
+# hex()
+name: cc::hex
+tag: cc,hex
+test: -t netif_receive_skb --filter-pkt 'host 127.0.0.1 and icmp' --output-arg 'hex(skb->head + skb->network_header + 12, 8)'
+match: (unsigned char *)'hex(skb->head + skb->network_header + 12, 8)'=7f0000017f000001
+trigger: ping -c 1 -s 64 127.0.0.1


### PR DESCRIPTION
Dump kernel buffer using hex encoding.

```bash
$ sudo ./bpfsnoop -t netif_receive_skb --filter-pkt 'host 1.1.1.1 and tcp' --output-arg 'hex(skb->head + skb->network_header + 12, 8)'
2025/06/26 15:30:56 bpfsnoop is running..
netif_receive_skb[tp] args=((struct sk_buff *)skb=0xffff8f75dafe1a00) cpu=6 process=(0:swapper/6)
Arg attrs: (unsigned char *)'hex(skb->head + skb->network_header + 12, 8)'=01010101c0a8f185
```