### PR TITLE
Fix broken both fngraph and fninsn on kernel 7.2

### DIFF
--- a/bpf/bpfsnoop.c
+++ b/bpf/bpfsnoop.c
@@ -108,7 +108,7 @@ emit_bpfsnoop_event(void *ctx)
         session_id = gen_session_id(fp);
         if (!bpfsnoop_session_enter(ctx, pid_tgid, func_ip, session_id, filter(args, session_id),
                                     &session_id, cfg->flags.is_session,
-                                    cfg->flags.graph_mode))
+                                    cfg->flags.graph_mode || cfg->flags.insn_mode))
             return BPF_OK;
 
         event_type = BPFSNOOP_EVENT_TYPE_FUNC_ENTRY;
@@ -116,7 +116,7 @@ emit_bpfsnoop_event(void *ctx)
 
     case BPFSNOOP_MODE_SESSION_EXIT:
         if (!bpfsnoop_session_exit(ctx, pid_tgid, func_ip, &session_id, cfg->flags.is_session,
-                                   cfg->flags.graph_mode))
+                                   cfg->flags.graph_mode || cfg->flags.insn_mode))
             return BPF_OK;
 
         event_type = BPFSNOOP_EVENT_TYPE_FUNC_EXIT;

--- a/bpf/bpfsnoop.c
+++ b/bpf/bpfsnoop.c
@@ -107,14 +107,16 @@ emit_bpfsnoop_event(void *ctx)
     case BPFSNOOP_MODE_SESSION_ENTRY:
         session_id = gen_session_id(fp);
         if (!bpfsnoop_session_enter(ctx, pid_tgid, func_ip, session_id, filter(args, session_id),
-                                    &session_id, cfg->flags.is_session))
+                                    &session_id, cfg->flags.is_session,
+                                    cfg->flags.graph_mode))
             return BPF_OK;
 
         event_type = BPFSNOOP_EVENT_TYPE_FUNC_ENTRY;
         break;
 
     case BPFSNOOP_MODE_SESSION_EXIT:
-        if (!bpfsnoop_session_exit(ctx, pid_tgid, func_ip, &session_id, cfg->flags.is_session))
+        if (!bpfsnoop_session_exit(ctx, pid_tgid, func_ip, &session_id, cfg->flags.is_session,
+                                   cfg->flags.graph_mode))
             return BPF_OK;
 
         event_type = BPFSNOOP_EVENT_TYPE_FUNC_EXIT;

--- a/bpf/bpfsnoop_kmulti.c
+++ b/bpf/bpfsnoop_kmulti.c
@@ -125,7 +125,7 @@ emit_bpfsnoop_kmulti_event(struct pt_regs *ctx)
         if (!bpfsnoop_session_enter(ctx, pid_tgid, func_ip, session_id,
                                     filter_kmulti(args, session_id),
                                     &session_id, cfg->flags.is_session,
-                                    cfg->flags.graph_mode))
+                                    cfg->flags.graph_mode || cfg->flags.insn_mode))
             return BPF_OK;
 
         event_type = BPFSNOOP_EVENT_TYPE_FUNC_ENTRY;
@@ -133,7 +133,7 @@ emit_bpfsnoop_kmulti_event(struct pt_regs *ctx)
 
     case BPFSNOOP_MODE_SESSION_EXIT:
         if (!bpfsnoop_session_exit(ctx, pid_tgid, func_ip, &session_id, cfg->flags.is_session,
-                                   cfg->flags.graph_mode))
+                                   cfg->flags.graph_mode || cfg->flags.insn_mode))
             return BPF_OK;
 
         event_type = BPFSNOOP_EVENT_TYPE_FUNC_EXIT;

--- a/bpf/bpfsnoop_kmulti.c
+++ b/bpf/bpfsnoop_kmulti.c
@@ -124,14 +124,16 @@ emit_bpfsnoop_kmulti_event(struct pt_regs *ctx)
         session_id = gen_session_id(func_ip);
         if (!bpfsnoop_session_enter(ctx, pid_tgid, func_ip, session_id,
                                     filter_kmulti(args, session_id),
-                                    &session_id, cfg->flags.is_session))
+                                    &session_id, cfg->flags.is_session,
+                                    cfg->flags.graph_mode))
             return BPF_OK;
 
         event_type = BPFSNOOP_EVENT_TYPE_FUNC_ENTRY;
         break;
 
     case BPFSNOOP_MODE_SESSION_EXIT:
-        if (!bpfsnoop_session_exit(ctx, pid_tgid, func_ip, &session_id, cfg->flags.is_session))
+        if (!bpfsnoop_session_exit(ctx, pid_tgid, func_ip, &session_id, cfg->flags.is_session,
+                                   cfg->flags.graph_mode))
             return BPF_OK;
 
         event_type = BPFSNOOP_EVENT_TYPE_FUNC_EXIT;

--- a/bpf/bpfsnoop_session.h
+++ b/bpf/bpfsnoop_session.h
@@ -14,7 +14,7 @@
 
 static __always_inline bool
 bpfsnoop_session_enter(void *ctx, __u64 pid_tgid, __u64 func_ip, __u64 sid, bool pass,
-                       __u64 *session_id, bool is_session)
+                       __u64 *session_id, bool is_session, bool update_session_map)
 {
     if (!pass)
         return false;
@@ -22,6 +22,8 @@ bpfsnoop_session_enter(void *ctx, __u64 pid_tgid, __u64 func_ip, __u64 sid, bool
     if (is_session) {
         __u64 *cookie = bpfsnoop_session_cookie(ctx);
         *cookie = sid;
+        if (update_session_map)
+            add_session(pid_tgid, func_ip, sid);
     } else {
         add_session(pid_tgid, func_ip, sid);
     }
@@ -31,7 +33,8 @@ bpfsnoop_session_enter(void *ctx, __u64 pid_tgid, __u64 func_ip, __u64 sid, bool
 }
 
 static __always_inline bool
-bpfsnoop_session_exit(void *ctx, __u64 pid_tgid, __u64 func_ip, __u64 *session_id, bool is_session)
+bpfsnoop_session_exit(void *ctx, __u64 pid_tgid, __u64 func_ip, __u64 *session_id, bool is_session,
+                      bool update_session_map)
 {
     if (is_session) {
         __u64 *cookie = bpfsnoop_session_cookie(ctx);
@@ -41,6 +44,8 @@ bpfsnoop_session_exit(void *ctx, __u64 pid_tgid, __u64 func_ip, __u64 *session_i
             return false;
 
         *session_id = sid - 1;
+        if (update_session_map)
+            get_and_del_session(pid_tgid, func_ip);
     } else {
         __u64 sid = get_and_del_session(pid_tgid, func_ip);
 

--- a/cmd/localtest/file.go
+++ b/cmd/localtest/file.go
@@ -107,7 +107,13 @@ func testFile(w io.Writer, file string) bool {
 		i++
 
 		if testName == "" || testName == t.name {
-			passed = test(w, t) && passed
+			if !test(w, t) {
+				failedTests = append(failedTests, failedTest{
+					file:     file,
+					testCase: t,
+				})
+				passed = false
+			}
 		}
 	}
 

--- a/cmd/localtest/main.go
+++ b/cmd/localtest/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -13,6 +14,13 @@ import (
 
 	"github.com/bpfsnoop/bpfsnoop/internal/assert"
 )
+
+type failedTest struct {
+	file string
+	testCase
+}
+
+var failedTests []failedTest
 
 func main() {
 	var passed bool
@@ -35,6 +43,7 @@ func main() {
 				prInfo(w, green, "=== ALL TESTS PASSED ===\n")
 			} else {
 				prErr(w, red, "=== SOME TESTS FAILED ===\n")
+				printFailedTests(w)
 			}
 		}()
 
@@ -53,6 +62,7 @@ func main() {
 				prInfo(w, green, "=== ALL TESTS PASSED ===\n")
 			} else {
 				prErr(w, red, "=== SOME TESTS FAILED ===\n")
+				printFailedTests(w)
 			}
 		}()
 
@@ -80,4 +90,28 @@ func main() {
 	}
 
 	passed = test(os.Stdout, f.testCase)
+	if !passed {
+		failedTests = append(failedTests, failedTest{testCase: f.testCase})
+		printFailedTests(os.Stdout)
+	}
+}
+
+func printFailedTests(w io.Writer) {
+	if len(failedTests) == 0 {
+		return
+	}
+
+	fmt.Fprintln(w)
+	prErr(w, red, "Failed tests:\n")
+	for _, failed := range failedTests {
+		name := failed.name
+		if name == "" {
+			name = "<unnamed>"
+		}
+		if failed.file != "" {
+			prErr(w, red, "- %s: %s (%s)\n", failed.file, name, failed.test)
+		} else {
+			prErr(w, red, "- %s (%s)\n", name, failed.test)
+		}
+	}
 }

--- a/t/fninsn.txt
+++ b/t/fninsn.txt
@@ -7,7 +7,7 @@
 name: fninsn::icmp_rcv
 tag: fninsn,pkt
 test: -k '(i)icmp_rcv' --filter-pkt 'host 127.0.0.1' --trace-insn-debug-cnt 10
-match_amd64: andq	$0xfffffffffffffffe
+match_amd64: movq	0x58(%rdi),
 match_arm64: and	x20, x20, #0xfffffffffffffffe
 trigger: ping -c 1 -s 64 127.0.0.1
 
@@ -17,6 +17,6 @@ trigger: ping -c 1 -s 64 127.0.0.1
 name: fninsn::icmp_rcv:output-insns
 tag: fninsn,pkt
 test: -k 'icmp_rcv' --filter-pkt 'host 127.0.0.1' --output-insns --trace-insn-debug-cnt 10
-match_amd64: andq	$0xfffffffffffffffe
+match_amd64: movq	0x58(%rdi),
 match_arm64: and	x20, x20, #0xfffffffffffffffe
 trigger: ping -c 1 -s 64 127.0.0.1


### PR DESCRIPTION
When fsession or kprobe.multi is used, update the session map for both function graph and function instruction features.

Closes #152 