### PR TITLE
bpfsnoop: Fix running exit mode by default

### DIFF
--- a/internal/bpfsnoop/bpf_disasm.go
+++ b/internal/bpfsnoop/bpf_disasm.go
@@ -1,0 +1,26 @@
+// Copyright 2025 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package bpfsnoop
+
+import (
+	"fmt"
+
+	"github.com/bpfsnoop/gapstone"
+)
+
+func disasmKfuncAt(kaddr uint64, bytes uint, ksyms *Kallsyms, engine *gapstone.Engine) ([]gapstone.Instruction, error) {
+	bytes = guessBytes(uintptr(kaddr), ksyms, bytes)
+	data, err := readKernel(kaddr, uint32(bytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %d bytes kernel memory from %#x: %w", bytes, kaddr, err)
+	}
+
+	data = trimTailingInsns(data)
+	insns, err := engine.Disasm(data, kaddr, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to disassemble insns: %w", err)
+	}
+
+	return insns, nil
+}

--- a/internal/bpfsnoop/bpf_feature.go
+++ b/internal/bpfsnoop/bpf_feature.go
@@ -14,7 +14,10 @@ import (
 	"github.com/bpfsnoop/bpfsnoop/internal/bpf"
 )
 
-var hasEndbr bool
+var (
+	hasEndbr    bool
+	requiredLbr bool
+)
 
 type BPFFeatures struct {
 	Run               bool
@@ -60,7 +63,7 @@ func DetectBPFFeatures() error {
 		return errors.New("ringbuf map not supported")
 	}
 
-	if outputLbr {
+	if requiredLbr {
 		krnl := getKernelBTF()
 
 		bpfFuncIDs, err := krnl.AnyTypeByName("bpf_func_id")
@@ -81,7 +84,7 @@ func DetectBPFFeatures() error {
 		}
 
 		if !feat.HasBranchSnapshot {
-			return errors.New("bpf_get_branch_snapshot() helper not supported for --output-lbr")
+			return errors.New("bpf_get_branch_snapshot() helper not supported for output LBR")
 		}
 	}
 

--- a/internal/bpfsnoop/bpf_tracing.go
+++ b/internal/bpfsnoop/bpf_tracing.go
@@ -238,7 +238,7 @@ func (t *bpfTracing) injectPktFilter(prog *ebpf.ProgramSpec, params []btf.FuncPa
 			return err
 		}
 
-		DebugLog("Injected --filter-pkt expr to %dth param (%s)%s of %s", i, btfx.Repr(typ), p.Name, fnName)
+		DebugLog("Injected --filter-pkt expr to %dth param (%s)'%s' of %s", i, btfx.Repr(typ), p.Name, fnName)
 		return nil
 	}
 
@@ -268,17 +268,17 @@ func (t *bpfTracing) injectPktOutput(pkt bool, prog *ebpf.ProgramSpec, params []
 		switch stt.Name {
 		case "sk_buff", "__sk_buff":
 			pktOutput.outputSkb(prog, i)
-			DebugLog("Injected --output-pkt to %dth param (%s)%s of %s", i, p.Name, btfx.Repr(p.Type), fnName)
+			DebugLog("Injected --output-pkt to %dth param (%s)'%s' of %s", i, p.Name, btfx.Repr(p.Type), fnName)
 			return true
 
 		case "xdp_buff", "xdp_md":
 			pktOutput.outputXdpBuff(prog, i)
-			DebugLog("Injected --output-pkt to %dth param (%s)%s of %s", i, p.Name, btfx.Repr(p.Type), fnName)
+			DebugLog("Injected --output-pkt to %dth param (%s)'%s' of %s", i, p.Name, btfx.Repr(p.Type), fnName)
 			return true
 
 		case "xdp_frame":
 			pktOutput.outputXdpFrame(prog, i)
-			DebugLog("Injected --output-pkt to %dth param (%s)%s of %s", i, p.Name, btfx.Repr(p.Type), fnName)
+			DebugLog("Injected --output-pkt to %dth param (%s)'%s' of %s", i, p.Name, btfx.Repr(p.Type), fnName)
 			return true
 		}
 	}

--- a/internal/bpfsnoop/bpf_tracing_func.go
+++ b/internal/bpfsnoop/bpf_tracing_func.go
@@ -165,13 +165,17 @@ func (t *bpfTracing) traceFuncs(errg *errgroup.Group, spec *ebpf.CollectionSpec,
 			continue
 		}
 
-		errg.Go(func() error {
-			return t.traceFunc(spec, reusedMaps, fn, bothEntryExit, bothEntryExit, fn.Flag.stack)
-		})
-
 		if bothEntryExit {
 			errg.Go(func() error {
-				return t.traceFunc(spec, reusedMaps, fn, bothEntryExit, false, false)
+				return t.traceFunc(spec, reusedMaps, fn, true, false, false)
+			})
+
+			errg.Go(func() error {
+				return t.traceFunc(spec, reusedMaps, fn, true, true, fn.Flag.stack)
+			})
+		} else {
+			errg.Go(func() error {
+				return t.traceFunc(spec, reusedMaps, fn, false, hasModeExit(), fn.Flag.stack)
 			})
 		}
 	}

--- a/internal/bpfsnoop/bpf_tracing_prog.go
+++ b/internal/bpfsnoop/bpf_tracing_prog.go
@@ -115,13 +115,17 @@ func (t *bpfTracing) traceProgs(errg *errgroup.Group, spec *ebpf.CollectionSpec,
 		bothEntryExit := info.flag.graph || info.flag.both
 		info := info
 
-		errg.Go(func() error {
-			return t.traceProg(spec, reusedMaps, info, bprogs, bothEntryExit, bothEntryExit, info.flag.stack)
-		})
-
 		if bothEntryExit {
 			errg.Go(func() error {
-				return t.traceProg(spec, reusedMaps, info, bprogs, bothEntryExit, false, false)
+				return t.traceProg(spec, reusedMaps, info, bprogs, true, false, false)
+			})
+
+			errg.Go(func() error {
+				return t.traceProg(spec, reusedMaps, info, bprogs, true, true, info.flag.stack)
+			})
+		} else {
+			errg.Go(func() error {
+				return t.traceProg(spec, reusedMaps, info, bprogs, false, hasModeExit(), info.flag.stack)
 			})
 		}
 	}

--- a/internal/bpfsnoop/bpfsnoop.go
+++ b/internal/bpfsnoop/bpfsnoop.go
@@ -66,7 +66,7 @@ func Run(reader *ringbuf.Reader, maps map[string]*ebpf.Map, w io.Writer, helpers
 	lbrs := maps["bpfsnoop_lbrs"]
 
 	runDelta := runDurationThreshold
-	DebugLog("Run duration threshold: %s", runDelta)
+	debugLogIf(runDelta > 0, "Run duration threshold: %s", runDelta)
 
 	var lbrData LbrData
 

--- a/internal/bpfsnoop/flags.go
+++ b/internal/bpfsnoop/flags.go
@@ -150,14 +150,17 @@ func ParseFlags() (*Flags, error) {
 		return nil, fmt.Errorf("--fgraph-max-depth is larger than limit 500")
 	}
 
+	requiredLbr = outputLbr
 	for _, s := range flags.kfuncs {
 		flags.requiredVmlinux = flags.requiredVmlinux || strings.Contains(s, "(s)")
+		requiredLbr = requiredLbr || strings.Contains(s, "(l)")
 	}
 	for _, s := range flags.ktps {
 		flags.requiredVmlinux = flags.requiredVmlinux || strings.Contains(s, "(s)")
 	}
 	for _, s := range flags.progs {
 		flags.requiredVmlinux = flags.requiredVmlinux || strings.Contains(s, "(s)")
+		requiredLbr = requiredLbr || strings.Contains(s, "(l)")
 	}
 	flags.requiredVmlinux = !flags.noVmlinux &&
 		(flags.requiredVmlinux || outputFuncStack || outputLbr)
@@ -219,7 +222,7 @@ func (f *Flags) Disasm() bool {
 }
 
 func (f *Flags) OutputLbr() bool {
-	return outputLbr
+	return requiredLbr
 }
 
 func (f *Flags) ShowFuncProto() bool {

--- a/internal/bpfsnoop/flags.go
+++ b/internal/bpfsnoop/flags.go
@@ -59,6 +59,7 @@ type Flags struct {
 	fgraphExtra   []string
 	fgraphDepth   uint
 	fgraphProto   bool
+	fgraphDebug   bool
 
 	outputFile string
 
@@ -98,6 +99,7 @@ func ParseFlags() (*Flags, error) {
 	f.StringSliceVar(&flags.fgraphExclude, "fgraph-exclude", nil, "exclude functions in function call graph, empty means no exclude, rules are same as -k")
 	f.StringSliceVar(&flags.fgraphExtra, "fgraph-extra", nil, "extra functions in function call graph as depth 1, rules are same as -k")
 	f.BoolVar(&flags.fgraphProto, "fgraph-proto", false, "output function prototype in function call graph, like --show-func-proto")
+	f.BoolVar(&flags.fgraphDebug, "fgraph-debug", false, "debug deadlock caused by fgraph")
 	f.BoolVar(&outputPkt, "output-pkt", false, "output packet's tuple info if tracee has skb/xdp argument")
 	f.Uint32Var(&filterPid, "filter-pid", 0, "filter pid for tracing")
 	f.StringSliceVar(&filterArg, "filter-arg", nil, "filter function's argument with C expression, e.g. 'prog->type == BPF_PROG_TYPE_TRACING'")
@@ -120,6 +122,7 @@ func ParseFlags() (*Flags, error) {
 	f.MarkHidden("trace-insn-debug-cnt")
 	f.MarkHidden("no-vmlinux")
 	f.MarkHidden("duration-threshold")
+	f.MarkHidden("fgraph-debug")
 
 	err := f.Parse(os.Args)
 

--- a/internal/bpfsnoop/func_graph.go
+++ b/internal/bpfsnoop/func_graph.go
@@ -217,7 +217,7 @@ func FindGraphFuncs(ctx context.Context, flags *Flags, kfuncs KFuncs, bprogs *bp
 	}
 
 	for ip, graph := range parser.graphs {
-		if g, ok := denylist[ip]; ok {
+		if g, ok := denylist[ip]; ok && !flags.fgraphDebug {
 			if g.Bprog != nil {
 				_ = g.Bprog.prog.Close() // close the bpf prog if it was denied
 			}

--- a/internal/bpfsnoop/func_graph_parser.go
+++ b/internal/bpfsnoop/func_graph_parser.go
@@ -119,14 +119,7 @@ func (p *FuncGraphParser) parse(ip uint64, bytes uint, depth uint, isBPF bool, t
 		return nil // already parsed, skip further processing
 	}
 
-	data, err := readKernel(ip, uint32(bytes))
-	if err != nil {
-		return fmt.Errorf("failed to read %d bytes kernel memory from %#x: %w", bytes, ip, err)
-	}
-
-	data = trimTailingInsns(data)
-
-	insts, err := p.engine.Disasm(data, ip, 0)
+	insts, err := disasmKfuncAt(ip, bytes, p.ksyms, p.engine)
 	if err != nil {
 		return fmt.Errorf("failed to disassemble %d bytes kernel memory from %#x: %w", bytes, ip, err)
 	}

--- a/internal/bpfsnoop/func_graph_proto.go
+++ b/internal/bpfsnoop/func_graph_proto.go
@@ -139,12 +139,9 @@ func (p *fgraphProto) parse(ctx context.Context, ip uint64, bytes, depth uint) {
 	callees, ok := p.callees[ip]
 
 	if !ok {
-		data, err := readKernel(ip, uint32(bytes))
-		assert.NoErr(err, "Failed to read kernel memory at %x: %v", ip, err)
+		insts, err := disasmKfuncAt(ip, bytes, p.ksyms, p.engine)
+		assert.NoErr(err, "Failed to disassemble insns at %x: %v", ip, err)
 
-		data = trimTailingInsns(data)
-
-		insts, err := p.engine.Disasm(data, ip, 0)
 		for _, inst := range insts {
 			if len(inst.Bytes) != 5 || inst.Bytes[0] != 0xe8 {
 				// TODO: long jump instructions (0xe9)

--- a/internal/bpfsnoop/func_insn.go
+++ b/internal/bpfsnoop/func_insn.go
@@ -27,13 +27,7 @@ func (i FuncInsns) parseFuncInsns(kfunc *KFunc, engine *gapstone.Engine, ksyms *
 		return fmt.Errorf("func %s insn count %d is larger than limit %d", kfunc.Ksym.name, bytesCnt, readLimit)
 	}
 
-	data, err := readKernel(kaddr, uint32(bytesCnt))
-	if err != nil {
-		return fmt.Errorf("failed to read kernel memory from %#x: %w", kaddr, err)
-	}
-
-	data = trimTailingInsns(data)
-	insns, err := engine.Disasm(data, kaddr, 0)
+	insns, err := disasmKfuncAt(kaddr, bytesCnt, ksyms, engine)
 	if err != nil {
 		return fmt.Errorf("failed to disassemble insns: %w", err)
 	}

--- a/t/massive.txt
+++ b/t/massive.txt
@@ -7,6 +7,6 @@
 name: massive::kallsyms
 tag: massive,kfuncs
 test: -k 'kallsyms_*'
-match: → kallsyms_open
+match: ← kallsyms_open
 timeout: 10s
 trigger: grep -q icmp_rcv /proc/kallsyms


### PR DESCRIPTION
It was broken caused by introducing per-tracee's both mode.

Meanwhile:

1. feat: Fix checking lbr.
2. Tidy code of disasm kfunc.
3. fngraph: Add hidden `--fgraph-debug` flag.
4. fngraph: Show `[traceable] mark for `--fgraph-proto`.