### PR TITLE
fnarg,tp: Compile expr using specific btf spec

### DIFF
--- a/internal/bpfsnoop/bpf_tracepoints.go
+++ b/internal/bpfsnoop/bpf_tracepoints.go
@@ -19,6 +19,7 @@ const tpMax = 256
 
 type tracepointInfo struct {
 	name   string
+	kmod   string
 	sym    uint64
 	nrArgs uint32
 

--- a/internal/bpfsnoop/filter_arg.go
+++ b/internal/bpfsnoop/filter_arg.go
@@ -96,9 +96,9 @@ func (arg *funcArgument) matchParams(params []btf.FuncParam) bool {
 	return false
 }
 
-func (arg *funcArgument) inject(prog *ebpf.ProgramSpec, spec *btf.Spec, params []btf.FuncParam) error {
+func (arg *funcArgument) inject(prog *ebpf.ProgramSpec, krnl, spec *btf.Spec, params []btf.FuncParam) error {
 	mode := cc.MemoryReadModeProbeRead
-	if _, err := spec.AnyTypeByName("bpf_rdonly_cast"); err == nil {
+	if _, err := krnl.AnyTypeByName("bpf_rdonly_cast"); err == nil {
 		mode = cc.MemoryReadModeCoreRead
 	}
 
@@ -119,12 +119,12 @@ func (arg *funcArgument) inject(prog *ebpf.ProgramSpec, spec *btf.Spec, params [
 	return nil
 }
 
-func (f *argumentFilter) inject(prog *ebpf.ProgramSpec, params []btf.FuncParam) (int, error) {
+func (f *argumentFilter) inject(prog *ebpf.ProgramSpec, params []btf.FuncParam, spec *btf.Spec) (int, error) {
 	if len(f.args) == 0 {
 		return 0, errSkipped
 	}
 
-	spec, err := btf.LoadKernelSpec()
+	krnl, err := btf.LoadKernelSpec()
 	if err != nil {
 		return 0, fmt.Errorf("failed to load kernel spec: %w", err)
 	}
@@ -134,7 +134,7 @@ func (f *argumentFilter) inject(prog *ebpf.ProgramSpec, params []btf.FuncParam) 
 			continue
 		}
 
-		err := arg.inject(prog, spec, params)
+		err := arg.inject(prog, krnl, spec, params)
 		if err != nil {
 			return 0, err
 		}

--- a/internal/bpfsnoop/kernel_functions.go
+++ b/internal/bpfsnoop/kernel_functions.go
@@ -51,6 +51,7 @@ type FuncParamFlags struct {
 type KFunc struct {
 	Ksym *KsymEntry
 	Func *btf.Func
+	Btf  *btf.Spec
 	Args []funcArgumentOutput
 	Prms []FuncParamFlags
 	Ret  FuncParamFlags
@@ -148,6 +149,7 @@ func findKernelFuncs(funcs, kmods []string, ksyms *Kallsyms, maxArgs int, findMa
 			if fn, ok := iter.Type.(*btf.Func); ok {
 				kf, ok := matchKernelFunc(matchFuncs, fn, maxArgs, ksyms, findManyArgs, silent)
 				if ok {
+					kf.Btf = spec
 					kfuncs[uintptr(kf.Ksym.addr)] = kf
 				}
 			}

--- a/internal/bpfsnoop/output_arg.go
+++ b/internal/bpfsnoop/output_arg.go
@@ -362,13 +362,8 @@ func (arg *argDataOutput) genExitLabel() string {
 	return label
 }
 
-func (arg *argDataOutput) matchParams(params []btf.FuncParam, checkArgType bool) ([]funcArgumentOutput, int, error) {
+func (arg *argDataOutput) matchParams(params []btf.FuncParam, spec *btf.Spec, checkArgType bool) ([]funcArgumentOutput, int, error) {
 	args := make([]funcArgumentOutput, 0, 12)
-
-	spec, err := btf.LoadKernelSpec()
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to load kernel spec: %w", err)
-	}
 
 	params = slices.Clone(params)
 	if checkArgType {
@@ -389,6 +384,7 @@ func (arg *argDataOutput) matchParams(params []btf.FuncParam, checkArgType bool)
 		}
 
 		a := a
+		var err error
 		offset, err = a.compile(params, spec, offset, arg.genExitLabel())
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to compile expr '%s': %w", a.expr, err)


### PR DESCRIPTION
As for kmod, it must use the kmod's BTF spec to compile `--output-arg` and `--filter-arg` expressions, when tracing kmod's functions and tracepoints.