### PR TITLE
fngraph: Fix getting fp of trampoline 

### DIFF
--- a/bpf/bpfsnoop_stack.h
+++ b/bpf/bpfsnoop_stack.h
@@ -27,34 +27,26 @@
  * Stack layout on arm64:
  * |  r9  |
  * |  fp  | FP of tracee's caller
+ * +------+ FP of tracee
  * |  lr  | IP of tracee
  * |  fp  | FP of tracee
- * +------+ FP of trampoline  <-------+
- * |  ..  | padding                   |
- * |  ..  | callee saved regs         |
- * | retv | retval of tracee          |
- * | regs | regs of tracee            |
- * | nreg | number of regs            |
- * |  ip  | IP of tracee if needed    | possible range of
- * | rctx | bpf_tramp_run_ctx         | detection
- * |  lr  | IP of trampoline          |
- * |  fp  | FP of trampoline  <--------- detect it
- * +------+ FP of current prog        |
- * | regs | callee saved regs         |
- * +------+ R10 of bpf prog   <-------+
+ * +------+ FP of trampoline  <--------- detect it
+ * |  ..  | padding
+ * |  ..  | x19, x20
+ * | retv | retval of tracee
+ * | regs | regs of tracee
+ * +------+ ctx of bpf prog
+ * | nreg | number of regs
+ * |  ip  | IP of tracee if needed
+ * | rctx | bpf_tramp_run_ctx
+ * |  lr  | IP of trampoline
+ * |  fp  | FP of trampoline
+ * +------+ FP of current prog
+ * | regs | callee saved regs
+ * +------+ R10 of bpf prog
  * |  ..  |
  * +------+ SP of current prog
  */
-
-static __always_inline u64
-get_tracing_fp(void)
-{
-	u64 fp;
-
-	/* get frame pointer */
-	asm volatile ("%[fp] = r10" : [fp] "+r"(fp) :);
-	return fp;
-}
 
 static __always_inline u64
 __get_ptr(void *ctx, __u32 args_nr, bool retval)
@@ -77,44 +69,57 @@ get_tramp_fp(void *ctx, __u32 args_nr, bool retval)
 
 /* This offset is different for each tracee because of the number of tracee's
  * arguments.
+ *
+ * It's the bytes number between ctx and the true fp of tracee.
  */
 u32 tramp_fp_offset;
 
 /* As R10 of bpf is not A64_FP, we need to detect the FP of trampoline
- * by scanning the stacks of current bpf prog and the trampoline.
+ * by scanning the stack of the trampoline.
  *
  * Since commit 5d4fa9ec5643 ("bpf, arm64: Avoid blindly saving/restoring all callee-saved registers"),
  * the number of callee-saved registers saved in the bpf prog prologue is
  * dynamic, not fixed anymore.
+ *
+ * Since commit 9014cf56f13d ("bpf, arm64: Support up to 12 function arguments"),
+ * the stack layout of the trampoline becomes more complicate.
+ *
+ * To get rid of the complicate stack layout, detect the FP of the
+ * trampoline by utilizing `ctx` of current prog and checking tracee's IP.
  */
 static __always_inline u64
-detect_tramp_fp_offset(u64 r10)
+detect_tramp_fp_offset(void *ctx, bool retval)
 {
-	static const int range_of_detection = 256;
-	u64 fp;
+	__u32 nregs = bpf_get_func_arg_cnt(ctx);
+	__u64 fp, ptr, ip;
 
-	for (int i = 6; i >= 0; i--) {
-		bpf_probe_read_kernel(&fp, sizeof(fp), (void *) (r10 + i * 16));
-		if (r10 < fp && fp < r10 + range_of_detection) {
-			tramp_fp_offset = i * 16;
-			return fp;
+	ip = bpf_get_func_ip(ctx);
+	ip += 8; /* The IP of tracee stored on stack has 8B far from its original entry. */
+	ptr = __get_ptr(ctx, nregs, retval);
+	ptr += 16; /* x19 and x20 always */
+
+	for (int i = 0; i < 6; i++) {
+		fp = bpf_probe_read_kernel(&fp, sizeof(fp), (void *) (ptr + i * 8));
+		if (fp == ip) {
+			tramp_fp_offset = i * 8 - 8;
+			return fp - 8;
 		}
 	}
 
-	return r10;
+	return ptr;
 }
 
 static __always_inline u64
 get_tramp_fp(void *ctx, __u32 args_nr, bool retval)
 {
-	u64 fp = get_tracing_fp();
+	u64 fp;
 
 	if (tramp_fp_offset) {
-		(void) bpf_probe_read_kernel(&fp, sizeof(fp), (void *) (fp + tramp_fp_offset));
+		(void) bpf_probe_read_kernel(&fp, sizeof(fp), ctx + tramp_fp_offset);
 		return fp;
 	}
 
-	fp = detect_tramp_fp_offset(fp);
+	fp = detect_tramp_fp_offset(ctx, retval);
 	return fp;
 }
 #else

--- a/internal/bpfsnoop/bpfsnoop_sess.go
+++ b/internal/bpfsnoop/bpfsnoop_sess.go
@@ -55,6 +55,9 @@ func (s *Session) pushTstamp(ts uint32) {
 }
 
 func (s *Session) popTstamp() {
+	if s.lastidx == 0 {
+		return
+	}
 	s.tstamps = s.tstamps[:s.lastidx]
 	s.lastidx--
 }


### PR DESCRIPTION
Since patch [bpf: Support private stack for bpf progs](https://lore.kernel.org/all/20241112163902.2223011-1-yonghong.song@linux.dev/)
(v6.13 kernel), it is unable to unwinding stack from current prog's fp,
because the true fp has been hidden from private stack.

However, the `ctx` of current prog is a pointer of trampoline's stack.

So, it is able to get trampoline's fp using `ctx`, as it knows args
number and knows retval is on trampoline's stack or not.

Check the trampoline's stack layout in `bpfsnoop_stack.h` for more
details.