### PR TITLE
bpfsnoop: Fix duped BTF types

### DIFF
--- a/internal/bpfsnoop/func_graph_parser.go
+++ b/internal/bpfsnoop/func_graph_parser.go
@@ -215,6 +215,15 @@ func (p *FuncGraphParser) parse(ip uint64, bytes uint, depth uint, isBPF bool, t
 	return nil
 }
 
+func findFuncInTypes(types []btf.Type) (*btf.Func, bool) {
+	for _, typ := range types {
+		if fn, ok := typ.(*btf.Func); ok {
+			return fn, true
+		}
+	}
+	return nil, false
+}
+
 func (p *FuncGraphParser) isExcludedKfunc(funcName string) (bool, error) {
 	var excluded bool
 
@@ -223,12 +232,12 @@ func (p *FuncGraphParser) isExcludedKfunc(funcName string) (bool, error) {
 			return true // skip if already matched
 		}
 
-		typ, err := spec.AnyTypeByName(funcName)
+		types, err := spec.AnyTypesByName(funcName)
 		if err != nil {
 			return false
 		}
 
-		fn, ok := typ.(*btf.Func)
+		fn, ok := findFuncInTypes(types)
 		if !ok {
 			return false // skip if not a function type
 		}
@@ -260,7 +269,7 @@ func (p *FuncGraphParser) checkIncludedKfunc(funcName string) (*KFunc, error) {
 			return true // stop if already found or error occurred
 		}
 
-		typ, err := spec.AnyTypeByName(funcName)
+		types, err := spec.AnyTypesByName(funcName)
 		if err != nil {
 			if errors.Is(err, btf.ErrNotFound) {
 				return false // continue iterating if not found
@@ -269,7 +278,7 @@ func (p *FuncGraphParser) checkIncludedKfunc(funcName string) (*KFunc, error) {
 			return false
 		}
 
-		fn, ok := typ.(*btf.Func)
+		fn, ok := findFuncInTypes(types)
 		if !ok {
 			VerboseLog("Type %s is not a function in BTF spec\n", funcName)
 			return false // skip if not a function type

--- a/internal/bpfsnoop/func_graph_proto.go
+++ b/internal/bpfsnoop/func_graph_proto.go
@@ -64,7 +64,7 @@ func detectKfuncTraceable(fnName string, ksyms *Kallsyms, fexit, silent bool) (b
 
 	fn, err := findBtfOfKfunc(fnName)
 	if err != nil {
-		return false, fmt.Errorf("failed to find BTF function %q: %w", fn.Name, err)
+		return false, fmt.Errorf("failed to find BTF function %q: %w", fnName, err)
 	}
 	if fn == nil {
 		verboseLogIf(!silent, "BTF function %q not found", fnName)
@@ -120,7 +120,7 @@ func findBtfOfKfunc(name string) (bfn *btf.Func, e error) {
 			return true
 		}
 
-		typ, err := s.AnyTypeByName(name)
+		types, err := s.AnyTypesByName(name)
 		if errors.Is(err, btf.ErrNotFound) {
 			return false
 		}
@@ -129,7 +129,7 @@ func findBtfOfKfunc(name string) (bfn *btf.Func, e error) {
 			return true // continue iterating
 		}
 
-		fn, ok := typ.(*btf.Func)
+		fn, ok := findFuncInTypes(types)
 		if !ok {
 			e = fmt.Errorf("type %q is not a function type", name)
 			return true // continue iterating

--- a/internal/bpfsnoop/type_proto.go
+++ b/internal/bpfsnoop/type_proto.go
@@ -28,7 +28,7 @@ func findStructUnionType(typeName string) (btf.Type, error) {
 	var err error
 
 	err = iterateKernelBtfs(true, nil, func(spec *btf.Spec) bool {
-		t, err := spec.AnyTypeByName(typeName)
+		types, err := spec.AnyTypesByName(typeName)
 		if errors.Is(err, btf.ErrNotFound) {
 			return false
 		}
@@ -37,8 +37,15 @@ func findStructUnionType(typeName string) (btf.Type, error) {
 			return true // stop iterating on error
 		}
 
-		typ = t
-		return true
+		for _, t := range types {
+			switch t.(type) {
+			case *btf.Struct, *btf.Union:
+				typ = t
+				return true
+			}
+		}
+
+		return false
 	})
 
 	return typ, err


### PR DESCRIPTION
When a name can be both struct and function, we must chose one of them.

BTW, fix a nil panic in detectKfuncTraceable(), when failed to find BTF type for the function.