### PR TITLE
fninsn: Add --output-insns

### DIFF
--- a/internal/bpfsnoop/bpf_tracing.go
+++ b/internal/bpfsnoop/bpf_tracing.go
@@ -515,8 +515,8 @@ func (t *bpfTracing) traceInsn(spec *ebpf.CollectionSpec, reusedMaps map[string]
 	}
 	defer coll.Close()
 
-	prog := coll.Programs["k_insn"]
-	delete(coll.Programs, "k_insn")
+	prog := coll.Programs["bpfsnoop_insn"]
+	delete(coll.Programs, "bpfsnoop_insn")
 	l, err := link.Kprobe(insn.Func, prog, &link.KprobeOptions{
 		Offset: insn.Off,
 	})

--- a/internal/bpfsnoop/flags.go
+++ b/internal/bpfsnoop/flags.go
@@ -30,6 +30,7 @@ var (
 
 	outputLbr       bool
 	outputFuncStack bool
+	outputFuncInsns bool
 	outputPkt       bool
 	filterPid       uint32
 	kfuncAllKmods   bool
@@ -78,6 +79,7 @@ func ParseFlags() (*Flags, error) {
 	f.BoolVar(&outputLbr, "output-lbr", false, "output LBR perf event")
 	f.BoolVar(&outputFuncStack, "output-stack", false, "output function call stack")
 	f.StringVar(&outputFlameGraph, "output-flamegraph", "", "output flamegraph fold data")
+	f.BoolVar(&outputFuncInsns, "output-insns", false, "output function's insns exec path, same as '(i)' in -k, only works with -k")
 	f.BoolVar(&outputPkt, "output-pkt", false, "output packet's tuple info if tracee has skb/xdp argument")
 	f.Uint32Var(&filterPid, "filter-pid", 0, "filter pid for tracing")
 	f.StringSliceVar(&filterArg, "filter-arg", nil, "filter function's argument with C expression, e.g. 'prog->type == BPF_PROG_TYPE_TRACING'")

--- a/internal/bpfsnoop/flags_kfunc.go
+++ b/internal/bpfsnoop/flags_kfunc.go
@@ -22,6 +22,7 @@ func parseKfuncFlag(k string) (KfuncFlag, error) {
 		kf.insn = true
 		k = k[3:]
 	}
+	kf.insn = kf.insn || outputFuncInsns
 
 	fields := strings.Split(k, ":")
 	switch len(fields) {

--- a/t/fninsn.txt
+++ b/t/fninsn.txt
@@ -9,3 +9,12 @@ tag: fninsn,pkt
 test: -k '(i)icmp_rcv' --filter-pkt 'host 127.0.0.1' --trace-insn-debug-cnt 10
 match: andq	$0xfffffffffffffffe, %r12
 trigger: ping -c 1 -s 64 127.0.0.1
+
+---
+
+# icmp_rcv
+name: fninsn::icmp_rcv:output-insns
+tag: fninsn,pkt
+test: -k 'icmp_rcv' --filter-pkt 'host 127.0.0.1' --output-insns --trace-insn-debug-cnt 10
+match: andq	$0xfffffffffffffffe, %r12
+trigger: ping -c 1 -s 64 127.0.0.1


### PR DESCRIPTION
As `-k '(i)'` is not obvious like `--output-insns`.

And:

1. Rename fninsn bpf prog name from `k_insn` to `bpfsnoop_insn`.
2. Output fninsn event by reserving then submitting ringbuf.