### PR TITLE
makefile: Move bpf objects to internal/bpf 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,28 +27,28 @@ $(VMLINUX_OBJ):
 	$(CMD_BPFTOOL) btf dump file /sys/kernel/btf/vmlinux format c > $(VMLINUX_OBJ)
 
 $(FEAT_BPF_OBJ): $(FEAT_BPF_SRC) $(VMLINUX_OBJ) $(LIBBPF_OBJ)
-	$(BPF2GO) feat bpf/feature.c -- $(BPF2GO_EXTRA_FLAGS)
+	$(BPF2GO) Feat $(CURDIR)/bpf/feature.c -- $(BPF2GO_EXTRA_FLAGS)
 
 $(TRACEABLE_BPF_OBJ): $(TRACEABLE_BPF_SRC) $(VMLINUX_OBJ) $(LIBBPF_OBJ)
-	$(BPF2GO) traceable bpf/traceable.c -- $(BPF2GO_EXTRA_FLAGS)
+	$(BPF2GO) Traceable $(CURDIR)/bpf/traceable.c -- $(BPF2GO_EXTRA_FLAGS)
 
 $(TRACEPOINT_BPF_OBJ): $(TRACEPOINT_BPF_SRC) $(VMLINUX_OBJ) $(LIBBPF_OBJ)
-	$(BPF2GO) tracepoint bpf/tracepoint.c -- $(BPF2GO_EXTRA_FLAGS)
+	$(BPF2GO) Tracepoint $(CURDIR)/bpf/tracepoint.c -- $(BPF2GO_EXTRA_FLAGS)
 
 $(TRACEPOINT_MODULE_BPF_OBJ): $(TRACEPOINT_MODULE_BPF_SRC) $(VMLINUX_OBJ) $(LIBBPF_OBJ)
-	$(BPF2GO) tracepoint_module bpf/tracepoint_module.c -- $(BPF2GO_EXTRA_FLAGS)
+	$(BPF2GO) Tracepoint_module $(CURDIR)/bpf/tracepoint_module.c -- $(BPF2GO_EXTRA_FLAGS)
 
 $(READ_BPF_OBJ): $(READ_BPF_SRC) $(VMLINUX_OBJ) $(LIBBPF_OBJ)
-	$(BPF2GO) read bpf/read.c -- $(BPF2GO_EXTRA_FLAGS)
+	$(BPF2GO) Read $(CURDIR)/bpf/read.c -- $(BPF2GO_EXTRA_FLAGS)
 
 $(TAILCALL_BPF_OBJ): $(TAILCALL_BPF_SRC) $(VMLINUX_OBJ) $(LIBBPF_OBJ)
-	$(BPF2GO) tailcall bpf/tailcall.c -- $(BPF2GO_EXTRA_FLAGS)
+	$(BPF2GO) Tailcall $(CURDIR)/bpf/tailcall.c -- $(BPF2GO_EXTRA_FLAGS)
 
 $(INSN_BPF_OBJ): $(INSN_BPF_SRC) $(VMLINUX_OBJ) $(LIBBPF_OBJ)
-	$(BPF2GO) insn bpf/bpfsnoop_insn.c -- $(BPF2GO_EXTRA_FLAGS)
+	$(BPF2GO) Insn $(CURDIR)/bpf/bpfsnoop_insn.c -- $(BPF2GO_EXTRA_FLAGS)
 
 $(BPFSNOOP_BPF_OBJ): $(BPFSNOOP_BPF_SRC) $(VMLINUX_OBJ) $(LIBBPF_OBJ)
-	$(BPF2GO) bpfsnoop bpf/bpfsnoop.c -- $(BPF2GO_EXTRA_FLAGS)
+	$(BPF2GO) Bpfsnoop $(CURDIR)/bpf/bpfsnoop.c -- $(BPF2GO_EXTRA_FLAGS)
 
 $(BPFSNOOP_OBJ): $(BPF_OBJS) $(BPFSNOOP_SRC) $(LIBCAPSTONE_OBJ) $(LIBPCAP_OBJ)
 	$(GOBUILD_CGO_CFLAGS) $(GOBUILD_CGO_LDFLAGS) $(GOBUILD)
@@ -60,8 +60,8 @@ local_release: $(BPFSNOOP_OBJ)
 
 .PHONY: clean
 clean:
-	rm -f $(BPF_OBJS)
-	rm -f $(BPFSNOOP_OBJ)
+	rm -f $(BPF_OBJS) $(XDPCRC_BPF_OBJ)
+	rm -f $(BPFSNOOP_OBJ) $(XDPCRC_OBJ) $(LOCALTEST_OBJ)
 	rm -rf $(DIR_BIN)/*
 	@touch $(DIR_BIN)/.gitkeep
 
@@ -84,7 +84,8 @@ $(LOCALTEST_OBJ): $(LOCALTEST_SRC)
 	$(GOBUILD) -o $(LOCALTEST_OBJ) ./cmd/localtest
 
 $(XDPCRC_OBJ): $(XDPCRC_SRC)
-	$(BPF2GO) xdp $(XDPCRC_DIR)/xdp.c -- $(BPF2GO_EXTRA_FLAGS) && mv ./xdp_bpf* $(XDPCRC_DIR)
+	cd ./cmd/xdpcrc && \
+		$(GO_RUN_BPF2GO) -go-package main xdp ./xdp.c -- $(BPF2GO_EXTRA_FLAGS)
 	$(GOBUILD) -o $(XDPCRC_OBJ) $(XDPCRC_DIR)
 
 .PHONY: testlocal

--- a/internal/bpf/.gitkeep
+++ b/internal/bpf/.gitkeep
@@ -1,0 +1,3 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+

--- a/internal/bpfsnoop/bpf_tail_call.go
+++ b/internal/bpfsnoop/bpf_tail_call.go
@@ -41,7 +41,7 @@ func isTailcallReachable(insns []byte) bool {
 	return tailcallReachable
 }
 
-func probeTailcallInfo(prog *ebpf.Program, readSpec *ebpf.CollectionSpec) (TailcallInfo, error) {
+func probeTailcallInfo(prog *ebpf.Program) (TailcallInfo, error) {
 	var info TailcallInfo
 
 	pinfo, err := prog.Info()
@@ -73,7 +73,7 @@ func probeTailcallInfo(prog *ebpf.Program, readSpec *ebpf.CollectionSpec) (Tailc
 	offset := binary.NativeEndian.Uint32(jinsns[1:])
 	kaddrTramp := kaddr + 5 /* next insn */ + uintptr(offset) /* callq target */
 
-	data, err := readKernel(readSpec, uint64(kaddrTramp), 512)
+	data, err := readKernel(uint64(kaddrTramp), 512)
 	if err != nil {
 		return info, fmt.Errorf("failed to read kernel memory from %#x: %w", kaddrTramp, err)
 	}
@@ -117,7 +117,7 @@ func probeTailcallInfo(prog *ebpf.Program, readSpec *ebpf.CollectionSpec) (Tailc
 	return info, nil
 }
 
-func ProbeTailcallIssue(spec, tailcallSpec, readSpec *ebpf.CollectionSpec) error {
+func ProbeTailcallIssue(spec, tailcallSpec *ebpf.CollectionSpec) error {
 	tcColl, err := ebpf.NewCollection(tailcallSpec)
 	if err != nil {
 		if errors.Is(err, unix.EINVAL) &&
@@ -165,7 +165,7 @@ func ProbeTailcallIssue(spec, tailcallSpec, readSpec *ebpf.CollectionSpec) error
 	}
 	defer l.Close()
 
-	info, err := probeTailcallInfo(tcProg, readSpec)
+	info, err := probeTailcallInfo(tcProg)
 	if err != nil {
 		return fmt.Errorf("failed to probe tailcall info: %w", err)
 	}

--- a/internal/bpfsnoop/disasm.go
+++ b/internal/bpfsnoop/disasm.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/Asphaltt/addr2line"
 	"github.com/bpfsnoop/gapstone"
-	"github.com/cilium/ebpf"
 	"github.com/fatih/color"
 	"golang.org/x/exp/maps"
 
@@ -25,7 +24,7 @@ const (
 	kcorePath = "/proc/kcore"
 )
 
-func Disasm(f *Flags, readSpec *ebpf.CollectionSpec) {
+func Disasm(f *Flags) {
 	assert.False(len(f.progs) != 0 && len(f.kfuncs) != 0, "progs %v or kfuncs %v to be disassembled?", f.progs, f.kfuncs)
 
 	if len(f.progs) != 0 {
@@ -40,7 +39,7 @@ func Disasm(f *Flags, readSpec *ebpf.CollectionSpec) {
 	if len(f.kfuncs) != 0 {
 		assert.SliceLen(f.kfuncs, 1, "Only one --kfunc is allowed for --disasm")
 
-		dumpKfunc(f.kfuncs[0], kfuncKmods, f.disasmBytes, readSpec)
+		dumpKfunc(f.kfuncs[0], kfuncKmods, f.disasmBytes)
 		return
 	}
 }
@@ -144,7 +143,7 @@ func parseDisasmKfunc(kfunc string, kmods []string, ksyms *Kallsyms, a2l *Addr2L
 	return kaddr, kfunc
 }
 
-func dumpKfunc(kfunc string, kmods []string, bytes uint, readSpec *ebpf.CollectionSpec) {
+func dumpKfunc(kfunc string, kmods []string, bytes uint) {
 	assert.True(runtime.GOARCH == "amd64", "Only support amd64 arch")
 
 	VerboseLog("Reading /proc/kallsyms ..")
@@ -177,7 +176,7 @@ func dumpKfunc(kfunc string, kmods []string, bytes uint, readSpec *ebpf.Collecti
 
 	bytes = guessBytes(uintptr(kaddr), kallsyms, bytes)
 	assert.False(bytes > readLimit, "Disasm bytes %d is larger than limit %d", bytes, readLimit)
-	data, err := readKernel(readSpec, kaddr, uint32(bytes))
+	data, err := readKernel(kaddr, uint32(bytes))
 	assert.NoErr(err, "Failed to read kernel memory: %v")
 
 	data = trimTailingInsns(data)

--- a/main.go
+++ b/main.go
@@ -27,11 +27,8 @@ func main() {
 	flags, err := bpfsnoop.ParseFlags()
 	assert.NoErr(err, "Failed to parse flags: %v")
 
-	readSpec, err := bpf.LoadRead()
-	assert.NoErr(err, "Failed to load read bpf spec: %v")
-
 	if flags.Disasm() {
-		bpfsnoop.Disasm(flags, readSpec)
+		bpfsnoop.Disasm(flags)
 		return
 	}
 
@@ -84,7 +81,7 @@ func main() {
 	tailcallSpec, err := bpf.LoadTailcall()
 	assert.NoErr(err, "Failed to load tailcall bpf spec: %v")
 
-	err = bpfsnoop.ProbeTailcallIssue(bpfSpec, tailcallSpec, readSpec)
+	err = bpfsnoop.ProbeTailcallIssue(bpfSpec, tailcallSpec)
 	assert.NoVerifierErr(err, "Failed to probe tailcall info: %v")
 
 	err = bpfSpec.Variables["PID"].Set(uint32(os.Getpid()))
@@ -133,7 +130,7 @@ func main() {
 	insnSpec, err := bpf.LoadInsn()
 	assert.NoErr(err, "Failed to load insn bpf spec: %v")
 
-	insns, err := bpfsnoop.NewFuncInsns(kfuncs, kallsyms, readSpec)
+	insns, err := bpfsnoop.NewFuncInsns(kfuncs, kallsyms)
 	assert.NoErr(err, "Failed to create func insns: %v")
 
 	bpfsnoop.VerboseLog("Disassembling bpf progs ..")

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/bpfsnoop/bpfsnoop/internal/assert"
+	"github.com/bpfsnoop/bpfsnoop/internal/bpf"
 	"github.com/bpfsnoop/bpfsnoop/internal/bpfsnoop"
 	"github.com/bpfsnoop/bpfsnoop/internal/mathx"
 )
@@ -26,7 +27,7 @@ func main() {
 	flags, err := bpfsnoop.ParseFlags()
 	assert.NoErr(err, "Failed to parse flags: %v")
 
-	readSpec, err := loadRead()
+	readSpec, err := bpf.LoadRead()
 	assert.NoErr(err, "Failed to load read bpf spec: %v")
 
 	if flags.Disasm() {
@@ -34,10 +35,10 @@ func main() {
 		return
 	}
 
-	tpSpec, err := loadTracepoint()
+	tpSpec, err := bpf.LoadTracepoint()
 	assert.NoErr(err, "Failed to load tracepoint bpf spec: %v")
 
-	tpModSpec, err := loadTracepoint_module()
+	tpModSpec, err := bpf.LoadTracepoint_module()
 	assert.NoErr(err, "Failed to load tracepoint_module bpf spec: %v")
 
 	if flags.ShowFuncProto() {
@@ -48,7 +49,7 @@ func main() {
 	progs, err := flags.ParseProgs()
 	assert.NoErr(err, "Failed to parse bpf prog infos: %v")
 
-	featBPFSpec, err := loadFeat()
+	featBPFSpec, err := bpf.LoadFeat()
 	assert.NoErr(err, "Failed to load feat bpf spec: %v")
 
 	err = bpfsnoop.DetectBPFFeatures(featBPFSpec)
@@ -68,10 +69,10 @@ func main() {
 	kallsyms, err := bpfsnoop.NewKallsyms()
 	assert.NoErr(err, "Failed to read /proc/kallsyms: %v")
 
-	traceableBPFSpec, err := loadTraceable()
+	traceableBPFSpec, err := bpf.LoadTraceable()
 	assert.NoErr(err, "Failed to load traceable bpf spec: %v")
 
-	bpfSpec, err := loadBpfsnoop()
+	bpfSpec, err := bpf.LoadBpfsnoop()
 	assert.NoErr(err, "Failed to load bpf spec: %v")
 
 	numCPU, err := ebpf.PossibleCPU()
@@ -80,7 +81,7 @@ func main() {
 	err = bpfSpec.Variables["CPU_MASK"].Set(uint32(mathx.Mask(numCPU)))
 	assert.NoErr(err, "Failed to set CPU_MASK: %v")
 
-	tailcallSpec, err := loadTailcall()
+	tailcallSpec, err := bpf.LoadTailcall()
 	assert.NoErr(err, "Failed to load tailcall bpf spec: %v")
 
 	err = bpfsnoop.ProbeTailcallIssue(bpfSpec, tailcallSpec, readSpec)
@@ -129,7 +130,7 @@ func main() {
 		assert.NoErr(err, "Failed to create addr2line: %v")
 	}
 
-	insnSpec, err := loadInsn()
+	insnSpec, err := bpf.LoadInsn()
 	assert.NoErr(err, "Failed to load insn bpf spec: %v")
 
 	insns, err := bpfsnoop.NewFuncInsns(kfuncs, kallsyms, readSpec)

--- a/makefiles/variables.mk
+++ b/makefiles/variables.mk
@@ -16,36 +16,38 @@ CMD_GIT ?= git
 CMD_GIT_MODULES ?= $(CMD_GIT) submodule
 
 DIR_BIN := ./bin
+DIR_BPF := ./internal/bpf
 
 GOBUILD := go build -v -trimpath
 GOBUILD_CGO_CFLAGS := CGO_CFLAGS='-O2 -I$(CURDIR)/lib/capstone/include -I$(CURDIR)/lib/libpcap'
 GOBUILD_CGO_LDFLAGS := CGO_LDFLAGS='-O2 -g -L$(CURDIR)/lib/capstone/build -lcapstone -L$(CURDIR)/lib/libpcap -lpcap -static'
 
-BPF2GO := go run github.com/cilium/ebpf/cmd/bpf2go -cc clang -go-package main
-BPF2GO_EXTRA_FLAGS := -g -D__TARGET_ARCH_x86 -I./bpf -I./bpf/headers -I./lib/libbpf/src -Wno-address-of-packed-member -Wall
+GO_RUN_BPF2GO := go run github.com/cilium/ebpf/cmd/bpf2go -cc clang
+BPF2GO := cd $(DIR_BPF) && $(GO_RUN_BPF2GO) -go-package bpf
+BPF2GO_EXTRA_FLAGS := -g -D__TARGET_ARCH_x86 -I$(CURDIR)/bpf -I$(CURDIR)/bpf/headers -I$(CURDIR)/lib/libbpf/src -Wno-address-of-packed-member -Wall
 
-BPFSNOOP_BPF_OBJ := bpfsnoop_bpfel.o bpfsnoop_bpfeb.o
+BPFSNOOP_BPF_OBJ := $(DIR_BPF)/bpfsnoop_bpfel.o $(DIR_BPF)/bpfsnoop_bpfeb.o
 BPFSNOOP_BPF_SRC := bpf/bpfsnoop.c $(wildcard bpf/*.h) $(wildcard bpf/headers/*.h)
 
-INSN_BPF_OBJ := insn_bpfel.o insn_bpfeb.o
+INSN_BPF_OBJ := $(DIR_BPF)/insn_bpfel.o $(DIR_BPF)/insn_bpfeb.o
 INSN_BPF_SRC := bpf/bpfsnoop_insn.c bpf/bpfsnoop_event.h bpf/bpfsnoop_sess.h
 
-FEAT_BPF_OBJ := feat_bpfel.o feat_bpfeb.o
+FEAT_BPF_OBJ := $(DIR_BPF)/feat_bpfel.o $(DIR_BPF)/feat_bpfeb.o
 FEAT_BPF_SRC := bpf/feature.c
 
-TRACEABLE_BPF_OBJ := traceable_bpfel.o traceable_bpfeb.o
+TRACEABLE_BPF_OBJ := $(DIR_BPF)/traceable_bpfel.o $(DIR_BPF)/traceable_bpfeb.o
 TRACEABLE_BPF_SRC := bpf/traceable.c
 
-TRACEPOINT_BPF_OBJ := tracepoint_bpfel.o tracepoint_bpfeb.o
+TRACEPOINT_BPF_OBJ := $(DIR_BPF)/tracepoint_bpfel.o $(DIR_BPF)/tracepoint_bpfeb.o
 TRACEPOINT_BPF_SRC := bpf/tracepoint.c
 
-TRACEPOINT_MODULE_BPF_OBJ := tracepoint_module_bpfel.o tracepoint_module_bpfeb.o
+TRACEPOINT_MODULE_BPF_OBJ := $(DIR_BPF)/tracepoint_module_bpfel.o $(DIR_BPF)/tracepoint_module_bpfeb.o
 TRACEPOINT_MODULE_BPF_SRC := bpf/tracepoint_module.c
 
-READ_BPF_OBJ := read_bpfel.o read_bpfeb.o
+READ_BPF_OBJ := $(DIR_BPF)/read_bpfel.o $(DIR_BPF)/read_bpfeb.o
 READ_BPF_SRC := bpf/read.c
 
-TAILCALL_BPF_OBJ := tailcall_bpfel.o tailcall_bpfeb.o
+TAILCALL_BPF_OBJ := $(DIR_BPF)/tailcall_bpfel.o $(DIR_BPF)/tailcall_bpfeb.o
 TAILCALL_BPF_SRC := bpf/tailcall.c
 
 BPF_OBJS := $(BPFSNOOP_BPF_OBJ) \
@@ -76,5 +78,6 @@ LOCALTEST_OBJ := localtest
 LOCALTEST_SRC := $(shell find ./cmd/localtest/ -type f -name '*.go')
 
 XDPCRC_DIR := ./cmd/xdpcrc
+XDPCRC_BPF_OBJ := $(XDPCRC_DIR)/xdp_bpfel.o $(DIR_BPF)/xdp_bpfeb.o
 XDPCRC_OBJ := xdpcrc
 XDPCRC_SRC := $(wildcard $(XDPCRC_DIR)/cmd/xdpcrc/*.go) $(wildcard $(XDPCRC_DIR)/cmd/xdpcrc/*.c)


### PR DESCRIPTION
Clean the file list in project root directory.

Thereafter, it can load bpf spec of reading kernel in `readKernel()` instead of passing it everywhere.