### PR TITLE
fngraph: Fix showing fgraph for the last entry of /proc/kallsyms

### DIFF
--- a/internal/bpfsnoop/bpf_tracing.go
+++ b/internal/bpfsnoop/bpf_tracing.go
@@ -238,7 +238,7 @@ func (t *bpfTracing) injectPktFilter(prog *ebpf.ProgramSpec, params []btf.FuncPa
 			return err
 		}
 
-		DebugLog("Injected --filter-pkt expr to %dth param (%s)'%s' of %s", i, btfx.Repr(typ), p.Name, fnName)
+		DebugLog("Injected --filter-pkt expr to %dth param (%s)%s of %s", i, btfx.Repr(typ), p.Name, fnName)
 		return nil
 	}
 
@@ -268,17 +268,17 @@ func (t *bpfTracing) injectPktOutput(pkt bool, prog *ebpf.ProgramSpec, params []
 		switch stt.Name {
 		case "sk_buff", "__sk_buff":
 			pktOutput.outputSkb(prog, i)
-			DebugLog("Injected --output-pkt to %dth param (%s)'%s' of %s", i, p.Name, btfx.Repr(p.Type), fnName)
+			DebugLog("Injected --output-pkt to %dth param (%s)%s of %s", i, btfx.Repr(p.Type), p.Name, fnName)
 			return true
 
 		case "xdp_buff", "xdp_md":
 			pktOutput.outputXdpBuff(prog, i)
-			DebugLog("Injected --output-pkt to %dth param (%s)'%s' of %s", i, p.Name, btfx.Repr(p.Type), fnName)
+			DebugLog("Injected --output-pkt to %dth param (%s)%s of %s", i, btfx.Repr(p.Type), p.Name, fnName)
 			return true
 
 		case "xdp_frame":
 			pktOutput.outputXdpFrame(prog, i)
-			DebugLog("Injected --output-pkt to %dth param (%s)'%s' of %s", i, p.Name, btfx.Repr(p.Type), fnName)
+			DebugLog("Injected --output-pkt to %dth param (%s)%s of %s", i, btfx.Repr(p.Type), p.Name, fnName)
 			return true
 		}
 	}

--- a/internal/bpfsnoop/disasm.go
+++ b/internal/bpfsnoop/disasm.go
@@ -73,8 +73,11 @@ func trimTailingInsns(b []byte) []byte {
 }
 
 func findDisasmKfuncInKmods(kfunc string, kaddr uint64, kmods []string, a2l *Addr2Line) (uint64, bool) {
+	if a2l == nil {
+		return 0, false
+	}
+
 	VerboseLog("Symbol %s not found in /proc/kallsyms", kfunc)
-	assert.NotNil(a2l, "Dbgsym is required to disasm %s", kfunc)
 
 	for _, kmodName := range kmods {
 		err := a2l.addKmod(kmodName)

--- a/internal/bpfsnoop/func_proto.go
+++ b/internal/bpfsnoop/func_proto.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"slices"
 	"sort"
 	"strings"
@@ -156,17 +155,19 @@ func ShowFuncProto(f *Flags) {
 				assert.NoErr(err, "Failed to find vmlinux: %v")
 			}
 
-			log.Printf("Found vmlinux: %s", vmlinux)
+			if vmlinux != "" {
+				LogIf(true, "Found vmlinux: %s", vmlinux)
 
-			textAddr, err := ReadTextAddrFromVmlinux(vmlinux)
-			assert.NoErr(err, "Failed to read .text address from vmlinux: %v", err)
+				textAddr, err := ReadTextAddrFromVmlinux(vmlinux)
+				assert.NoErr(err, "Failed to read .text address from vmlinux: %v", err)
 
-			kaslr := NewKaslr(kallsyms.Stext(), textAddr)
-			addr2line, err = NewAddr2Line(vmlinux, kaslr, kallsyms.SysBPF(), kallsyms.Stext())
-			assert.NoErr(err, "Failed to create addr2line: %v", err)
+				kaslr := NewKaslr(kallsyms.Stext(), textAddr)
+				addr2line, err = NewAddr2Line(vmlinux, kaslr, kallsyms.SysBPF(), kallsyms.Stext())
+				assert.NoErr(err, "Failed to create addr2line: %v", err)
 
-			bprogs, err = NewBPFProgs([]ProgFlag{{all: false}}, true, false)
-			assert.NoErr(err, "Failed to prepare bpf progs: %v", err)
+				bprogs, err = NewBPFProgs([]ProgFlag{{all: false}}, true, false)
+				assert.NoErr(err, "Failed to prepare bpf progs: %v", err)
+			}
 		}
 
 		for _, fn := range fns {

--- a/internal/bpfsnoop/kernel_btf.go
+++ b/internal/bpfsnoop/kernel_btf.go
@@ -6,6 +6,7 @@ package bpfsnoop
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"slices"
 
 	"github.com/cilium/ebpf/btf"
@@ -54,6 +55,10 @@ func iterateKernelBtfs(allKmods bool, kmods []string, iter func(*btf.Spec) bool)
 		}
 
 		for _, kmod := range kmods {
+			if !fileExists(filepath.Join(kernelBTFPath, kmod)) {
+				continue
+			}
+
 			kmodBtf, err := btf.LoadKernelModuleSpec(kmod)
 			if err != nil {
 				return fmt.Errorf("failed to load kernel module BTF: %w", err)


### PR DESCRIPTION
It is unable to guess the function insn count of the last entry of /proc/kallsyms, which is a bpf trampoline symbol possibly.

Then, when the last one is a bpf trampoline symbol, it cannot find its BTF info as it is not a normal kernel function builtin vmlinux.

Thereafter, as for `--fgraph-proto`, showing its function name is enough.