### PR TITLE
bpfsnoop: Add --filter-comm

### DIFF
--- a/bpf/bpfsnoop.c
+++ b/bpf/bpfsnoop.c
@@ -9,6 +9,7 @@
 #include "bpfsnoop_arg_filter.h"
 #include "bpfsnoop_arg_output.h"
 #include "bpfsnoop_cfg.h"
+#include "bpfsnoop_comm_filter.h"
 #include "bpfsnoop_event.h"
 #include "bpfsnoop_event_output.h"
 #include "bpfsnoop_fn_args_output.h"
@@ -67,6 +68,7 @@ emit_bpfsnoop_event(void *ctx)
     __u64 retval = 0;
     __u16 event_type;
     __u32 cpu, pid;
+    __u8 comm[16];
 
     if (!ready)
         return BPF_OK;
@@ -97,6 +99,10 @@ emit_bpfsnoop_event(void *ctx)
     if (pid == PID)
         return BPF_OK;
     if (cfg->pid && pid != cfg->pid)
+        return BPF_OK;
+
+    bpf_get_current_comm(comm, sizeof(comm));
+    if (!filter_comm(comm))
         return BPF_OK;
 
     /* fp of tracee caller */
@@ -133,7 +139,7 @@ emit_bpfsnoop_event(void *ctx)
         break;
     }
 
-    return output_event(ctx, event_type, session_id, func_ip, cpu, pid,
+    return output_event(ctx, event_type, session_id, func_ip, cpu, pid, comm,
                         lbr, can_output_lbr, args, retval, cfg->flags.output_pkt,
                         cfg->flags.output_arg);
 }

--- a/bpf/bpfsnoop_cfg.h
+++ b/bpf/bpfsnoop_cfg.h
@@ -20,6 +20,8 @@ struct bpfsnoop_fn_args {
 struct bpfsnoop_config {
     TRACEE_FLAGS;
     __u32 pid;
+    __u8 comm[16];
+    __u32 comm_len;
 
     struct bpfsnoop_fn_args fn_args;
     __u32 tracee_arg_entry_size;

--- a/bpf/bpfsnoop_comm_filter.h
+++ b/bpf/bpfsnoop_comm_filter.h
@@ -1,0 +1,28 @@
+// Copyright 2026 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef __BPFSNOOP_COMM_FILTER_H_
+#define __BPFSNOOP_COMM_FILTER_H_
+
+#include "vmlinux.h"
+
+#include "bpfsnoop_cfg.h"
+
+static __always_inline bool
+filter_comm(__u8 comm[16])
+{
+    if (!cfg->comm_len)
+        return true;
+
+#pragma unroll
+    for (__u32 i = 0; i < 16; i++) {
+        if (i == cfg->comm_len)
+            return comm[i] == '\0';
+        if (cfg->comm[i] != comm[i])
+            return false;
+    }
+
+    return true;
+}
+
+#endif // __BPFSNOOP_COMM_FILTER_H_

--- a/bpf/bpfsnoop_event_output.h
+++ b/bpf/bpfsnoop_event_output.h
@@ -17,9 +17,16 @@
 #include "bpfsnoop_pkt_output.h"
 #include "bpfsnoop_stack_map.h"
 
+static __always_inline void
+copy_comm(__u8 dst[16], __u8 src[16])
+{
+    *(__u64 *)dst = *(__u64 *)src;
+    *(__u64 *)(dst + 8) = *(__u64 *)(src + 8);
+}
+
 static __always_inline int
 output_event(void *ctx, __u16 event_type, __u64 session_id, __u64 func_ip,
-             __u32 cpu, __u32 pid, struct bpfsnoop_lbr_data *lbr,
+             __u32 cpu, __u32 pid, __u8 comm[16], struct bpfsnoop_lbr_data *lbr,
              bool can_output_lbr, __u64 *args, __u64 retval, bool can_output_pkt,
              bool can_output_arg)
 {
@@ -41,7 +48,7 @@ output_event(void *ctx, __u16 event_type, __u64 session_id, __u64 func_ip,
     evt->func_ip = func_ip;
     evt->cpu = cpu;
     evt->pid = pid;
-    bpf_get_current_comm(evt->comm, sizeof(evt->comm));
+    copy_comm(evt->comm, comm);
     evt->func_stack_id = -1;
     evt->tracee_flags = cfg->tracee_flags;
     evt->flags.output_lbr &= can_output_lbr;

--- a/bpf/bpfsnoop_kmulti.c
+++ b/bpf/bpfsnoop_kmulti.c
@@ -9,6 +9,7 @@
 #include "bpfsnoop_arg_filter.h"
 #include "bpfsnoop_arg_output.h"
 #include "bpfsnoop_cfg.h"
+#include "bpfsnoop_comm_filter.h"
 #include "bpfsnoop_event.h"
 #include "bpfsnoop_event_output.h"
 #include "bpfsnoop_fn_args_output.h"
@@ -92,6 +93,7 @@ emit_bpfsnoop_kmulti_event(struct pt_regs *ctx)
     bool can_output_lbr;
     __u16 event_type;
     __u32 cpu, pid;
+    __u8 comm[16];
 
     if (!ready)
         return BPF_OK;
@@ -117,6 +119,10 @@ emit_bpfsnoop_kmulti_event(struct pt_regs *ctx)
     if (pid == PID)
         return BPF_OK;
     if (cfg->pid && pid != cfg->pid)
+        return BPF_OK;
+
+    bpf_get_current_comm(comm, sizeof(comm));
+    if (!filter_comm(comm))
         return BPF_OK;
 
     switch (mode) {
@@ -153,7 +159,7 @@ emit_bpfsnoop_kmulti_event(struct pt_regs *ctx)
     }
 
     return output_event(ctx, event_type, session_id, func_ip,
-                        cpu, pid, lbr, can_output_lbr, args, retval, output_pkt,
+                        cpu, pid, comm, lbr, can_output_lbr, args, retval, output_pkt,
                         output_arg);
 }
 

--- a/internal/bpfsnoop/bpf_tracing.go
+++ b/internal/bpfsnoop/bpf_tracing.go
@@ -63,6 +63,8 @@ func setBpfsnoopConfig(spec *ebpf.CollectionSpec, c traceeConfig) error {
 	cfg.SetIsProg(c.isProg)
 	cfg.SetKmultiMode(c.kmultiMode)
 	cfg.FilterPid = filterPid
+	copy(cfg.FilterComm[:], []uint8(filterComm))
+	cfg.FilterCommLen = uint32(len(filterComm))
 	cfg.FnArgsNr = uint32(c.fnArgsNr)
 	cfg.WithRet = c.withRet
 	cfg.FnArgsBuf = uint32(c.fnArgsBufSz)

--- a/internal/bpfsnoop/bpfsnoop_config.go
+++ b/internal/bpfsnoop/bpfsnoop_config.go
@@ -34,6 +34,8 @@ const (
 type BpfsnoopConfig struct {
 	Flags            uint32
 	FilterPid        uint32
+	FilterComm       [16]uint8
+	FilterCommLen    uint32
 	FnArgsNr         uint32
 	WithRet          bool
 	Pad              [3]uint8

--- a/internal/bpfsnoop/flags.go
+++ b/internal/bpfsnoop/flags.go
@@ -19,6 +19,8 @@ import (
 const (
 	TracingModeEntry = "entry"
 	TracingModeExit  = "exit"
+
+	filterCommLenMax = 16
 )
 
 var (
@@ -40,6 +42,7 @@ var (
 	outputFuncGraph bool
 	outputPkt       bool
 	filterPid       uint32
+	filterComm      string
 	kfuncAllKmods   bool
 	kfuncKmods      []string
 	noColorOutput   bool
@@ -117,6 +120,7 @@ func ParseFlags() (*Flags, error) {
 	f.BoolVar(&flags.fgraphDebug, "fgraph-debug", false, "debug deadlock caused by fgraph")
 	f.BoolVar(&outputPkt, "output-pkt", false, "output packet's tuple info if tracee has skb/xdp argument")
 	f.Uint32Var(&filterPid, "filter-pid", 0, "filter pid for tracing")
+	f.StringVar(&filterComm, "filter-comm", "", "filter command for tracing")
 	f.StringSliceVar(&filterArg, "filter-arg", nil, "filter function's argument with C expression, e.g. 'prog->type == BPF_PROG_TYPE_TRACING'")
 	f.StringArrayVar /* use StringArray to accept comma in value */ (&outputArg, "output-arg", nil, "output function's argument with C expression, e.g. 'prog->type'")
 	f.StringVar(&filterPkt, "filter-pkt", "", "filter packet with pcap-filter(7) expr if function argument is skb or xdp, e.g. 'icmp and host 1.1.1.1'")
@@ -170,6 +174,10 @@ func ParseFlags() (*Flags, error) {
 		assert.NoErr(err, "Failed to find vmlinux file: %v")
 		fmt.Println(vmlinuxPath)
 		os.Exit(0)
+	}
+
+	if len(filterComm) >= filterCommLenMax {
+		return nil, fmt.Errorf("--filter-comm is too long, only allow max %d chars", filterCommLenMax-1)
 	}
 
 	modes = flags.setDefaultModes()

--- a/t/kfunc.txt
+++ b/t/kfunc.txt
@@ -36,3 +36,12 @@ tag: kfuncs,pkt,multi
 test: -k '(b)(m)icmp_rcv:(struct sk_buff *)skb' --filter-pkt 'host 127.0.0.1' --output-pkt
 match: Pkt tuple: 127.0.0.1 -> 127.0.0.1 (ICMP)
 trigger: ping -c 1 -s 64 127.0.0.1
+
+---
+
+# icmp_echo by filter-comm
+name: kfuncs::icmp_echo:filter-comm
+tag: kfuncs
+test: -k '(b)icmp_echo:(struct sk_buff *)skb' --filter-pkt 'host 127.0.0.1' --filter-comm ping --output-pkt
+match: Pkt tuple: 127.0.0.1 -> 127.0.0.1 (ICMP)
+trigger: ping -c 1 -s 64 127.0.0.1


### PR DESCRIPTION
Unlike `--filter-pid` to filter one process, `--filter-comm` is able to filter multiple processes, because many processes can share the same command name with different PID.