### PR TITLE
fnarg: Fix clang-eliminated filter_arg()

### DIFF
--- a/bpf/bpfsnoop_arg_filter.h
+++ b/bpf/bpfsnoop_arg_filter.h
@@ -11,7 +11,7 @@
 static __noinline bool
 filter_arg(__u64 *args)
 {
-    return args != NULL;
+    return args[0] != 0;
 }
 
 #endif // __BPFSNOOP_ARG_FILTER_H_


### PR DESCRIPTION
`filter_arg()` is eliminated by clang unexpectedly.

In order to avoid such elimination, update `filter_arg()` to:

```C
static __noinline bool
filter_arg(__u64 *args)
{
    return args[0] != 0;
}
```