### PR TITLE
fngraph: Fix getting retval

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ clean:
 .PHONY: publish
 publish: local_release
 	@if [ -z "$(VERSION)" ]; then echo "VERSION is not set"; exit 1; fi
-	$(CMD_TAR) -czf $(DIR_BIN)/$(BPFSNOOP_OBJ)-$(VERSION)-linux-amd64.tar.gz $(DIR_BIN)/$(BPFSNOOP_OBJ) $(DIR_BIN)/$(BPFSNOOP_CSM)
+	$(CMD_CD) $(DIR_BIN) && $(CMD_TAR) -czf $(BPFSNOOP_OBJ)-$(VERSION)-linux-amd64.tar.gz $(BPFSNOOP_OBJ) $(BPFSNOOP_CSM) && $(CMD_CD) -
 	@$(CMD_MV) $(RELEASE_NOTES) $(DIR_BIN)/$(RELEASE_NOTES)
 	$(CMD_GH) release create $(VERSION) $(DIR_BIN)/$(BPFSNOOP_OBJ)-$(VERSION)-linux-amd64.tar.gz --title "bpfsnoop $(VERSION)" --notes-file $(DIR_BIN)/$(RELEASE_NOTES)
 

--- a/internal/bpfsnoop/bpf_tracing_graph.go
+++ b/internal/bpfsnoop/bpf_tracing_graph.go
@@ -37,7 +37,7 @@ type bpfFgraphConfig struct {
 	Pad2      uint16
 	MyPID     uint32
 	FnArgsNr  uint32
-	WithRet   bool
+	WithRet   uint8
 	Pad       [3]uint8
 	FnArgsBuf uint32
 }
@@ -64,7 +64,7 @@ func (t *bpfTracing) traceGraph(spec *ebpf.CollectionSpec,
 	cfg.Entry = uint8(b2i(entry))
 	cfg.TinBPF = uint8(b2i(tailcallInfo.supportTailcallInBpf2bpf))
 	cfg.FnArgsNr = uint32(len(params))
-	cfg.WithRet = !entry
+	cfg.WithRet = uint8(b2i(!entry))
 	cfg.FnArgsBuf = uint32(fnArgsBufSize)
 	cfg.MyPID = uint32(os.Getpid())
 

--- a/internal/bpfsnoop/flags.go
+++ b/internal/bpfsnoop/flags.go
@@ -168,7 +168,7 @@ func ParseFlags() (*Flags, error) {
 		requiredLbr = requiredLbr || strings.Contains(s, "(l)")
 	}
 	flags.requiredVmlinux = !flags.noVmlinux &&
-		(flags.requiredVmlinux || outputFuncStack || outputLbr)
+		(flags.requiredVmlinux || outputFuncStack || outputLbr || requiredLbr)
 
 	if len(showTypes) != 0 {
 		showTypeProto(showTypes)


### PR DESCRIPTION
Fix three minor issues:

1. makefile: Do not include `bin` dir in the final `.tar.gz` file.
2. lbr: Show line info if '(l)' is used for `-p`/`-k` and dbgsym is existing.
3. fngraph: Get the correct retval on stack by converting the `ctx` type from `unsigned long long *` to `void *`.