### PR TITLE
fnarg: Output buffer using builtin int funcs

### DIFF
--- a/internal/bpfsnoop/output_arg.go
+++ b/internal/bpfsnoop/output_arg.go
@@ -54,6 +54,8 @@ type funcArgumentOutput struct {
 	portType string
 	isSlice  bool
 	isHex    bool
+	isInt    bool
+	intType  string
 }
 
 type argDataOutput struct {
@@ -277,7 +279,7 @@ func (arg *funcArgumentOutput) compile(params []btf.FuncParam, krnl, spec *btf.S
 
 	case cc.EvalResultTypeBuf, cc.EvalResultTypeString, cc.EvalResultTypePkt,
 		cc.EvalResultTypeAddr, cc.EvalResultTypePort, cc.EvalResultTypeSlice,
-		cc.EvalResultTypeHex:
+		cc.EvalResultTypeHex, cc.EvalResultTypeInt:
 		arg.isBuf = res.Type == cc.EvalResultTypeBuf
 		arg.isString = res.Type == cc.EvalResultTypeString
 		arg.isPkt = res.Type == cc.EvalResultTypePkt
@@ -288,6 +290,8 @@ func (arg *funcArgumentOutput) compile(params []btf.FuncParam, krnl, spec *btf.S
 		arg.portType = res.Port
 		arg.isSlice = res.Type == cc.EvalResultTypeSlice
 		arg.isHex = res.Type == cc.EvalResultTypeHex
+		arg.isInt = res.Type == cc.EvalResultTypeInt
+		arg.intType = res.Int
 		offset, err = arg.genBufInsns(&res, offset, size, labelExit)
 
 	default:

--- a/internal/cc/expr.go
+++ b/internal/cc/expr.go
@@ -105,6 +105,7 @@ const (
 	EvalResultTypePort
 	EvalResultTypeSlice
 	EvalResultTypeHex
+	EvalResultTypeInt
 )
 
 type EvalResult struct {
@@ -118,6 +119,7 @@ type EvalResult struct {
 	Pkt   string // pkt type, e.g. "eth", "ip4", "ip6", "icmp", "icmp6", "tcp" and "udp"
 	Addr  string // addr type, e.g. "eth", "eth2", "ip4", "ip42", "ip6", "ip62"
 	Port  string // port type, e.g. "port", "port2"
+	Int   string // number type, e.g. "u8", "u16", "u32", "u64", "s8", "s16", "s32", "s64", "le16", "le32", "le64", "be16", "be32" and "be64"
 
 	LabelUsed bool
 }

--- a/t/cc.txt
+++ b/t/cc.txt
@@ -93,3 +93,13 @@ test: -p 'n:crc' --filter-pkt 'host 127.0.0.1 and icmp' --output-arg '*(int *)(c
 match: (int)'*(int *)(ctx->data + 14 + 12)'=16777343
 prerequisite: ./xdpcrc -d lo
 trigger: ping -c 1 -s 64 127.0.0.1
+
+---
+
+# be32()
+name: cc::be32
+tag: cc,int
+test: -p 'n:crc' --filter-pkt 'host 127.0.0.1 and icmp' --output-arg 'be32(ctx->data + 14 + 12)'
+match: (void *)'be32(ctx->data + 14 + 12)'=0x7f000001/2130706433
+prerequisite: ./xdpcrc -d lo
+trigger: ping -c 1 -s 64 127.0.0.1


### PR DESCRIPTION
It's to dump kernel buffer as an int conveniently:

```bash
$ sudo ./bpfsnoop -p 'n:crc' --filter-pkt 'host 127.0.0.1 and icmp' --output-arg 'be32(ctx->data + 14 + 12)'
2025/06/29 14:51:00 bpfsnoop is running..
crc[bpf][ex] args=((struct xdp_md *)ctx=0xffffae0780634d30) retval=XDP_PASS cpu=7 process=(165602:ping)
Arg attrs: (void *)'be32(ctx->data + 14 + 12)'=0x7f000001/2130706433
```