### PR TITLE
cc: Add hidden -P to read kernel memory using bpf_probe_read_kernel() 

### DIFF
--- a/internal/bpfsnoop/filter_arg.go
+++ b/internal/bpfsnoop/filter_arg.go
@@ -101,6 +101,9 @@ func (arg *funcArgument) inject(prog *ebpf.ProgramSpec, krnl, spec *btf.Spec, pa
 	if _, err := krnl.AnyTypeByName("bpf_rdonly_cast"); err == nil {
 		mode = cc.MemoryReadModeCoreRead
 	}
+	if forceProbeReadKernel {
+		mode = cc.MemoryReadModeProbeRead
+	}
 
 	insns, err := cc.CompileFilterExpr(cc.CompileExprOptions{
 		Expr:      arg.expr,

--- a/internal/bpfsnoop/flags.go
+++ b/internal/bpfsnoop/flags.go
@@ -47,6 +47,8 @@ var (
 	debugTraceInsnCnt uint
 
 	kernelVmlinuxDir string
+
+	forceProbeReadKernel bool
 )
 
 type Flags struct {
@@ -116,6 +118,7 @@ func ParseFlags() (*Flags, error) {
 	f.UintVarP(&limitEvents, "limit-events-internal", "E", 0, "limited number events to output, 0 to output all events")
 	f.BoolVarP(&flags.noVmlinux, "no-vmlinux", "N", false, "do not load vmlinux")
 	f.DurationVar(&runDurationThreshold, "duration-threshold", 0, "threshold for run duration, e.g. 1s, 100ms, 0 to disable")
+	f.BoolVarP(&forceProbeReadKernel, "force-probe-read-kernel", "P", false, "force reading kernel memory using bpf_probe_read_kernel() helper")
 
 	f.MarkHidden("debug-log")
 	f.MarkHidden("output-flamegraph")
@@ -125,6 +128,7 @@ func ParseFlags() (*Flags, error) {
 	f.MarkHidden("no-vmlinux")
 	f.MarkHidden("duration-threshold")
 	f.MarkHidden("fgraph-debug")
+	f.MarkHidden("force-probe-read-kernel")
 
 	err := f.Parse(os.Args)
 

--- a/internal/bpfsnoop/output_arg.go
+++ b/internal/bpfsnoop/output_arg.go
@@ -244,6 +244,9 @@ func (arg *funcArgumentOutput) compile(params []btf.FuncParam, krnl, spec *btf.S
 	if _, err := spec.AnyTypeByName("bpf_rdonly_cast"); err == nil {
 		mode = cc.MemoryReadModeCoreRead
 	}
+	if forceProbeReadKernel {
+		mode = cc.MemoryReadModeProbeRead
+	}
 
 	res, err := cc.CompileEvalExpr(cc.CompileExprOptions{
 		Expr:          arg.expr,


### PR DESCRIPTION
Sometimes, it would fail to read kernel memory using bpf_rdonly_case() kfunc:

```bash
$ sudo ./bpfsnoop -k dump_emit --output-arg 'cprm->file->f_iocb_flags'
...
	297: (79) r1 = *(u64 *)(r0 +8)        ; frame1: R0=untrusted_ptr_coredump_params() R1=untrusted_ptr_file() refs=5
	298: (15) if r1 == 0x0 goto pc+8      ; frame1: R1=untrusted_ptr_file() refs=5
	299: (b7) r2 = 649                    ; frame1: R2_w=649 refs=5
	300: (85) call bpf_rdonly_cast#41126          ; frame1: R0_w=untrusted_ptr_file() refs=5
	301: (61) r7 = *(u32 *)(r0 +0)
	cannot access ptr member next with moff 0 in struct callback_head with off 0 size 4
	processed 190 insns (limit 1000000) max_states_per_insn 0 total_states 14 peak_states 14 mark_read 11
```

To address this, it is able to read kernel memory using bpf_probe_read_kernel() helper forcely by '-P'.