### PR TITLE
bpf: Fix traceable

### DIFF
--- a/bpf/traceable.c
+++ b/bpf/traceable.c
@@ -27,15 +27,16 @@ probe_addr_info(int i)
 
 #if defined(bpf_target_x86)
     static const u64 nop5 = 0x0000441F0F;
-    u64 a, b;
+    u64 a, b, c;
 
     ptr = has_endbr ? buff + 4 : buff;
-    if (tramp_jmp && ptr[0] == 0xE9 /* jmp */)
-        tramps[i] = addr + (has_endbr ? 4 : 0) + 5 + (__s32) (((*(u64 *) ptr) >> 8) & 0xFFFFFFFF);
     /* Avoid 'misaligned stack access off 0+-12+0 size 8' */
     a = *(u32 *) ptr;
     b = *(u8 *) (ptr + 4);
-    traceable = (b<<32 | a) == nop5 /* nop5 */ || ptr[0] == 0xE8 /* callq */ ||
+    c = (b << 32) | a;
+    if (tramp_jmp && ptr[0] == 0xE9 /* jmp */)
+        tramps[i] = addr + (has_endbr ? 4 : 0) + 5 + (__s32) ((c >> 8) & 0xFFFFFFFF);
+    traceable = c == nop5 /* nop5 */ || ptr[0] == 0xE8 /* callq */ ||
            /* 373f2f44c300 ("bpf,x86: adjust the "jmp" mode for bpf trampoline")
             * since 6.19 kernel.
             */


### PR DESCRIPTION
Fix the issue "misaligned stack access off 0+-12+0 size 8" again, similar to commit 077a0c7fc990.

The issue was introduced by 01c5cf6dfa70.