### PR TITLE
Add retval support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 Please check [bpfsnoop.com](https://bpfsnoop.com) for more details.
 
+See [Typed return values](docs/retval.md) for using `$retval` in argument expressions and packet tracing.
+
 ## Acknowledgments
 
 - [cilium/ebpf](https://github.com/cilium/ebpf) for interacting with bpf subsystem.

--- a/bpf/bpfsnoop.c
+++ b/bpf/bpfsnoop.c
@@ -68,6 +68,7 @@ emit_bpfsnoop_event(void *ctx)
     bool can_output_lbr;
     __u64 retval = 0;
     __u16 event_type;
+    bool output_pkt;
     __u32 cpu, pid;
     __u8 comm[16];
 
@@ -145,8 +146,10 @@ emit_bpfsnoop_event(void *ctx)
         break;
     }
 
+    output_pkt = cfg->flags.output_pkt;
+    output_pkt = output_pkt && (event_type == BPFSNOOP_EVENT_TYPE_FUNC_EXIT || !cfg->flags.pkt_retval);
     return output_event(ctx, event_type, session_id, func_ip, cpu, pid, comm,
-                        lbr, can_output_lbr, args, retval, cfg->flags.output_pkt,
+                        lbr, can_output_lbr, args, retval, output_pkt,
                         cfg->flags.output_arg, filter_pass);
 }
 

--- a/bpf/bpfsnoop.c
+++ b/bpf/bpfsnoop.c
@@ -60,9 +60,10 @@ static __always_inline int
 emit_bpfsnoop_event(void *ctx)
 {
     struct bpfsnoop_lbr_data *lbr;
+    __u64 args[MAX_FN_ARGS + 1];
     __u64 fp, session_id = 0;
     enum bpfsnoop_mode mode;
-    __u64 args[MAX_FN_ARGS];
+    bool filter_pass = true;
     __u64 pid_tgid, func_ip;
     bool can_output_lbr;
     __u64 retval = 0;
@@ -92,6 +93,7 @@ emit_bpfsnoop_event(void *ctx)
     if (cfg->fn_args.with_retval && (mode == BPFSNOOP_MODE_EXIT ||
                                      mode == BPFSNOOP_MODE_SESSION_EXIT))
         (void) bpf_probe_read_kernel(&retval, sizeof(retval), ctx + 8*cfg->fn_args.args_nr);
+    args[cfg->fn_args.args_nr] = retval;
 
     func_ip = FUNC_IP;
     pid_tgid = bpf_get_current_pid_tgid();
@@ -112,7 +114,8 @@ emit_bpfsnoop_event(void *ctx)
     switch (mode) {
     case BPFSNOOP_MODE_SESSION_ENTRY:
         session_id = gen_session_id(fp);
-        if (!bpfsnoop_session_enter(ctx, pid_tgid, func_ip, session_id, filter(args, session_id),
+        filter_pass = cfg->flags.deferred_filter ? true : filter(args, session_id);
+        if (!bpfsnoop_session_enter(ctx, pid_tgid, func_ip, session_id, filter_pass,
                                     &session_id, cfg->flags.is_session,
                                     cfg->flags.graph_mode || cfg->flags.insn_mode))
             return BPF_OK;
@@ -124,6 +127,8 @@ emit_bpfsnoop_event(void *ctx)
         if (!bpfsnoop_session_exit(ctx, pid_tgid, func_ip, &session_id, cfg->flags.is_session,
                                    cfg->flags.graph_mode || cfg->flags.insn_mode))
             return BPF_OK;
+        if (cfg->flags.deferred_filter)
+            filter_pass = filter(args, session_id);
 
         event_type = BPFSNOOP_EVENT_TYPE_FUNC_EXIT;
         break;
@@ -131,7 +136,8 @@ emit_bpfsnoop_event(void *ctx)
     case BPFSNOOP_MODE_ENTRY:
     case BPFSNOOP_MODE_EXIT:
         session_id = gen_session_id(fp);
-        if (!filter(args, session_id))
+        filter_pass = filter(args, session_id);
+        if (!filter_pass)
             return BPF_OK;
 
         event_type = (mode == BPFSNOOP_MODE_ENTRY) ? BPFSNOOP_EVENT_TYPE_FUNC_ENTRY
@@ -141,7 +147,7 @@ emit_bpfsnoop_event(void *ctx)
 
     return output_event(ctx, event_type, session_id, func_ip, cpu, pid, comm,
                         lbr, can_output_lbr, args, retval, cfg->flags.output_pkt,
-                        cfg->flags.output_arg);
+                        cfg->flags.output_arg, filter_pass);
 }
 
 SEC("fexit")

--- a/bpf/bpfsnoop_cfg_flags.h
+++ b/bpf/bpfsnoop_cfg_flags.h
@@ -22,7 +22,8 @@
             __u32 is_prog:1;            \
             __u32 kmulti_mode:1;        \
             __u32 deferred_filter:1;    \
-            __u32 pad:19;               \
+            __u32 pkt_retval:1;         \
+            __u32 pad:18;               \
         } flags;                        \
         __u32 tracee_flags;             \
     }

--- a/bpf/bpfsnoop_cfg_flags.h
+++ b/bpf/bpfsnoop_cfg_flags.h
@@ -21,7 +21,8 @@
             __u32 is_tp:1;              \
             __u32 is_prog:1;            \
             __u32 kmulti_mode:1;        \
-            __u32 pad:20;               \
+            __u32 deferred_filter:1;    \
+            __u32 pad:19;               \
         } flags;                        \
         __u32 tracee_flags;             \
     }

--- a/bpf/bpfsnoop_event_output.h
+++ b/bpf/bpfsnoop_event_output.h
@@ -28,7 +28,7 @@ static __always_inline int
 output_event(void *ctx, __u16 event_type, __u64 session_id, __u64 func_ip,
              __u32 cpu, __u32 pid, __u8 comm[16], struct bpfsnoop_lbr_data *lbr,
              bool can_output_lbr, __u64 *args, __u64 retval, bool can_output_pkt,
-             bool can_output_arg)
+             bool can_output_arg, bool filter_pass)
 {
     void *buffer, *ptr;
     struct event *evt;
@@ -54,6 +54,7 @@ output_event(void *ctx, __u16 event_type, __u64 session_id, __u64 func_ip,
     evt->flags.output_lbr &= can_output_lbr;
     evt->flags.output_pkt &= can_output_pkt;
     evt->flags.output_arg &= can_output_arg;
+    evt->flags.deferred_filter = filter_pass;
     evt->tracee_arg_entry_size = cfg->tracee_arg_entry_size;
     evt->tracee_arg_exit_size = cfg->tracee_arg_exit_size;
     evt->tracee_arg_data_size = cfg->tracee_arg_data_size;

--- a/bpf/bpfsnoop_kmulti.c
+++ b/bpf/bpfsnoop_kmulti.c
@@ -160,7 +160,7 @@ emit_bpfsnoop_kmulti_event(struct pt_regs *ctx)
 
     return output_event(ctx, event_type, session_id, func_ip,
                         cpu, pid, comm, lbr, can_output_lbr, args, retval, output_pkt,
-                        output_arg);
+                        output_arg, true);
 }
 
 SEC("kprobe.multi")

--- a/docs/how_to_build.md
+++ b/docs/how_to_build.md
@@ -90,9 +90,9 @@ Usage of bpfsnoop:
       --fgraph-include strings      limited functions in function call graph, empty means all functions, rules are same as -k
       --fgraph-max-depth uint       maximum depth of function call graph, larger means slower to start bpfsnoop, 5 by default (default 5)
       --fgraph-proto                output function prototype in function call graph, like --show-func-proto
-      --filter-arg strings          filter function's argument with C expression, e.g. 'prog->type == BPF_PROG_TYPE_TRACING'
+      --filter-arg strings          filter function arguments with a C expression; typed $retval is available in exit modes
       --filter-pid uint32           filter pid for tracing
-      --filter-pkt string           filter packet with pcap-filter(7) expr if function argument is skb or xdp, e.g. 'icmp and host 1.1.1.1'
+      --filter-pkt string           filter skb/xdp argument with a pcap-filter(7) expression; prefix with '(r)' for a packet-typed return value
       --kernel-vmlinux string       specific kernel vmlinux directory to search vmlinux and modules dbgsym files
   -k, --kfunc strings               filter kernel functions, '(i)' prefix means insn tracing, '<kfunc>[:<arg>][:<type>]' format, e.g. 'tcp_v4_connect:sk:struct sock *', '*:(struct sk_buff *)skb'
       --kfunc-all-kmods             filter functions in all kernel modules
@@ -100,11 +100,11 @@ Usage of bpfsnoop:
       --limit-events uint           limited number events to output, 0 to output all events
   -m, --mode strings                mode of bpfsnoop, exit and/or entry (default [exit])
   -o, --output string               output file for the result, default is stdout
-      --output-arg stringArray      output function's argument with C expression, e.g. 'prog->type'
+      --output-arg stringArray      output a C expression over function arguments; e.g. 'prog->type' or '(int)$retval'
   -g, --output-fgraph               output function call graph, works with -k,-p
       --output-insns                output function's insns exec path, same as '(i)' in -k, only works with -k
       --output-lbr                  output LBR perf event
-      --output-pkt                  output packet's tuple info if tracee has skb/xdp argument
+      --output-pkt                  output packet tuple; append '(r)' to select a packet-typed return value
       --output-stack                output function call stack
   -p, --prog strings                bpf prog info for bpfsnoop in format PROG[,PROG,..], PROG: PROGID[:<prog function name>], PROGID: <prog ID> or 'i/id:<prog ID>' or 'p/pinned:<pinned file>' or 't/tag:<prog tag>' or 'n/name:<prog full name>' or 'pid:<pid>'; all bpf progs will be traced if '*' is specified
       --read stringArray            read kernel memory using C expressions

--- a/docs/retval.md
+++ b/docs/retval.md
@@ -1,0 +1,25 @@
+# Typed return values
+
+`--filter-arg` and `--output-arg` expose a function return value as `$retval` when exit tracing is enabled. The pseudo-variable always requires an explicit concrete cast:
+
+```sh
+bpfsnoop -k tcp_v4_connect -m exit \
+  --filter-arg '(int)$retval != 0' \
+  --output-arg '(int)$retval'
+```
+
+The cast must match the function's declared return type after BTF typedef and qualifier wrappers are removed. For example, `(int)$retval` does not select a pointer-returning function. `$retval` is distinct from a real parameter named `retval`.
+
+Return expressions work in `--mode exit` and `--mode entry,exit`. An entry-only target is skipped when its filter needs `$retval`, while return-only output expressions are ignored. Tracepoints and void-returning functions do not provide `$retval`.
+
+In combined entry/exit mode, a return-dependent filter is evaluated at exit. bpfsnoop buffers the related entry, function-graph, and instruction data until that decision is known. A rejected session produces no output, does not consume `--limit-events`, and does not update histogram, t-digest, or flamegraph aggregates.
+
+Packet options use only real function parameters by default. Prefix them with `(r)` to explicitly select a packet-typed return value:
+
+```sh
+bpfsnoop -k skb_recv_datagram -m exit \
+  --filter-pkt '(r) icmp' \
+  --output-pkt '(r)'
+```
+
+The same deferred decision applies to packet-return filters in combined entry/exit, function-graph, and instruction tracing.

--- a/internal/bpfsnoop/bpf_read_data.go
+++ b/internal/bpfsnoop/bpf_read_data.go
@@ -36,7 +36,7 @@ func readKernelData(expr string, helpers *Helpers) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	readSize, err := arg.compile(nil, krnl, krnl, 0, int(cc.MemoryReadFlagForce), "__read_data_fail")
+	readSize, err := arg.compile(nil, nil, krnl, krnl, 0, int(cc.MemoryReadFlagForce), "__read_data_fail")
 	if err != nil {
 		return fmt.Errorf("Failed to compile expression %q: %w", expr, err)
 	}
@@ -106,7 +106,7 @@ func readKernelData(expr string, helpers *Helpers) error {
 
 	var sb strings.Builder
 	f := findSymbolHelper(0, helpers)
-	err = __outputFuncArgAttrs(&sb, []funcArgumentOutput{arg}, buff, hist, tdigest, f)
+	err = __outputFuncArgAttrs(&sb, []funcArgumentOutput{arg}, buff, true, hist, tdigest, f)
 	if err != nil {
 		return fmt.Errorf("failed to output function arg attrs: %w", err)
 	}

--- a/internal/bpfsnoop/bpf_spec.go
+++ b/internal/bpfsnoop/bpf_spec.go
@@ -18,7 +18,7 @@ func TrimSpec(spec *ebpf.CollectionSpec) {
 		}
 
 		if len(argOutput.args) == 0 {
-			argOutput.clear(prog)
+			clearOutputArgSubprog(prog)
 		}
 	}
 }

--- a/internal/bpfsnoop/bpf_tail_call.go
+++ b/internal/bpfsnoop/bpf_tail_call.go
@@ -158,7 +158,7 @@ func ProbeTailcallIssue(spec *ebpf.CollectionSpec) error {
 	prog := spec.Programs[TracingProgName()]
 	pktFilter.clear(prog)
 	pktOutput.clear(prog)
-	argOutput.clear(prog)
+	clearOutputArgSubprog(prog)
 	clearFilterArgSubprog(prog)
 
 	attachType := ebpf.AttachTraceFExit

--- a/internal/bpfsnoop/bpf_tracing.go
+++ b/internal/bpfsnoop/bpf_tracing.go
@@ -44,6 +44,12 @@ type traceeConfig struct {
 	session       bool
 }
 
+type traceeOutputs struct {
+	args        []funcArgumentOutput
+	argDataSize int
+	pkt         bool
+}
+
 func (t *bpfTracing) Progs() []*ebpf.Program {
 	return t.progs
 }
@@ -196,6 +202,25 @@ func (t *bpfTracing) injectArgOutput(prog *ebpf.ProgramSpec, params []btf.FuncPa
 	debugLogIf(len(args) != 0, "Injected --output-arg expr to func %s", fnName)
 
 	return args, size, nil
+}
+
+func (t *bpfTracing) injectTraceeOutputs(prog *ebpf.ProgramSpec, params []btf.FuncParam, spec *btf.Spec, fnName string, outputPkt bool) (traceeOutputs, error) {
+	var outputs traceeOutputs
+
+	outputs.pkt = t.injectPktOutput(outputPkt, prog, params, fnName)
+	if err := t.injectPktFilter(prog, params, fnName); err != nil {
+		return outputs, err
+	}
+	if err := t.injectArgFilter(prog, params, spec, fnName); err != nil {
+		return outputs, err
+	}
+	var err error
+	outputs.args, outputs.argDataSize, err = t.injectArgOutput(prog, params, spec, fnName)
+	if err != nil {
+		return outputs, err
+	}
+
+	return outputs, nil
 }
 
 func (t *bpfTracing) injectSkbFilter(prog *ebpf.ProgramSpec, index int, typ btf.Type) error {

--- a/internal/bpfsnoop/bpf_tracing.go
+++ b/internal/bpfsnoop/bpf_tracing.go
@@ -45,12 +45,14 @@ type traceeConfig struct {
 	withRet       bool
 	session       bool
 	exitFilter    bool
+	pktRetval     bool
 }
 
 type traceeOutputs struct {
 	args        []funcArgumentOutput
 	argDataSize int
 	pkt         bool
+	pktRetval   bool
 	exitFilter  bool
 }
 
@@ -73,6 +75,7 @@ func setBpfsnoopConfig(spec *ebpf.CollectionSpec, c traceeConfig) error {
 	cfg.SetIsProg(c.isProg)
 	cfg.SetKmultiMode(c.kmultiMode)
 	cfg.SetExitFilter(c.exitFilter)
+	cfg.SetPktRetval(c.pktRetval)
 	cfg.FilterPid = filterPid
 	copy(cfg.FilterComm[:], []uint8(filterComm))
 	cfg.FilterCommLen = uint32(len(filterComm))
@@ -223,11 +226,20 @@ func (t *bpfTracing) injectTraceeOutputs(prog *ebpf.ProgramSpec, params []btf.Fu
 		return outputs, false, nil
 	}
 
-	outputs.pkt = t.injectPktOutput(outputPkt, prog, params, fnName)
-	if err := t.injectPktFilter(prog, params, fnName); err != nil {
+	outputParams := paramsAddRetval(params, ret, outputPktRetval)
+	outputs.pkt, outputs.pktRetval = t.injectPktOutput(prog, outputParams, fnName, outputPkt, outputPktRetval)
+
+	filterParams := paramsAddRetval(params, ret, pktFilter.retval)
+	pktFilterRetval, err := t.injectPktFilter(prog, filterParams, fnName, isExit, pktFilter.retval)
+	if err != nil {
 		return outputs, false, err
 	}
-	outputs.exitFilter = filterRetval && bothEntryExit
+	if pktFilterRetval && !canExit {
+		DebugLog("Skip %s because --filter-pkt requires %s in entry-only mode", fnName, cc.RetvalName)
+		return outputs, false, nil
+	}
+
+	outputs.exitFilter = (filterRetval || pktFilterRetval) && bothEntryExit
 	if err := t.injectArgFilter(prog, params, ret, spec, fnName, filterMatch, !filterRetval || isExit); err != nil {
 		return outputs, false, err
 	}
@@ -263,12 +275,16 @@ func (t *bpfTracing) injectXdpFrameFilter(prog *ebpf.ProgramSpec, index int, typ
 	return nil
 }
 
-func (t *bpfTracing) injectPktFilter(prog *ebpf.ProgramSpec, params []btf.FuncParam, fnName string) error {
+func (t *bpfTracing) injectPktFilter(prog *ebpf.ProgramSpec, params []btf.FuncParam, fnName string, compileRetval, retvalOnly bool) (bool, error) {
 	if pktFilter.expr == "" {
-		return nil
+		return false, nil
 	}
 
 	for i, p := range params {
+		retval := p.Name == cc.RetvalName
+		if retvalOnly && !retval {
+			continue
+		}
 		typ := mybtf.UnderlyingType(p.Type)
 		ptr, ok := typ.(*btf.Pointer)
 		if !ok {
@@ -279,6 +295,10 @@ func (t *bpfTracing) injectPktFilter(prog *ebpf.ProgramSpec, params []btf.FuncPa
 		if !ok {
 			continue
 		}
+		if retval && !compileRetval {
+			pktFilter.clear(prog)
+			return true, nil
+		}
 
 		var err error
 		switch stt.Name {
@@ -288,7 +308,7 @@ func (t *bpfTracing) injectPktFilter(prog *ebpf.ProgramSpec, params []btf.FuncPa
 		case "__sk_buff":
 			typ, err := btfx.GetStructBtfPointer("sk_buff", getKernelBTF())
 			if err != nil {
-				return err
+				return false, err
 			}
 
 			err = t.injectSkbFilter(prog, i, typ)
@@ -299,7 +319,7 @@ func (t *bpfTracing) injectPktFilter(prog *ebpf.ProgramSpec, params []btf.FuncPa
 		case "xdp_md":
 			typ, err := btfx.GetStructBtfPointer("xdp_buff", getKernelBTF())
 			if err != nil {
-				return err
+				return false, err
 			}
 
 			err = t.injectXdpFilter(prog, i, typ)
@@ -312,25 +332,28 @@ func (t *bpfTracing) injectPktFilter(prog *ebpf.ProgramSpec, params []btf.FuncPa
 		}
 
 		if err != nil {
-			return err
+			return false, err
 		}
 
 		DebugLog("Injected --filter-pkt expr to %dth param (%s)%s of %s", i, btfx.Repr(typ), p.Name, fnName)
-		return nil
+		return retval, nil
 	}
 
 	pktFilter.clear(prog)
 
-	return nil
+	return false, nil
 }
 
-func (t *bpfTracing) injectPktOutput(pkt bool, prog *ebpf.ProgramSpec, params []btf.FuncParam, fnName string) bool {
+func (t *bpfTracing) injectPktOutput(prog *ebpf.ProgramSpec, params []btf.FuncParam, fnName string, pkt bool, retvalOnly bool) (bool, bool) {
 	if !pkt {
 		pktOutput.clear(prog)
-		return false
+		return false, false
 	}
 
 	for i, p := range params {
+		if retvalOnly && p.Name != cc.RetvalName {
+			continue
+		}
 		typ := mybtf.UnderlyingType(p.Type)
 		ptr, ok := typ.(*btf.Pointer)
 		if !ok {
@@ -346,21 +369,29 @@ func (t *bpfTracing) injectPktOutput(pkt bool, prog *ebpf.ProgramSpec, params []
 		case "sk_buff", "__sk_buff":
 			pktOutput.outputSkb(prog, i)
 			DebugLog("Injected --output-pkt to %dth param (%s)%s of %s", i, btfx.Repr(p.Type), p.Name, fnName)
-			return true
+			return true, p.Name == cc.RetvalName
 
 		case "xdp_buff", "xdp_md":
 			pktOutput.outputXdpBuff(prog, i)
 			DebugLog("Injected --output-pkt to %dth param (%s)%s of %s", i, btfx.Repr(p.Type), p.Name, fnName)
-			return true
+			return true, p.Name == cc.RetvalName
 
 		case "xdp_frame":
 			pktOutput.outputXdpFrame(prog, i)
 			DebugLog("Injected --output-pkt to %dth param (%s)%s of %s", i, btfx.Repr(p.Type), p.Name, fnName)
-			return true
+			return true, p.Name == cc.RetvalName
 		}
 	}
 
 	pktOutput.clear(prog)
 
-	return false
+	return false, false
+}
+
+func paramsAddRetval(params []btf.FuncParam, ret btf.Type, retval bool) []btf.FuncParam {
+	if !retval {
+		return params
+	}
+	params = slices.Clone(params)
+	return append(params, btf.FuncParam{Name: cc.RetvalName, Type: ret})
 }

--- a/internal/bpfsnoop/bpf_tracing.go
+++ b/internal/bpfsnoop/bpf_tracing.go
@@ -5,6 +5,7 @@ package bpfsnoop
 
 import (
 	"fmt"
+	"slices"
 	"sync"
 
 	"github.com/Asphaltt/mybtf"
@@ -13,6 +14,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/bpfsnoop/bpfsnoop/internal/btfx"
+	"github.com/bpfsnoop/bpfsnoop/internal/cc"
 )
 
 type bpfTracing struct {
@@ -42,12 +44,14 @@ type traceeConfig struct {
 	kmultiMode    bool
 	withRet       bool
 	session       bool
+	exitFilter    bool
 }
 
 type traceeOutputs struct {
 	args        []funcArgumentOutput
 	argDataSize int
 	pkt         bool
+	exitFilter  bool
 }
 
 func (t *bpfTracing) Progs() []*ebpf.Program {
@@ -68,6 +72,7 @@ func setBpfsnoopConfig(spec *ebpf.CollectionSpec, c traceeConfig) error {
 	cfg.SetIsTp(c.isTp)
 	cfg.SetIsProg(c.isProg)
 	cfg.SetKmultiMode(c.kmultiMode)
+	cfg.SetExitFilter(c.exitFilter)
 	cfg.FilterPid = filterPid
 	copy(cfg.FilterComm[:], []uint8(filterComm))
 	cfg.FilterCommLen = uint32(len(filterComm))
@@ -172,27 +177,28 @@ func TracingProgName() string {
 	return "bpfsnoop_fn"
 }
 
-func (t *bpfTracing) injectArgFilter(prog *ebpf.ProgramSpec, params []btf.FuncParam, spec *btf.Spec, fnName string) error {
-	i, err := argFilter.inject(prog, params, spec)
-	if err != nil {
-		if err == errSkipped {
-			clearFilterArgSubprog(prog)
-			return nil
-		}
+func (t *bpfTracing) injectArgFilter(prog *ebpf.ProgramSpec, params []btf.FuncParam, ret btf.Type, spec *btf.Spec, fnName string, match *funcArgument, compile bool) error {
+	if match == nil || !compile {
+		clearFilterArgSubprog(prog)
+		return nil
+	}
+
+	if err := match.inject(prog, getKernelBTF(), spec, params, ret); err != nil {
 		return fmt.Errorf("failed to inject func arg filter expr: %w", err)
 	}
 
-	DebugLog("Injected --filter-arg '%s' to func %s", argFilter.args[i].expr, fnName)
+	DebugLog("Injected --filter-arg '%s' to func %s", match.expr, fnName)
 
 	return nil
 }
 
-func (t *bpfTracing) injectArgOutput(prog *ebpf.ProgramSpec, params []btf.FuncParam, spec *btf.Spec, fnName string) ([]funcArgumentOutput, int, error) {
+func (t *bpfTracing) injectArgOutput(prog *ebpf.ProgramSpec, params []btf.FuncParam, ret btf.Type, spec *btf.Spec, fnName string, canExit bool) ([]funcArgumentOutput, int, error) {
 	if len(argOutput.args) == 0 {
+		clearOutputArgSubprog(prog)
 		return nil, 0, nil
 	}
 
-	args, size, err := argOutput.matchParams(params, spec)
+	args, size, err := argOutput.matchParams(params, ret, spec, canExit)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to match params: %w", err)
 	}
@@ -204,23 +210,33 @@ func (t *bpfTracing) injectArgOutput(prog *ebpf.ProgramSpec, params []btf.FuncPa
 	return args, size, nil
 }
 
-func (t *bpfTracing) injectTraceeOutputs(prog *ebpf.ProgramSpec, params []btf.FuncParam, spec *btf.Spec, fnName string, outputPkt bool) (traceeOutputs, error) {
+func (t *bpfTracing) injectTraceeOutputs(prog *ebpf.ProgramSpec, params []btf.FuncParam, ret btf.Type, spec *btf.Spec, fnName string, outputPkt, bothEntryExit, isExit, canExit bool) (traceeOutputs, bool, error) {
 	var outputs traceeOutputs
+
+	filterMatch, err := argFilter.selectMatch(params, ret, spec)
+	if err != nil {
+		return outputs, false, fmt.Errorf("failed to match func arg filter expr: %w", err)
+	}
+	filterRetval := filterMatch != nil && slices.Contains(filterMatch.vars, cc.RetvalName)
+	if filterRetval && !canExit {
+		DebugLog("Skip %s because selected --filter-arg requires %s in entry-only mode", fnName, cc.RetvalName)
+		return outputs, false, nil
+	}
 
 	outputs.pkt = t.injectPktOutput(outputPkt, prog, params, fnName)
 	if err := t.injectPktFilter(prog, params, fnName); err != nil {
-		return outputs, err
+		return outputs, false, err
 	}
-	if err := t.injectArgFilter(prog, params, spec, fnName); err != nil {
-		return outputs, err
+	outputs.exitFilter = filterRetval && bothEntryExit
+	if err := t.injectArgFilter(prog, params, ret, spec, fnName, filterMatch, !filterRetval || isExit); err != nil {
+		return outputs, false, err
 	}
-	var err error
-	outputs.args, outputs.argDataSize, err = t.injectArgOutput(prog, params, spec, fnName)
+	outputs.args, outputs.argDataSize, err = t.injectArgOutput(prog, params, ret, spec, fnName, canExit)
 	if err != nil {
-		return outputs, err
+		return outputs, false, err
 	}
 
-	return outputs, nil
+	return outputs, true, nil
 }
 
 func (t *bpfTracing) injectSkbFilter(prog *ebpf.ProgramSpec, index int, typ btf.Type) error {

--- a/internal/bpfsnoop/bpf_tracing_func.go
+++ b/internal/bpfsnoop/bpf_tracing_func.go
@@ -127,6 +127,7 @@ func (t *bpfTracing) traceFunc(spec *ebpf.CollectionSpec, reusedMaps map[string]
 		withRet:       withRet,
 		session:       fsession,
 		exitFilter:    outputs.exitFilter,
+		pktRetval:     outputs.pktRetval,
 	}); err != nil {
 		return fmt.Errorf("failed to set bpfsnoop config: %w", err)
 	}

--- a/internal/bpfsnoop/bpf_tracing_func.go
+++ b/internal/bpfsnoop/bpf_tracing_func.go
@@ -74,9 +74,15 @@ func (t *bpfTracing) traceFunc(spec *ebpf.CollectionSpec, reusedMaps map[string]
 	progSpec := spec.Programs[tracingFuncName]
 	funcProto := fn.Func.Type.(*btf.FuncProto)
 	params := funcProto.Params
-	outputs, err := t.injectTraceeOutputs(progSpec, params, fn.Btf, traceeName, fn.Flag.pkt)
+	retType := funcProto.Return
+	canExit := !isTracepoint && (isExit || bothEntryExit)
+	outputs, ok, err := t.injectTraceeOutputs(progSpec, params, retType, fn.Btf, traceeName,
+		fn.Flag.pkt, bothEntryExit, isExit, canExit)
 	if err != nil {
 		return err
+	}
+	if !ok {
+		return nil
 	}
 	fn.Args = outputs.args
 	fn.Data = outputs.argDataSize
@@ -120,6 +126,7 @@ func (t *bpfTracing) traceFunc(spec *ebpf.CollectionSpec, reusedMaps map[string]
 		kmultiMode:    false,
 		withRet:       withRet,
 		session:       fsession,
+		exitFilter:    outputs.exitFilter,
 	}); err != nil {
 		return fmt.Errorf("failed to set bpfsnoop config: %w", err)
 	}

--- a/internal/bpfsnoop/bpf_tracing_func.go
+++ b/internal/bpfsnoop/bpf_tracing_func.go
@@ -74,19 +74,13 @@ func (t *bpfTracing) traceFunc(spec *ebpf.CollectionSpec, reusedMaps map[string]
 	progSpec := spec.Programs[tracingFuncName]
 	funcProto := fn.Func.Type.(*btf.FuncProto)
 	params := funcProto.Params
-	fn.Pkt = t.injectPktOutput(fn.Flag.pkt, progSpec, params, traceeName)
-	if err := t.injectPktFilter(progSpec, params, traceeName); err != nil {
-		return err
-	}
-	if err := t.injectArgFilter(progSpec, params, fn.Btf, traceeName); err != nil {
-		return err
-	}
-	args, argDataSize, err := t.injectArgOutput(progSpec, params, fn.Btf, traceeName)
+	outputs, err := t.injectTraceeOutputs(progSpec, params, fn.Btf, traceeName, fn.Flag.pkt)
 	if err != nil {
 		return err
 	}
-	fn.Args = args
-	fn.Data = argDataSize
+	fn.Args = outputs.args
+	fn.Data = outputs.argDataSize
+	fn.Pkt = outputs.pkt
 
 	withRet := !isTracepoint && isExit
 	fnArgsBufSize, err := injectOutputFuncArgs(progSpec, fn.Prms, fn.Ret, withRet)
@@ -114,7 +108,7 @@ func (t *bpfTracing) traceFunc(spec *ebpf.CollectionSpec, reusedMaps map[string]
 		fnArgsBufSz:   fnArgsBufSize,
 		argEntrySz:    argEntrySize,
 		argExitSz:     argExitSize,
-		argDataSz:     argDataSize,
+		argDataSz:     outputs.argDataSize,
 		outputLbr:     fn.Flag.lbr,
 		outputStack:   stack,
 		outputPkt:     fn.Pkt,

--- a/internal/bpfsnoop/bpf_tracing_func_multi.go
+++ b/internal/bpfsnoop/bpf_tracing_func_multi.go
@@ -182,9 +182,6 @@ func (t *bpfTracing) traceKfuncMultiMode(reusedMaps map[string]*ebpf.Map, g *kfu
 
 	fn := g.fn
 	bothEntryExit := fn.Flag.both
-	if err := validateKmultiArgOutput(fn); err != nil {
-		return err
-	}
 
 	tracingFuncName := "bpfsnoop_kmulti"
 	progSpec := spec.Programs[tracingFuncName]
@@ -258,6 +255,7 @@ func (t *bpfTracing) traceKfuncMultiMode(reusedMaps map[string]*ebpf.Map, g *kfu
 		withRet:       withRet,
 		session:       sessionMode,
 		exitFilter:    false,
+		pktRetval:     false,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to set bpfsnoop config: %w", err)
@@ -311,22 +309,6 @@ func (t *bpfTracing) traceKfuncMultiMode(reusedMaps map[string]*ebpf.Map, g *kfu
 		p: prog,
 	})
 	t.llock.Unlock()
-
-	return nil
-}
-
-func validateKmultiArgOutput(fn *KFunc) error {
-	if len(argOutput.args) == 0 {
-		return nil
-	}
-
-	for _, a := range argOutput.args {
-		for _, v := range a.vars {
-			if v != fn.Flag.argName {
-				return fmt.Errorf("kmulti --output-arg '%s' must match trace arg '%s'", a.expr, fn.Flag.argName)
-			}
-		}
-	}
 
 	return nil
 }

--- a/internal/bpfsnoop/bpf_tracing_func_multi.go
+++ b/internal/bpfsnoop/bpf_tracing_func_multi.go
@@ -190,21 +190,24 @@ func (t *bpfTracing) traceKfuncMultiMode(reusedMaps map[string]*ebpf.Map, g *kfu
 	progSpec := spec.Programs[tracingFuncName]
 	funcProto := fn.Func.Type.(*btf.FuncProto)
 	params := funcProto.Params
-
 	if isExit {
 		clearFilterArgSubprog(progSpec)
 		pktFilter.clear(progSpec)
 		clearOutputArgSubprog(progSpec)
 		clearOutputPktSubprogs(progSpec)
 	} else {
+		filterMatch, err := argFilter.selectMatch(params, nil, fn.Btf)
+		if err != nil {
+			return fmt.Errorf("failed to match kmulti arg filter: %w", err)
+		}
 		fn.Pkt = t.injectPktOutput(fn.Flag.pkt, progSpec, params, fn.Func.Name)
 		if err := t.injectPktFilter(progSpec, params, fn.Func.Name); err != nil {
 			return err
 		}
-		if err := t.injectArgFilter(progSpec, params, fn.Btf, fn.Func.Name); err != nil {
+		if err := t.injectArgFilter(progSpec, params, nil, fn.Btf, fn.Func.Name, filterMatch, true); err != nil {
 			return err
 		}
-		args, argDataSize, err := t.injectArgOutput(progSpec, params, fn.Btf, fn.Func.Name)
+		args, argDataSize, err := t.injectArgOutput(progSpec, params, nil, fn.Btf, fn.Func.Name, false)
 		if err != nil {
 			return err
 		}
@@ -254,6 +257,7 @@ func (t *bpfTracing) traceKfuncMultiMode(reusedMaps map[string]*ebpf.Map, g *kfu
 		kmultiMode:    true,
 		withRet:       withRet,
 		session:       sessionMode,
+		exitFilter:    false,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to set bpfsnoop config: %w", err)

--- a/internal/bpfsnoop/bpf_tracing_func_multi.go
+++ b/internal/bpfsnoop/bpf_tracing_func_multi.go
@@ -200,8 +200,8 @@ func (t *bpfTracing) traceKfuncMultiMode(reusedMaps map[string]*ebpf.Map, g *kfu
 		if err != nil {
 			return fmt.Errorf("failed to match kmulti arg filter: %w", err)
 		}
-		fn.Pkt = t.injectPktOutput(fn.Flag.pkt, progSpec, params, fn.Func.Name)
-		if err := t.injectPktFilter(progSpec, params, fn.Func.Name); err != nil {
+		fn.Pkt, _ = t.injectPktOutput(progSpec, params, fn.Func.Name, fn.Flag.pkt, false)
+		if _, err := t.injectPktFilter(progSpec, params, fn.Func.Name, false, false); err != nil {
 			return err
 		}
 		if err := t.injectArgFilter(progSpec, params, nil, fn.Btf, fn.Func.Name, filterMatch, true); err != nil {

--- a/internal/bpfsnoop/bpf_tracing_prog.go
+++ b/internal/bpfsnoop/bpf_tracing_prog.go
@@ -78,6 +78,10 @@ func (t *bpfTracing) traceProg(spec *ebpf.CollectionSpec, reusedMaps map[string]
 	if err != nil {
 		return fmt.Errorf("failed to correct arg types in params of %s: %w", info.fn.Name, err)
 	}
+	retType, err := correctArgType(info.fn.Type.(*btf.FuncProto).Return)
+	if err != nil {
+		return fmt.Errorf("failed to correct return type of %s: %w", info.fn.Name, err)
+	}
 
 	spec = spec.Copy()
 
@@ -85,9 +89,14 @@ func (t *bpfTracing) traceProg(spec *ebpf.CollectionSpec, reusedMaps map[string]
 	tracingFuncName := TracingProgName()
 	progSpec := spec.Programs[tracingFuncName]
 	bprog := bprogs.funcs[info.funcIP]
-	outputs, err := t.injectTraceeOutputs(progSpec, params, krnl, traceeName, info.flag.pkt)
+	canExit := fexit || bothEntryExit
+	outputs, ok, err := t.injectTraceeOutputs(progSpec, params, retType, krnl, traceeName,
+		info.flag.pkt, bothEntryExit, fexit, canExit)
 	if err != nil {
 		return err
+	}
+	if !ok {
+		return nil
 	}
 	bprog.funcArgs = outputs.args
 	bprog.argDataSz = outputs.argDataSize
@@ -129,6 +138,7 @@ func (t *bpfTracing) traceProg(spec *ebpf.CollectionSpec, reusedMaps map[string]
 		kmultiMode:    false,
 		withRet:       fexit,
 		session:       fsession,
+		exitFilter:    outputs.exitFilter,
 	}); err != nil {
 		return fmt.Errorf("failed to set bpfsnoop config: %w", err)
 	}

--- a/internal/bpfsnoop/bpf_tracing_prog.go
+++ b/internal/bpfsnoop/bpf_tracing_prog.go
@@ -85,19 +85,13 @@ func (t *bpfTracing) traceProg(spec *ebpf.CollectionSpec, reusedMaps map[string]
 	tracingFuncName := TracingProgName()
 	progSpec := spec.Programs[tracingFuncName]
 	bprog := bprogs.funcs[info.funcIP]
-	bprog.pktOutput = t.injectPktOutput(info.flag.pkt, progSpec, params, traceeName)
-	if err := t.injectPktFilter(progSpec, params, traceeName); err != nil {
-		return err
-	}
-	if err := t.injectArgFilter(progSpec, params, krnl, traceeName); err != nil {
-		return err
-	}
-	args, argDataSize, err := t.injectArgOutput(progSpec, params, krnl, traceeName)
+	outputs, err := t.injectTraceeOutputs(progSpec, params, krnl, traceeName, info.flag.pkt)
 	if err != nil {
 		return err
 	}
-	bprog.funcArgs = args
-	bprog.argDataSz = argDataSize
+	bprog.funcArgs = outputs.args
+	bprog.argDataSz = outputs.argDataSize
+	bprog.pktOutput = outputs.pkt
 	fnArgsBufSize, err := injectOutputFuncArgs(progSpec, info.params, info.ret, fexit)
 	if err != nil {
 		return fmt.Errorf("failed to inject output func args: %w", err)
@@ -123,7 +117,7 @@ func (t *bpfTracing) traceProg(spec *ebpf.CollectionSpec, reusedMaps map[string]
 		fnArgsBufSz:   fnArgsBufSize,
 		argEntrySz:    argEntrySize,
 		argExitSz:     argExitSize,
-		argDataSz:     argDataSize,
+		argDataSz:     outputs.argDataSize,
 		outputLbr:     info.flag.lbr,
 		outputStack:   stack,
 		outputPkt:     bprog.pktOutput,

--- a/internal/bpfsnoop/bpf_tracing_prog.go
+++ b/internal/bpfsnoop/bpf_tracing_prog.go
@@ -139,6 +139,7 @@ func (t *bpfTracing) traceProg(spec *ebpf.CollectionSpec, reusedMaps map[string]
 		withRet:       fexit,
 		session:       fsession,
 		exitFilter:    outputs.exitFilter,
+		pktRetval:     outputs.pktRetval,
 	}); err != nil {
 		return fmt.Errorf("failed to set bpfsnoop config: %w", err)
 	}

--- a/internal/bpfsnoop/bpfsnoop.go
+++ b/internal/bpfsnoop/bpfsnoop.go
@@ -141,12 +141,21 @@ func Run(reader *ringbuf.Reader, maps map[string]*ebpf.Map, w io.Writer, helpers
 		if requiredSession {
 			if event.Type == eventTypeFuncEntry {
 				sess = sessions.Add(event.SessID, event.KernNs, fgraphMaxDepth, isGraph)
+				if haveFlag(event.TraceeFlags, traceeFlagExitFilter) {
+					sess.deferDerived(helpers.Flags.histExpr, helpers.Flags.tdigestExpr)
+				}
 			} else {
 				s, ok := sessions.GetAndDel(event.SessID + 1)
 				if ok {
 					sess = s
 					duration = time.Duration(event.KernNs - s.started)
 					if duration < runDelta {
+						return nil
+					}
+					if s.deferred && !haveFlag(event.TraceeFlags, traceeFlagExitFilter) {
+						sb.Reset()
+						lbrStack.reset()
+						fnStack.reset()
 						return nil
 					}
 				} else {
@@ -182,7 +191,11 @@ func Run(reader *ringbuf.Reader, maps map[string]*ebpf.Map, w io.Writer, helpers
 
 		if argDataSz := int(event.TraceeArgDataSz); argDataSz != 0 {
 			f := findSymbolHelper(uint64(event.FuncIP), helpers)
-			err := outputFuncArgAttrs(&sb, fnInfo.args, data[:argDataSz], hist, tdigest, f)
+			outputHist, outputTDigest := hist, tdigest
+			if sess != nil && sess.deferred {
+				outputHist, outputTDigest = sess.hist, sess.tdigest
+			}
+			err := outputFuncArgAttrs(&sb, fnInfo.args, data[:argDataSz], isExit, outputHist, outputTDigest, f)
 			if err != nil {
 				return fmt.Errorf("failed to output function arg attrs: %w", err)
 			}
@@ -198,7 +211,11 @@ func Run(reader *ringbuf.Reader, maps map[string]*ebpf.Map, w io.Writer, helpers
 		}
 
 		if haveFlag(event.TraceeFlags, traceeFlagOutputStack) && event.StackID >= 0 {
-			err := fnStack.output(&sb, helpers, stacks, fg, event)
+			outputFlame := fg
+			if sess != nil && sess.deferred {
+				outputFlame = sess.flame
+			}
+			err := fnStack.output(&sb, helpers, stacks, outputFlame, event)
 			if err != nil {
 				return fmt.Errorf("failed to output function stack: %w", err)
 			}
@@ -207,6 +224,7 @@ func Run(reader *ringbuf.Reader, maps map[string]*ebpf.Map, w io.Writer, helpers
 		if sess != nil {
 			sess.outputs = append(sess.outputs, sb.String())
 			if haveRetval {
+				sess.commitDerived(hist, tdigest, fg)
 				for _, output := range sess.outputs {
 					fmt.Fprint(w, output)
 				}

--- a/internal/bpfsnoop/bpfsnoop_arg.go
+++ b/internal/bpfsnoop/bpfsnoop_arg.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net"
+	"slices"
 	"strings"
 	"unsafe"
 
@@ -38,10 +39,14 @@ func dumpOutputArgBuf(data []byte) string {
 	return sb.String()
 }
 
-func __outputFuncArgAttrs(sb *strings.Builder, args []funcArgumentOutput, data []byte, hist *histogram, tdigest *TDigest, f btfx.FindSymbol) error {
+func __outputFuncArgAttrs(sb *strings.Builder, args []funcArgumentOutput, data []byte, outputRetval bool, hist *histogram, tdigest *TDigest, f btfx.FindSymbol) error {
 	gray := color.RGB(0x88, 0x88, 0x88 /* gray */)
 	shouldPrintComma := false
 	for _, arg := range args {
+		if slices.Contains(arg.vars, cc.RetvalName) && !outputRetval {
+			data = data[arg.size:]
+			continue
+		}
 		if shouldPrintComma {
 			fmt.Fprint(sb, ", ")
 		}
@@ -273,14 +278,17 @@ func __outputFuncArgAttrs(sb *strings.Builder, args []funcArgumentOutput, data [
 	return nil
 }
 
-func outputFuncArgAttrs(sb *strings.Builder, args []funcArgumentOutput, data []byte, hist *histogram, tdigest *TDigest, f btfx.FindSymbol) error {
+func outputFuncArgAttrs(sb *strings.Builder, args []funcArgumentOutput, data []byte, outputRetval bool, hist *histogram, tdigest *TDigest, f btfx.FindSymbol) error {
 	histTdigestOnly := true
 	for _, arg := range args {
+		if slices.Contains(arg.vars, cc.RetvalName) && !outputRetval {
+			continue
+		}
 		histTdigestOnly = histTdigestOnly && (arg.isHist || arg.isTDig)
 	}
 	if !histTdigestOnly {
 		fmt.Fprint(sb, "Arg attrs: ")
 	}
 
-	return __outputFuncArgAttrs(sb, args, data, hist, tdigest, f)
+	return __outputFuncArgAttrs(sb, args, data, outputRetval, hist, tdigest, f)
 }

--- a/internal/bpfsnoop/bpfsnoop_config.go
+++ b/internal/bpfsnoop/bpfsnoop_config.go
@@ -17,6 +17,7 @@ const (
 	configFlagIsProgIdx
 	configFlagKmultiModeIdx
 	configFlagExitFilterIdx
+	configFlagPktRetvalIdx
 )
 
 const (
@@ -120,4 +121,8 @@ func (cfg *BpfsnoopConfig) SetKmultiMode(v bool) {
 
 func (cfg *BpfsnoopConfig) SetExitFilter(v bool) {
 	cfg.setFlags(v, configFlagExitFilterIdx)
+}
+
+func (cfg *BpfsnoopConfig) SetPktRetval(v bool) {
+	cfg.setFlags(v, configFlagPktRetvalIdx)
 }

--- a/internal/bpfsnoop/bpfsnoop_config.go
+++ b/internal/bpfsnoop/bpfsnoop_config.go
@@ -16,6 +16,7 @@ const (
 	configFlagIsTpIdx
 	configFlagIsProgIdx
 	configFlagKmultiModeIdx
+	configFlagExitFilterIdx
 )
 
 const (
@@ -29,6 +30,7 @@ const (
 	traceeFlagIsTp        = uint32(1 << configFlagIsTpIdx)
 	traceeFlagIsProg      = uint32(1 << configFlagIsProgIdx)
 	traceeFlagKmultiMode  = uint32(1 << configFlagKmultiModeIdx)
+	traceeFlagExitFilter  = uint32(1 << configFlagExitFilterIdx)
 )
 
 type BpfsnoopConfig struct {
@@ -114,4 +116,8 @@ func (cfg *BpfsnoopConfig) SetIsProg(v bool) {
 
 func (cfg *BpfsnoopConfig) SetKmultiMode(v bool) {
 	cfg.setFlags(v, configFlagKmultiModeIdx)
+}
+
+func (cfg *BpfsnoopConfig) SetExitFilter(v bool) {
+	cfg.setFlags(v, configFlagExitFilterIdx)
 }

--- a/internal/bpfsnoop/bpfsnoop_sess.go
+++ b/internal/bpfsnoop/bpfsnoop_sess.go
@@ -4,14 +4,37 @@
 package bpfsnoop
 
 type Session struct {
-	started uint32
-	outputs []string
-	tstamps []uint32
-	lastidx int
+	started  uint32
+	outputs  []string
+	tstamps  []uint32
+	lastidx  int
+	deferred bool
+	hist     *histogram
+	tdigest  *TDigest
+	flame    *FlameGraph
 }
 
 type Sessions struct {
 	sessions map[uint64]*Session
+}
+
+func (s *Session) deferDerived(histExpr, tdigestExpr string) {
+	s.deferred = true
+	s.hist = newHistogram(histExpr)
+	s.tdigest = newTDigest(tdigestExpr)
+	s.flame = NewFlameGraph()
+}
+
+func (s *Session) commitDerived(hist *histogram, tdigest *TDigest, flame *FlameGraph) {
+	if !s.deferred {
+		return
+	}
+	for i, count := range s.hist.log2 {
+		hist.log2[i] += count
+	}
+	hist.total += s.hist.total
+	_ = tdigest.Merge(s.tdigest.TDigest)
+	flame.merge(s.flame)
 }
 
 func NewSessions() *Sessions {

--- a/internal/bpfsnoop/error.go
+++ b/internal/bpfsnoop/error.go
@@ -8,5 +8,4 @@ import "errors"
 var (
 	ErrNotFound = errors.New("not found")
 	ErrFinished = errors.New("finished")
-	errSkipped  = errors.New("skipped")
 )

--- a/internal/bpfsnoop/filter_arg.go
+++ b/internal/bpfsnoop/filter_arg.go
@@ -26,8 +26,9 @@ type argumentFilter struct {
 }
 
 type funcArgument struct {
-	expr string
-	vars []string
+	expr   string
+	vars   []string
+	retval bool
 }
 
 func getTypeDescFrom(s string) (string, error) {
@@ -60,6 +61,7 @@ func prepareFuncArgument(expr string) (funcArgument, error) {
 	if len(arg.vars) == 0 {
 		return arg, fmt.Errorf("'%s' has no var names", expr)
 	}
+	arg.retval = slices.Contains(arg.vars, cc.RetvalName)
 
 	return arg, nil
 }
@@ -87,16 +89,22 @@ func (arg *funcArgument) clear(prog *ebpf.ProgramSpec) {
 }
 
 func (arg *funcArgument) matchParams(params []btf.FuncParam) bool {
-	for _, param := range params {
-		if slices.Contains(arg.vars, param.Name) {
-			return true
+	for _, name := range arg.vars {
+		if name == cc.RetvalName {
+			continue
+		}
+
+		if !slices.ContainsFunc(params, func(p btf.FuncParam) bool {
+			return p.Name == name
+		}) {
+			return false
 		}
 	}
 
-	return false
+	return true
 }
 
-func (arg *funcArgument) inject(prog *ebpf.ProgramSpec, krnl, spec *btf.Spec, params []btf.FuncParam) error {
+func (arg *funcArgument) inject(prog *ebpf.ProgramSpec, krnl, spec *btf.Spec, params []btf.FuncParam, ret btf.Type) error {
 	mode := cc.MemoryReadModeProbeRead
 	if _, err := krnl.AnyTypeByName("bpf_rdonly_cast"); err == nil {
 		mode = cc.MemoryReadModeCoreRead
@@ -106,11 +114,12 @@ func (arg *funcArgument) inject(prog *ebpf.ProgramSpec, krnl, spec *btf.Spec, pa
 	}
 
 	insns, err := cc.CompileFilterExpr(cc.CompileExprOptions{
-		Expr:      arg.expr,
-		Params:    params,
-		Spec:      spec,
-		Kernel:    krnl,
-		LabelExit: "__label_cc_exit",
+		Expr:       arg.expr,
+		Params:     params,
+		RetvalType: ret,
+		Spec:       spec,
+		Kernel:     krnl,
+		LabelExit:  "__label_cc_exit",
 
 		MemoryReadMode: mode,
 	})
@@ -123,24 +132,26 @@ func (arg *funcArgument) inject(prog *ebpf.ProgramSpec, krnl, spec *btf.Spec, pa
 	return nil
 }
 
-func (f *argumentFilter) inject(prog *ebpf.ProgramSpec, params []btf.FuncParam, spec *btf.Spec) (int, error) {
-	if len(f.args) == 0 {
-		return 0, errSkipped
-	}
-
+func (f *argumentFilter) selectMatch(params []btf.FuncParam, ret btf.Type, spec *btf.Spec) (*funcArgument, error) {
 	krnl := getKernelBTF()
-
-	for i, arg := range f.args {
-		if !arg.matchParams(params) {
-			continue
+	for i := range f.args {
+		arg := &f.args[i]
+		if arg.retval {
+			matched, err := cc.MatchRetvalType(arg.expr, ret, spec, krnl)
+			if err != nil {
+				return nil, err
+			}
+			if !matched {
+				continue
+			}
 		}
 
-		err := arg.inject(prog, krnl, spec, params)
-		if err != nil {
-			return 0, err
+		// A return expression may also refer to regular parameters. It is a
+		// match only when the return type and every non-return variable match.
+		if arg.matchParams(params) {
+			return arg, nil
 		}
-		return i, nil
 	}
 
-	return 0, errSkipped
+	return nil, nil
 }

--- a/internal/bpfsnoop/filter_pkt.go
+++ b/internal/bpfsnoop/filter_pkt.go
@@ -5,6 +5,7 @@ package bpfsnoop
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
@@ -28,12 +29,16 @@ const (
 var pktFilter packetFilter
 
 type packetFilter struct {
-	expr string
+	expr   string
+	retval bool
 }
 
 func preparePacketFilter(expr string) packetFilter {
-	var pf packetFilter
-	pf.expr = expr
+	pf := packetFilter{expr: strings.TrimSpace(expr)}
+	if after, ok := strings.CutPrefix(pf.expr, "(r)"); ok {
+		pf.retval = true
+		pf.expr = strings.TrimSpace(after)
+	}
 	return pf
 }
 

--- a/internal/bpfsnoop/flags.go
+++ b/internal/bpfsnoop/flags.go
@@ -31,6 +31,7 @@ var (
 	filterArg         []string
 	filterBr          []string
 	filterPkt         string
+	outputPktRetval   bool
 	outputArg         []string
 	skipTunnel        bool
 
@@ -118,12 +119,12 @@ func ParseFlags() (*Flags, error) {
 	f.StringSliceVar(&flags.fgraphExtra, "fgraph-extra", nil, "extra functions in function call graph as depth 1, rules are same as -k, '(m)' is not supported here yet")
 	f.BoolVar(&flags.fgraphProto, "fgraph-proto", false, "output function prototype in function call graph, like --show-func-proto")
 	f.BoolVar(&flags.fgraphDebug, "fgraph-debug", false, "debug deadlock caused by fgraph")
-	f.BoolVar(&outputPkt, "output-pkt", false, "output packet's tuple info if tracee has skb/xdp argument")
+	f.BoolVar(&outputPkt, "output-pkt", false, "output packet tuple; append '(r)' to select a packet-typed return value")
 	f.Uint32Var(&filterPid, "filter-pid", 0, "filter pid for tracing")
 	f.StringVar(&filterComm, "filter-comm", "", "filter command for tracing")
-	f.StringSliceVar(&filterArg, "filter-arg", nil, "filter function's argument with C expression, e.g. 'prog->type == BPF_PROG_TYPE_TRACING'")
-	f.StringArrayVar /* use StringArray to accept comma in value */ (&outputArg, "output-arg", nil, "output function's argument with C expression, e.g. 'prog->type'")
-	f.StringVar(&filterPkt, "filter-pkt", "", "filter packet with pcap-filter(7) expr if function argument is skb or xdp, e.g. 'icmp and host 1.1.1.1'")
+	f.StringSliceVar(&filterArg, "filter-arg", nil, "filter function arguments with a C expression; typed $retval is available in exit modes")
+	f.StringArrayVar /* use StringArray to accept comma in value */ (&outputArg, "output-arg", nil, "output a C expression over function arguments; e.g. 'prog->type' or '(int)$retval'")
+	f.StringVar(&filterPkt, "filter-pkt", "", "filter skb/xdp argument with a pcap-filter(7) expression; prefix with '(r)' for a packet-typed return value")
 	f.StringSliceVar(&filterBr, "filter-br", []string{"any"}, "filter branch types: any, any_call, any_return, ind_call, abort_tx, in_tx, no_tx, cond, call_stack, ind_jump, call")
 	f.UintVar(&limitEvents, "limit-events", 0, "limited number events to output, 0 to output all events")
 	f.BoolVar(&flags.showFuncProto, "show-func-proto", false, "show function prototype of -p,-k,-t")
@@ -151,7 +152,9 @@ func ParseFlags() (*Flags, error) {
 	f.MarkHidden("force-probe-read-kernel")
 	f.MarkHidden("find-vmlinux")
 
-	err := f.Parse(os.Args)
+	args, retvalOutput := normalizePacketOutputArgs(os.Args)
+	outputPktRetval = retvalOutput
+	err := f.Parse(args)
 
 	outputFuncStack = outputFuncStack || outputFlameGraph != ""
 	noColorOutput = flags.outputFile != "" || !isatty(os.Stdout.Fd())
@@ -254,6 +257,28 @@ func ParseFlags() (*Flags, error) {
 	return &flags, err
 }
 
+// normalizePacketOutputArgs preserves the boolean --output-pkt flag while
+// allowing its packet-return selector to use the same prefix form as
+// --filter-pkt: --output-pkt '(r)'.
+func normalizePacketOutputArgs(args []string) ([]string, bool) {
+	normalized := make([]string, 0, len(args))
+	retval := false
+	for i := 0; i < len(args); i++ {
+		switch {
+		case args[i] == "--output-pkt=(r)":
+			retval = true
+			normalized = append(normalized, "--output-pkt")
+		case args[i] == "--output-pkt" && i+1 < len(args) && args[i+1] == "(r)":
+			retval = true
+			normalized = append(normalized, args[i])
+			i++
+		default:
+			normalized = append(normalized, args[i])
+		}
+	}
+	return normalized, retval
+}
+
 func (f *Flags) ParseProgs() ([]ProgFlag, error) {
 	return parseProgsFlag(f.progs)
 }
@@ -348,16 +373,10 @@ func (f *Flags) checkMultiExitFilterConflict() error {
 	}) {
 		used = append(used, "--filter-arg")
 	}
-	if filterPkt != "" {
-		used = append(used, "--filter-pkt")
-	}
 	if slices.ContainsFunc(argOutput.args, func(arg funcArgumentOutput) bool {
 		return !slices.Contains(arg.vars, cc.RetvalName)
 	}) {
 		used = append(used, "--output-arg")
-	}
-	if outputPkt {
-		used = append(used, "--output-pkt")
 	}
 	if len(used) == 0 {
 		return nil

--- a/internal/bpfsnoop/flags.go
+++ b/internal/bpfsnoop/flags.go
@@ -14,6 +14,7 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"github.com/bpfsnoop/bpfsnoop/internal/assert"
+	"github.com/bpfsnoop/bpfsnoop/internal/cc"
 )
 
 const (
@@ -188,6 +189,9 @@ func ParseFlags() (*Flags, error) {
 	if e := flags.checkMode(); e != nil {
 		return nil, e
 	}
+	if err := flags.checkKmultiArgAccess(); err != nil {
+		return nil, err
+	}
 	if err := flags.checkMultiExitFilterConflict(); err != nil {
 		return nil, err
 	}
@@ -359,6 +363,52 @@ func hasModeExit() bool {
 	return slices.Contains(modes, TracingModeExit)
 }
 
+func (f *Flags) checkKmultiArgAccess() error {
+	kfuncs := f.KfuncsMulti()
+	if len(kfuncs) == 0 {
+		return nil
+	}
+
+	kflags, err := parseKfuncFlags(kfuncs)
+	if err != nil {
+		return err
+	}
+	argName := kflags[0].argName
+	argType := kflags[0].argType
+	for _, kf := range kflags[1:] {
+		if kf.argName != argName || kf.argType != argType {
+			return fmt.Errorf("kprobe.multi targets must use one common typed argument, got %q (%s) and %q (%s)",
+				argName, argType, kf.argName, kf.argType)
+		}
+	}
+
+	for _, arg := range argFilter.args {
+		if slices.Contains(arg.vars, cc.RetvalName) {
+			return fmt.Errorf("kprobe.multi does not support %s in --filter-arg", cc.RetvalName)
+		}
+		if len(arg.vars) != 1 || arg.vars[0] != argName {
+			return fmt.Errorf("kmulti --filter-arg '%s' must use only trace arg '%s'", arg.expr, argName)
+		}
+	}
+	for _, arg := range argOutput.args {
+		if slices.Contains(arg.vars, cc.RetvalName) {
+			return fmt.Errorf("kprobe.multi does not support %s in --output-arg", cc.RetvalName)
+		}
+		if len(arg.vars) != 1 || arg.vars[0] != argName {
+			return fmt.Errorf("kmulti --output-arg '%s' must use only trace arg '%s'", arg.expr, argName)
+		}
+	}
+
+	if pktFilter.retval {
+		return fmt.Errorf("kprobe.multi does not support '(r)' in --filter-pkt")
+	}
+	if outputPktRetval {
+		return fmt.Errorf("kprobe.multi does not support '(r)' in --output-pkt")
+	}
+
+	return nil
+}
+
 func (f *Flags) checkMultiExitFilterConflict() error {
 	if len(f.KfuncsMulti()) == 0 {
 		return nil
@@ -368,15 +418,17 @@ func (f *Flags) checkMultiExitFilterConflict() error {
 	}
 
 	var used []string
-	if slices.ContainsFunc(argFilter.args, func(arg funcArgument) bool {
-		return !slices.Contains(arg.vars, cc.RetvalName)
-	}) {
+	if len(argFilter.args) != 0 {
 		used = append(used, "--filter-arg")
 	}
-	if slices.ContainsFunc(argOutput.args, func(arg funcArgumentOutput) bool {
-		return !slices.Contains(arg.vars, cc.RetvalName)
-	}) {
+	if len(argOutput.args) != 0 {
 		used = append(used, "--output-arg")
+	}
+	if pktFilter.expr != "" {
+		used = append(used, "--filter-pkt")
+	}
+	if outputPkt {
+		used = append(used, "--output-pkt")
 	}
 	if len(used) == 0 {
 		return nil

--- a/internal/bpfsnoop/flags.go
+++ b/internal/bpfsnoop/flags.go
@@ -343,13 +343,17 @@ func (f *Flags) checkMultiExitFilterConflict() error {
 	}
 
 	var used []string
-	if len(filterArg) != 0 {
+	if slices.ContainsFunc(argFilter.args, func(arg funcArgument) bool {
+		return !slices.Contains(arg.vars, cc.RetvalName)
+	}) {
 		used = append(used, "--filter-arg")
 	}
 	if filterPkt != "" {
 		used = append(used, "--filter-pkt")
 	}
-	if len(outputArg) != 0 {
+	if slices.ContainsFunc(argOutput.args, func(arg funcArgumentOutput) bool {
+		return !slices.Contains(arg.vars, cc.RetvalName)
+	}) {
 		used = append(used, "--output-arg")
 	}
 	if outputPkt {

--- a/internal/bpfsnoop/flamegraph.go
+++ b/internal/bpfsnoop/flamegraph.go
@@ -65,6 +65,29 @@ func (fg *FlameGraph) AddStack(stack []string, value int) {
 	}
 }
 
+func (fg *FlameGraph) merge(other *FlameGraph) {
+	if other == nil {
+		return
+	}
+	var walk func(*StackFrame, []string)
+	walk = func(frame *StackFrame, path []string) {
+		if frame.Name != "root" {
+			path = append(path, frame.Name)
+			self := frame.Value
+			for _, child := range frame.Children {
+				self -= child.Value
+			}
+			if self > 0 {
+				fg.AddStack(path, self)
+			}
+		}
+		for _, child := range frame.Children {
+			walk(child, path)
+		}
+	}
+	walk(other.RootFrame, nil)
+}
+
 // generateFoldedStacks converts the tree structure to folded stack format
 // compatible with Brendan Gregg's flamegraph.pl
 func (fg *FlameGraph) generateFoldedStacks() []string {

--- a/internal/bpfsnoop/kernel_functions_max_arg.go
+++ b/internal/bpfsnoop/kernel_functions_max_arg.go
@@ -31,7 +31,7 @@ func DetectSupportedMaxArg(spec *ebpf.CollectionSpec, ksyms *Kallsyms) (int, err
 	prog := spec.Programs[TracingProgName()]
 	pktFilter.clear(prog)
 	pktOutput.clear(prog)
-	argOutput.clear(prog)
+	clearOutputArgSubprog(prog)
 	clearFilterArgSubprog(prog)
 
 	attachType := ebpf.AttachTraceFExit

--- a/internal/bpfsnoop/output_arg.go
+++ b/internal/bpfsnoop/output_arg.go
@@ -241,7 +241,7 @@ func (arg *funcArgumentOutput) genDefaultInsns(res *cc.EvalResult, offset, size 
 	return offset, nil
 }
 
-func (arg *funcArgumentOutput) compile(params []btf.FuncParam, krnl, spec *btf.Spec, offset, flags int, labelExit string) (int, error) {
+func (arg *funcArgumentOutput) compile(params []btf.FuncParam, ret btf.Type, krnl, spec *btf.Spec, offset, flags int, labelExit string) (int, error) {
 	mode := cc.MemoryReadModeProbeRead
 	if _, err := spec.AnyTypeByName("bpf_rdonly_cast"); err == nil {
 		mode = cc.MemoryReadModeCoreRead
@@ -253,6 +253,7 @@ func (arg *funcArgumentOutput) compile(params []btf.FuncParam, krnl, spec *btf.S
 	res, err := cc.CompileEvalExpr(cc.CompileExprOptions{
 		Expr:          arg.expr,
 		Params:        params,
+		RetvalType:    ret,
 		Spec:          spec,
 		Kernel:        krnl,
 		LabelExit:     labelExit,
@@ -331,13 +332,19 @@ func (arg *funcArgumentOutput) compile(params []btf.FuncParam, krnl, spec *btf.S
 }
 
 func (arg *funcArgumentOutput) match(params []btf.FuncParam) bool {
-	for _, p := range params {
-		if slices.Contains(arg.vars, p.Name) {
-			return true
+	for _, name := range arg.vars {
+		if name == cc.RetvalName {
+			continue
+		}
+
+		if !slices.ContainsFunc(params, func(p btf.FuncParam) bool {
+			return p.Name == name
+		}) {
+			return false
 		}
 	}
 
-	return false
+	return true
 }
 
 func (arg *argDataOutput) genExitLabel() string {
@@ -346,19 +353,31 @@ func (arg *argDataOutput) genExitLabel() string {
 	return label
 }
 
-func (arg *argDataOutput) matchParams(params []btf.FuncParam, spec *btf.Spec) ([]funcArgumentOutput, int, error) {
+func (arg *argDataOutput) matchParams(params []btf.FuncParam, ret btf.Type, spec *btf.Spec, allowRetval bool) ([]funcArgumentOutput, int, error) {
 	args := make([]funcArgumentOutput, 0, 12)
 
 	krnl := getKernelBTF()
 	offset := 0
 	for _, a := range arg.args {
+		if slices.Contains(a.vars, cc.RetvalName) {
+			if !allowRetval {
+				continue
+			}
+			matched, err := cc.MatchRetvalType(a.expr, ret, spec, krnl)
+			if err != nil {
+				return nil, 0, fmt.Errorf("failed to match %s type for expr '%s': %w", cc.RetvalName, a.expr, err)
+			}
+			if !matched {
+				continue
+			}
+		}
 		if !a.match(params) {
 			continue
 		}
 
 		a := a
 		var err error
-		offset, err = a.compile(params, krnl, spec, offset, 0, arg.genExitLabel())
+		offset, err = a.compile(params, ret, krnl, spec, offset, 0, arg.genExitLabel())
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to compile expr '%s': %w", a.expr, err)
 		}

--- a/internal/cc/evaluate.go
+++ b/internal/cc/evaluate.go
@@ -137,12 +137,9 @@ func (c *compiler) evaluate(expr *cc.Expr) (exprValue, error) {
 // evaluateName handles variable name lookup.
 // Returns Pending if it's a known variable, EnumMaybe otherwise.
 func (c *compiler) evaluateName(expr *cc.Expr) (exprValue, error) {
-	// Check for special constants
-	if slices.Contains([]string{"NULL", "false"}, expr.Text) {
-		return newConstant(0), nil
-	}
-	if expr.Text == "true" {
-		return newConstant(1), nil
+	// Check for built-in constants before resolving function parameters.
+	if value, ok := builtinVars[expr.Text]; ok {
+		return newConstant(value), nil
 	}
 
 	// Look up variable

--- a/internal/cc/evaluate.go
+++ b/internal/cc/evaluate.go
@@ -1263,6 +1263,10 @@ func (c *compiler) evaluateLt(expr *cc.Expr) (exprValue, error) {
 	}
 
 	left, right = c.adjustNums(left, right)
+	jumpOp := asm.JGE
+	if comparisonIsSigned(left, right) {
+		jumpOp = asm.JSGE
+	}
 
 	if left.isConstant() && right.isConstant() {
 		return newConstant(int64(bool2int(left.num < right.num))), nil
@@ -1282,7 +1286,7 @@ func (c *compiler) evaluateLt(expr *cc.Expr) (exprValue, error) {
 	}
 
 	if right.isConstant() {
-		c.emit(JmpOff(asm.JGE, left.reg, right.num, 2))
+		c.emit(JmpOff(jumpOp, left.reg, right.num, 2))
 		c.emitReg2bool(left.reg)
 		return newMaterialized(left.reg, left.btf), nil
 	}
@@ -1292,7 +1296,7 @@ func (c *compiler) evaluateLt(expr *cc.Expr) (exprValue, error) {
 		return exprValue{}, err
 	}
 
-	c.emit(JmpReg(asm.JGE, left.reg, right.reg, 2))
+	c.emit(JmpReg(jumpOp, left.reg, right.reg, 2))
 	c.emitReg2bool(left.reg)
 	c.regalloc.Free(right.reg)
 
@@ -1317,6 +1321,10 @@ func (c *compiler) evaluateLtEq(expr *cc.Expr) (exprValue, error) {
 	}
 
 	left, right = c.adjustNums(left, right)
+	jumpOp := asm.JGT
+	if comparisonIsSigned(left, right) {
+		jumpOp = asm.JSGT
+	}
 
 	if left.isConstant() && right.isConstant() {
 		return newConstant(int64(bool2int(left.num <= right.num))), nil
@@ -1336,7 +1344,7 @@ func (c *compiler) evaluateLtEq(expr *cc.Expr) (exprValue, error) {
 	}
 
 	if right.isConstant() {
-		c.emit(JmpOff(asm.JGT, left.reg, right.num, 2))
+		c.emit(JmpOff(jumpOp, left.reg, right.num, 2))
 		c.emitReg2bool(left.reg)
 		return newMaterialized(left.reg, left.btf), nil
 	}
@@ -1346,7 +1354,7 @@ func (c *compiler) evaluateLtEq(expr *cc.Expr) (exprValue, error) {
 		return exprValue{}, err
 	}
 
-	c.emit(JmpReg(asm.JGT, left.reg, right.reg, 2))
+	c.emit(JmpReg(jumpOp, left.reg, right.reg, 2))
 	c.emitReg2bool(left.reg)
 	c.regalloc.Free(right.reg)
 
@@ -1371,6 +1379,10 @@ func (c *compiler) evaluateGt(expr *cc.Expr) (exprValue, error) {
 	}
 
 	left, right = c.adjustNums(left, right)
+	jumpOp := asm.JLE
+	if comparisonIsSigned(left, right) {
+		jumpOp = asm.JSLE
+	}
 
 	if left.isConstant() && right.isConstant() {
 		return newConstant(int64(bool2int(left.num > right.num))), nil
@@ -1390,7 +1402,7 @@ func (c *compiler) evaluateGt(expr *cc.Expr) (exprValue, error) {
 	}
 
 	if right.isConstant() {
-		c.emit(JmpOff(asm.JLE, left.reg, right.num, 2))
+		c.emit(JmpOff(jumpOp, left.reg, right.num, 2))
 		c.emitReg2bool(left.reg)
 		return newMaterialized(left.reg, left.btf), nil
 	}
@@ -1400,7 +1412,7 @@ func (c *compiler) evaluateGt(expr *cc.Expr) (exprValue, error) {
 		return exprValue{}, err
 	}
 
-	c.emit(JmpReg(asm.JLE, left.reg, right.reg, 2))
+	c.emit(JmpReg(jumpOp, left.reg, right.reg, 2))
 	c.emitReg2bool(left.reg)
 	c.regalloc.Free(right.reg)
 
@@ -1425,6 +1437,10 @@ func (c *compiler) evaluateGtEq(expr *cc.Expr) (exprValue, error) {
 	}
 
 	left, right = c.adjustNums(left, right)
+	jumpOp := asm.JLT
+	if comparisonIsSigned(left, right) {
+		jumpOp = asm.JSLT
+	}
 
 	if left.isConstant() && right.isConstant() {
 		return newConstant(int64(bool2int(left.num >= right.num))), nil
@@ -1444,7 +1460,7 @@ func (c *compiler) evaluateGtEq(expr *cc.Expr) (exprValue, error) {
 	}
 
 	if right.isConstant() {
-		c.emit(JmpOff(asm.JLT, left.reg, right.num, 2))
+		c.emit(JmpOff(jumpOp, left.reg, right.num, 2))
 		c.emitReg2bool(left.reg)
 		return newMaterialized(left.reg, left.btf), nil
 	}
@@ -1454,7 +1470,7 @@ func (c *compiler) evaluateGtEq(expr *cc.Expr) (exprValue, error) {
 		return exprValue{}, err
 	}
 
-	c.emit(JmpReg(asm.JLT, left.reg, right.reg, 2))
+	c.emit(JmpReg(jumpOp, left.reg, right.reg, 2))
 	c.emitReg2bool(left.reg)
 	c.regalloc.Free(right.reg)
 
@@ -1834,6 +1850,27 @@ func (c *compiler) adjustNums(left, right exprValue) (exprValue, exprValue) {
 	return left, right
 }
 
+func isSignedBTFType(typ btf.Type) bool {
+	switch typ := mybtf.UnderlyingType(typ).(type) {
+	case *btf.Int:
+		return typ.Encoding == btf.Signed
+	case *btf.Enum:
+		return typ.Signed
+	default:
+		return false
+	}
+}
+
+func comparisonIsSigned(left, right exprValue) bool {
+	if left.isConstant() {
+		return !right.isConstant() && isSignedBTFType(right.btf)
+	}
+	if right.isConstant() {
+		return isSignedBTFType(left.btf)
+	}
+	return isSignedBTFType(left.btf) && isSignedBTFType(right.btf)
+}
+
 // adjustNumForType adjusts a number based on the target type's size.
 func (c *compiler) adjustNumForType(num int64, typ btf.Type, mem *btf.Member) int64 {
 	if isMemberBitfield(mem) {
@@ -1842,6 +1879,18 @@ func (c *compiler) adjustNumForType(num int64, typ btf.Type, mem *btf.Member) in
 	}
 
 	size, _ := btf.Sizeof(typ)
+	if isSignedBTFType(typ) {
+		switch size {
+		case 1:
+			return int64(int8(num))
+		case 2:
+			return int64(int16(num))
+		case 4:
+			return int64(int32(num))
+		default:
+			return num
+		}
+	}
 	switch size {
 	case 1:
 		return num & 0xFF

--- a/internal/cc/evaluate_test.go
+++ b/internal/cc/evaluate_test.go
@@ -2895,6 +2895,49 @@ func TestEvaluateGtEq(t *testing.T) {
 	})
 }
 
+func TestEvaluateSignedComparisons(t *testing.T) {
+	i32 := &btf.Int{Name: "int", Size: 4, Encoding: btf.Signed}
+	u32 := &btf.Int{Name: "unsigned int", Size: 4, Encoding: btf.Unsigned}
+	tests := []struct {
+		name   string
+		expr   string
+		op     asm.JumpOp
+		source asm.Source
+	}{
+		{name: "less than immediate", expr: "n < 0", op: asm.JSGE, source: asm.ImmSource},
+		{name: "less than or equal immediate", expr: "n <= 0", op: asm.JSGT, source: asm.ImmSource},
+		{name: "greater than immediate", expr: "n > 0", op: asm.JSLE, source: asm.ImmSource},
+		{name: "greater than or equal immediate", expr: "n >= 0", op: asm.JSLT, source: asm.ImmSource},
+		{name: "constant left", expr: "0 < n", op: asm.JSGE, source: asm.RegSource},
+		{name: "signed registers", expr: "n < m", op: asm.JSGE, source: asm.RegSource},
+		{name: "mixed register types", expr: "n < u", op: asm.JGE, source: asm.RegSource},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			insns, err := CompileFilterExpr(CompileExprOptions{
+				Expr:      tt.expr,
+				LabelExit: "exit",
+				Spec:      testBtf,
+				Kernel:    testBtf,
+				Params: []btf.FuncParam{
+					{Name: "n", Type: i32},
+					{Name: "m", Type: i32},
+					{Name: "u", Type: u32},
+				},
+			})
+			test.AssertNoErr(t, err)
+
+			for _, insn := range insns {
+				if insn.OpCode.JumpOp() == tt.op && insn.OpCode.Source() == tt.source {
+					return
+				}
+			}
+			t.Fatalf("%q did not emit %v with %v source: %v", tt.expr, tt.op, tt.source, insns)
+		})
+	}
+}
+
 func TestEvaluateAndAnd(t *testing.T) {
 	c := prepareCompilerDirectRead(t)
 
@@ -3786,6 +3829,28 @@ func TestAdjustNums(t *testing.T) {
 	})
 }
 
+func TestIsSignedBTFType(t *testing.T) {
+	signedInt := &btf.Int{Name: "int", Size: 4, Encoding: btf.Signed}
+	tests := []struct {
+		name string
+		typ  btf.Type
+		want bool
+	}{
+		{name: "signed int", typ: signedInt, want: true},
+		{name: "signed typedef", typ: &btf.Typedef{Name: "status_t", Type: signedInt}, want: true},
+		{name: "unsigned int", typ: &btf.Int{Name: "unsigned int", Size: 4, Encoding: btf.Unsigned}},
+		{name: "signed enum", typ: &btf.Enum{Name: "state", Size: 4, Signed: true}, want: true},
+		{name: "unsigned enum", typ: &btf.Enum{Name: "state", Size: 4}},
+		{name: "pointer", typ: &btf.Pointer{Target: signedInt}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			test.AssertEqual(t, isSignedBTFType(tt.typ), tt.want)
+		})
+	}
+}
+
 func TestAdjustNumForType(t *testing.T) {
 	c := prepareCompiler(t)
 
@@ -3826,6 +3891,28 @@ func TestAdjustNumForType(t *testing.T) {
 
 		n := c.adjustNumForType(7, getU64Btf(t), nil)
 		test.AssertEqual(t, n, 7)
+	})
+
+	t.Run("signed sizes", func(t *testing.T) {
+		tests := []struct {
+			name string
+			size uint32
+			num  int64
+			want int64
+		}{
+			{name: "byte", size: 1, num: 255, want: -1},
+			{name: "word", size: 2, num: 65535, want: -1},
+			{name: "dword", size: 4, num: 1<<32 - 1, want: -1},
+			{name: "qword", size: 8, num: -7, want: -7},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				typ := &btf.Int{Name: tt.name, Size: tt.size, Encoding: btf.Signed}
+				n := c.adjustNumForType(tt.num, typ, nil)
+				test.AssertEqual(t, n, tt.want)
+			})
+		}
 	})
 }
 

--- a/internal/cc/evaluate_test.go
+++ b/internal/cc/evaluate_test.go
@@ -63,7 +63,7 @@ func TestEvaluateName(t *testing.T) {
 
 	t.Run("special constants", func(t *testing.T) {
 		defer c.reset()
-		for name, want := range map[string]int64{"NULL": 0, "false": 0, "true": 1} {
+		for name, want := range map[string]int64{"NULL": 0, "null": 0, "false": 0, "true": 1} {
 			expr := &cc.Expr{Op: cc.Name, Text: name}
 			v, err := c.evaluate(expr)
 			test.AssertNoErr(t, err)

--- a/internal/cc/expr.go
+++ b/internal/cc/expr.go
@@ -34,6 +34,7 @@ const (
 type CompileExprOptions struct {
 	Expr          string
 	Params        []btf.FuncParam
+	RetvalType    btf.Type
 	Spec, Kernel  btfSpecer
 	LabelExit     string
 	ReservedStack int
@@ -44,6 +45,11 @@ type CompileExprOptions struct {
 }
 
 func CompileFilterExpr(opts CompileExprOptions) (asm.Instructions, error) {
+	var err error
+	opts, err = prepareCompileOptions(opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare expression: %w", err)
+	}
 	c, err := newCompiler(opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create compiler: %w", err)
@@ -139,6 +145,11 @@ type EvalResult struct {
 
 func CompileEvalExpr(opts CompileExprOptions) (EvalResult, error) {
 	var res EvalResult
+	var err error
+	opts, err = prepareCompileOptions(opts)
+	if err != nil {
+		return res, fmt.Errorf("failed to prepare expression: %w", err)
+	}
 
 	c, err := newCompiler(opts)
 	if err != nil {

--- a/internal/cc/expr_test.go
+++ b/internal/cc/expr_test.go
@@ -308,7 +308,7 @@ func TestCompile(t *testing.T) {
 			asm.FnProbeReadKernel.Call(),
 			asm.LoadMem(asm.R8, asm.RFP, -8, asm.DWord),
 			asm.LSh.Imm(asm.R8, 32),
-			asm.RSh.Imm(asm.R8, 32),
+			asm.ArSh.Imm(asm.R8, 32),
 			JmpOff(asm.JNE, asm.R8, 11, 2),
 			asm.Mov.Imm(asm.R8, 1),
 			Ja(1),

--- a/internal/cc/materialize.go
+++ b/internal/cc/materialize.go
@@ -152,11 +152,25 @@ func (c *compiler) adjustRegisterSize(val exprValue) {
 
 	switch size {
 	case 1:
-		c.emit(asm.And.Imm(val.reg, 0xFF))
+		if isSignedBTFType(val.btf) {
+			c.emit(asm.LSh.Imm(val.reg, 56))
+			c.emit(asm.ArSh.Imm(val.reg, 56))
+		} else {
+			c.emit(asm.And.Imm(val.reg, 0xFF))
+		}
 	case 2:
-		c.emit(asm.And.Imm(val.reg, 0xFFFF))
+		if isSignedBTFType(val.btf) {
+			c.emit(asm.LSh.Imm(val.reg, 48))
+			c.emit(asm.ArSh.Imm(val.reg, 48))
+		} else {
+			c.emit(asm.And.Imm(val.reg, 0xFFFF))
+		}
 	case 4:
 		c.emit(asm.LSh.Imm(val.reg, 32))
-		c.emit(asm.RSh.Imm(val.reg, 32))
+		if isSignedBTFType(val.btf) {
+			c.emit(asm.ArSh.Imm(val.reg, 32))
+		} else {
+			c.emit(asm.RSh.Imm(val.reg, 32))
+		}
 	}
 }

--- a/internal/cc/materialize_test.go
+++ b/internal/cc/materialize_test.go
@@ -235,7 +235,7 @@ func TestMaterializePending(t *testing.T) {
 			asm.JEq.Imm(r8, 0, c.labelExit),    // null check
 			asm.LoadMem(r8, r8, 224, dword),    // dev->ifindex
 			asm.LSh.Imm(r8, 32),
-			asm.RSh.Imm(r8, 32),
+			asm.ArSh.Imm(r8, 32),
 		})
 	})
 }
@@ -372,6 +372,19 @@ func TestAdjustRegisterSize(t *testing.T) {
 		})
 	})
 
+	t.Run("sign extend byte", func(t *testing.T) {
+		defer c.reset()
+
+		i8 := &btf.Int{Name: "signed char", Size: 1, Encoding: btf.Signed}
+		val := newMaterialized(r8, i8)
+
+		c.adjustRegisterSize(val)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.LSh.Imm(r8, 56),
+			asm.ArSh.Imm(r8, 56),
+		})
+	})
+
 	t.Run("adjust to word", func(t *testing.T) {
 		defer c.reset()
 
@@ -381,6 +394,19 @@ func TestAdjustRegisterSize(t *testing.T) {
 		c.adjustRegisterSize(val)
 		test.AssertEqualSlice(t, c.insns, asm.Instructions{
 			asm.And.Imm(r8, 0xFFFF),
+		})
+	})
+
+	t.Run("sign extend word", func(t *testing.T) {
+		defer c.reset()
+
+		i16 := &btf.Int{Name: "short", Size: 2, Encoding: btf.Signed}
+		val := newMaterialized(r8, i16)
+
+		c.adjustRegisterSize(val)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.LSh.Imm(r8, 48),
+			asm.ArSh.Imm(r8, 48),
 		})
 	})
 
@@ -394,6 +420,19 @@ func TestAdjustRegisterSize(t *testing.T) {
 		test.AssertEqualSlice(t, c.insns, asm.Instructions{
 			asm.LSh.Imm(r8, 32),
 			asm.RSh.Imm(r8, 32),
+		})
+	})
+
+	t.Run("sign extend dword", func(t *testing.T) {
+		defer c.reset()
+
+		i32 := &btf.Int{Name: "int", Size: 4, Encoding: btf.Signed}
+		val := newMaterialized(r8, i32)
+
+		c.adjustRegisterSize(val)
+		test.AssertEqualSlice(t, c.insns, asm.Instructions{
+			asm.LSh.Imm(r8, 32),
+			asm.ArSh.Imm(r8, 32),
 		})
 	})
 }

--- a/internal/cc/retval.go
+++ b/internal/cc/retval.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import (
+	"strings"
+
+	c2go "rsc.io/c2go/cc"
+)
+
+const (
+	// RetvalName is the user-visible function return pseudo-variable.
+	RetvalName = "$retval"
+	// retvalCompilerName is deliberately not a valid user spelling. It is used
+	// only after token-aware rewriting, since '$' isn't accepted by the C parser.
+	retvalCompilerName = "____retval____"
+)
+
+func rewriteRetval(expr string) string {
+	return strings.ReplaceAll(expr, RetvalName, retvalCompilerName)
+}
+
+func validRetvalCast(typ *c2go.Type) bool {
+	if typ == nil {
+		return false
+	}
+	if typ.Kind == c2go.TypedefType {
+		if typ.Base == nil {
+			return true
+		}
+		return validRetvalCast(typ.Base)
+	}
+	switch typ.Kind {
+	case c2go.Char, c2go.Uchar, c2go.Short, c2go.Ushort,
+		c2go.Int, c2go.Uint, c2go.Long, c2go.Ulong,
+		c2go.Longlong, c2go.Ulonglong, c2go.Float, c2go.Double,
+		c2go.Enum, c2go.Ptr:
+		return true
+	default:
+		return false
+	}
+}
+
+func enclosesThroughParens(expr, target *c2go.Expr) bool {
+	for expr != nil && expr.Op == c2go.Paren {
+		expr = expr.Left
+	}
+	return expr == target
+}

--- a/internal/cc/retval.go
+++ b/internal/cc/retval.go
@@ -4,8 +4,12 @@
 package cc
 
 import (
+	"fmt"
+	"slices"
 	"strings"
 
+	"github.com/Asphaltt/mybtf"
+	"github.com/cilium/ebpf/btf"
 	c2go "rsc.io/c2go/cc"
 )
 
@@ -47,4 +51,82 @@ func enclosesThroughParens(expr, target *c2go.Expr) bool {
 		expr = expr.Left
 	}
 	return expr == target
+}
+
+func matchRetvalType(analysis ExprAnalysis, returnType btf.Type, spec, kernel btfSpecer) (bool, error) {
+	if analysis.retvalExpr == nil {
+		return false, nil
+	}
+
+	c := &compiler{btfSpec: spec, krnlSpec: kernel}
+	cast, err := c.cc2btf(analysis.retvalExpr)
+	if err != nil {
+		return false, fmt.Errorf("failed to resolve %s cast %q: %w", RetvalName, analysis.RetvalCast, err)
+	}
+	if _, void := mybtf.UnderlyingType(returnType).(*btf.Void); void {
+		return false, nil
+	}
+	return sameUnderlyingType(cast, returnType), nil
+}
+
+func sameUnderlyingType(left, right btf.Type) bool {
+	left, right = mybtf.UnderlyingType(left), mybtf.UnderlyingType(right)
+	switch l := left.(type) {
+	case *btf.Void:
+		_, ok := right.(*btf.Void)
+		return ok
+	case *btf.Int:
+		r, ok := right.(*btf.Int)
+		return ok && l.Size == r.Size && l.Encoding == r.Encoding
+	case *btf.Enum:
+		r, ok := right.(*btf.Enum)
+		return ok && l.Name == r.Name && l.Size == r.Size && l.Signed == r.Signed
+	case *btf.Float:
+		r, ok := right.(*btf.Float)
+		return ok && l.Size == r.Size
+	case *btf.Pointer:
+		r, ok := right.(*btf.Pointer)
+		return ok && sameUnderlyingType(l.Target, r.Target)
+	case *btf.Struct:
+		r, ok := right.(*btf.Struct)
+		return ok && l.Name == r.Name
+	case *btf.Union:
+		r, ok := right.(*btf.Union)
+		return ok && l.Name == r.Name
+	default:
+		return fmt.Sprintf("%v", left) == fmt.Sprintf("%v", right)
+	}
+}
+
+// MatchRetvalType reports whether the typed $retval in expr matches a declared
+// return type after typedef and qualifier wrappers are removed.
+func MatchRetvalType(expr string, returnType btf.Type, spec, kernel *btf.Spec) (bool, error) {
+	analysis, err := AnalyzeExpr(expr)
+	if err != nil {
+		return false, err
+	}
+	return matchRetvalType(analysis, returnType, spec, kernel)
+}
+
+func prepareCompileOptions(opts CompileExprOptions) (CompileExprOptions, error) {
+	if !strings.Contains(opts.Expr, RetvalName) {
+		return opts, nil
+	}
+	analysis, err := AnalyzeExpr(opts.Expr)
+	if err != nil {
+		return opts, err
+	}
+	opts.Expr = analysis.CompilerExpr
+	if opts.RetvalType == nil {
+		return opts, fmt.Errorf("expression uses %s without a declared return type", RetvalName)
+	}
+	matched, err := matchRetvalType(analysis, opts.RetvalType, opts.Spec, opts.Kernel)
+	if err != nil {
+		return opts, err
+	}
+	if !matched {
+		return opts, fmt.Errorf("%s cast %q does not match declared return type %v", RetvalName, analysis.RetvalCast, opts.RetvalType)
+	}
+	opts.Params = append(slices.Clone(opts.Params), btf.FuncParam{Name: retvalCompilerName, Type: opts.RetvalType})
+	return opts, nil
 }

--- a/internal/cc/retval_test.go
+++ b/internal/cc/retval_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package cc
+
+import (
+	"strings"
+	"testing"
+
+	c2go "rsc.io/c2go/cc"
+)
+
+func TestAnalyzeRetvalExpr(t *testing.T) {
+	tests := []struct {
+		name     string
+		expr     string
+		vars     []string
+		cast     string
+		wantErr  string
+		ordinary bool
+	}{
+		{name: "ordinary", expr: "retval > count", vars: []string{"count", "retval"}, ordinary: true},
+		{name: "string literal", expr: `"$retval"`, wantErr: "requires an explicit concrete cast"},
+		{name: "signed", expr: "(int)$retval < 0", vars: []string{RetvalName}, cast: "int"},
+		{name: "unsigned", expr: "(unsigned int)$retval != 0", vars: []string{RetvalName}, cast: "uint"},
+		{name: "pointer", expr: "(void *)$retval != NULL", vars: []string{RetvalName}, cast: "void*"},
+		{name: "builtin constants", expr: "(int)$retval != NULL && null == false && true", vars: []string{RetvalName}, cast: "int"},
+		{name: "struct pointer", expr: "((struct sk_buff *)$retval)->len > 0", vars: []string{RetvalName}, cast: "struct sk_buff*"},
+		{name: "same repeated cast", expr: "(int)$retval > 0 && (int)$retval < 10", vars: []string{RetvalName}, cast: "int"},
+		{name: "qualified equivalent casts", expr: "(int)$retval > 0 && (const int)$retval < 10", vars: []string{RetvalName}, cast: "int"},
+		{name: "bare", expr: "$retval != 0", wantErr: "requires an explicit concrete cast"},
+		{name: "bare through parens", expr: "($retval) != 0", wantErr: "requires an explicit concrete cast"},
+		{name: "member before cast", expr: "(int)$retval.foo != 0", wantErr: "requires an explicit concrete cast"},
+		{name: "void cast", expr: "(void)$retval", wantErr: "invalid non-scalar cast"},
+		{name: "struct value cast", expr: "(struct sk_buff)$retval", wantErr: "invalid non-scalar cast"},
+		{name: "conflicting casts", expr: "(int)$retval > 0 && (unsigned int)$retval < 10", wantErr: "conflicting casts"},
+		{name: "unknown dollar name", expr: "(int)$return != 0", wantErr: "failed to parse expression"},
+		{name: "retval suffix", expr: "(int)$retval2 != 0", wantErr: "requires an explicit concrete cast"},
+		{name: "embedded retval", expr: "x$retval != 0", wantErr: "requires an explicit concrete cast"},
+		{name: "missing cast close", expr: "(int $retval != 0", wantErr: "failed to parse expression"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := AnalyzeExpr(tt.expr)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("got error %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Join(got.Vars, ",") != strings.Join(tt.vars, ",") {
+				t.Fatalf("vars = %q, want %q", got.Vars, tt.vars)
+			}
+			if got.RetvalCast != tt.cast {
+				t.Fatalf("cast = %q, want %q", got.RetvalCast, tt.cast)
+			}
+			if tt.ordinary && got.CompilerExpr != tt.expr {
+				t.Fatalf("ordinary expression changed to %q", got.CompilerExpr)
+			}
+			if tt.cast != "" && !strings.Contains(got.CompilerExpr, retvalCompilerName) {
+				t.Fatalf("compiler expression %q doesn't contain internal retval name", got.CompilerExpr)
+			}
+		})
+	}
+}
+
+func TestRewriteRetval(t *testing.T) {
+	expr := `"$retval"`
+	got := rewriteRetval(expr)
+	want := `"____retval____"`
+	if got != want {
+		t.Fatalf("rewrite = %q, want %q", got, want)
+	}
+}
+
+func TestRetvalCTypeHelpers(t *testing.T) {
+	intType := &c2go.Type{Kind: c2go.Int}
+	intAlias := &c2go.Type{Kind: c2go.TypedefType, Name: "integer", Base: intType}
+	opaqueAlias := &c2go.Type{Kind: c2go.TypedefType, Name: "opaque"}
+
+	if validRetvalCast(nil) {
+		t.Fatal("nil cast should be invalid")
+	}
+	if !validRetvalCast(opaqueAlias) || !validRetvalCast(intAlias) {
+		t.Fatal("scalar typedef casts should be valid")
+	}
+
+	target := &c2go.Expr{Op: c2go.Name, Text: retvalCompilerName}
+	wrapped := &c2go.Expr{Op: c2go.Paren, Left: &c2go.Expr{Op: c2go.Paren, Left: target}}
+	if !enclosesThroughParens(wrapped, target) {
+		t.Fatal("nested parentheses should enclose target")
+	}
+}

--- a/internal/cc/retval_test.go
+++ b/internal/cc/retval_test.go
@@ -7,8 +7,20 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Asphaltt/mybtf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
 	c2go "rsc.io/c2go/cc"
 )
+
+func requireType(t *testing.T, name string) btf.Type {
+	t.Helper()
+	typ, err := testBtf.AnyTypeByName(name)
+	if err != nil {
+		t.Fatalf("find BTF type %q: %v", name, err)
+	}
+	return typ
+}
 
 func TestAnalyzeRetvalExpr(t *testing.T) {
 	tests := []struct {
@@ -94,4 +106,200 @@ func TestRetvalCTypeHelpers(t *testing.T) {
 	if !enclosesThroughParens(wrapped, target) {
 		t.Fatal("nested parentheses should enclose target")
 	}
+}
+
+func TestSameUnderlyingRetvalType(t *testing.T) {
+	intType := &btf.Int{Name: "int", Size: 4, Encoding: btf.Signed}
+	uintType := &btf.Int{Name: "unsigned int", Size: 4, Encoding: btf.Unsigned}
+	tests := []struct {
+		name        string
+		left, right btf.Type
+	}{
+		{name: "void", left: &btf.Void{}, right: &btf.Void{}},
+		{name: "int", left: intType, right: &btf.Int{Name: "another name", Size: 4, Encoding: btf.Signed}},
+		{name: "enum", left: &btf.Enum{Name: "state", Size: 4, Signed: true}, right: &btf.Enum{Name: "state", Size: 4, Signed: true}},
+		{name: "float", left: &btf.Float{Name: "double", Size: 8}, right: &btf.Float{Name: "other", Size: 8}},
+		{name: "pointer", left: &btf.Pointer{Target: intType}, right: &btf.Pointer{Target: &btf.Const{Type: intType}}},
+		{name: "struct", left: &btf.Struct{Name: "record"}, right: &btf.Struct{Name: "record"}},
+		{name: "union", left: &btf.Union{Name: "value"}, right: &btf.Union{Name: "value"}},
+		{name: "fallback", left: &btf.Array{Index: uintType, Type: intType, Nelems: 2}, right: &btf.Array{Index: uintType, Type: intType, Nelems: 2}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !sameUnderlyingType(tt.left, tt.right) {
+				t.Fatalf("types should match: %v and %v", tt.left, tt.right)
+			}
+		})
+	}
+}
+
+func TestRetvalTypeMatches(t *testing.T) {
+	intType := requireType(t, "int")
+	uintType := requireType(t, "unsigned int")
+	skbType := requireType(t, "sk_buff")
+
+	tests := []struct {
+		name string
+		expr string
+		ret  btf.Type
+		want bool
+	}{
+		{name: "signed", expr: "(int)$retval == 0", ret: intType, want: true},
+		{name: "nested parentheses", expr: "(int)(($retval))", ret: intType, want: true},
+		{name: "signed typedef qualifier", expr: "(int)$retval == 0", ret: &btf.Const{Type: &btf.Typedef{Name: "status_t", Type: intType}}, want: true},
+		{name: "signed unsigned mismatch", expr: "(int)$retval == 0", ret: uintType},
+		{name: "pointer", expr: "(struct sk_buff *)$retval != NULL", ret: &btf.Pointer{Target: skbType}, want: true},
+		{name: "qualified pointer target", expr: "(struct sk_buff *)$retval != NULL", ret: &btf.Pointer{Target: &btf.Const{Type: skbType}}, want: true},
+		{name: "unrelated struct", expr: "(struct sk_buff *)$retval != NULL", ret: &btf.Pointer{Target: &btf.Struct{Name: "x"}}},
+		{name: "pointer scalar mismatch", expr: "(struct sk_buff *)$retval != NULL", ret: intType},
+		{name: "void return", expr: "(void *)$retval != NULL", ret: &btf.Void{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MatchRetvalType(tt.expr, tt.ret, testBtf, testBtf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("match = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	if got, err := MatchRetvalType("count > 0", intType, testBtf, testBtf); err != nil || got {
+		t.Fatalf("expression without retval match = (%v, %v), want (false, nil)", got, err)
+	}
+	if _, err := MatchRetvalType("(int)$unknown", intType, testBtf, testBtf); err == nil {
+		t.Fatal("invalid retval expression should fail")
+	}
+}
+
+func TestPrepareRetvalCompileOptions(t *testing.T) {
+	intType := requireType(t, "int")
+
+	tests := []struct {
+		name, expr string
+		ret        btf.Type
+		want       string
+	}{
+		{name: "parse error", expr: "(int)$unknown", ret: intType, want: "failed to parse expression"},
+		{name: "analysis error", expr: "$retval", ret: intType, want: "requires an explicit concrete cast"},
+		{name: "missing return type", expr: "(int)$retval", want: "without a declared return type"},
+		{name: "resolution error", expr: "(struct type_that_does_not_exist *)$retval", ret: &btf.Pointer{Target: &btf.Struct{Name: "type_that_does_not_exist"}}, want: "failed to resolve"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := CompileFilterExpr(CompileExprOptions{
+				Expr:       tt.expr,
+				RetvalType: tt.ret,
+				Spec:       testBtf,
+				Kernel:     testBtf,
+				LabelExit:  "exit",
+			})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("got error %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompileRetvalExpr(t *testing.T) {
+	intType := requireType(t, "int")
+	skbType := requireType(t, "sk_buff")
+
+	t.Run("filter loads synthetic final slot", func(t *testing.T) {
+		insns, err := CompileFilterExpr(CompileExprOptions{
+			Expr:       "retval == 7 && (int)$retval < 0",
+			Params:     []btf.FuncParam{{Name: "retval", Type: intType}},
+			RetvalType: intType,
+			Spec:       testBtf,
+			Kernel:     testBtf,
+			LabelExit:  "exit",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var loadsReal, loadsRetval, signExtendsRetval, signedComparison bool
+		for _, insn := range insns {
+			if insn.OpCode == asm.LoadMemOp(asm.DWord) && insn.Src == asm.R9 {
+				loadsReal = loadsReal || insn.Offset == 0
+				loadsRetval = loadsRetval || insn.Offset == 8
+			}
+			signExtendsRetval = signExtendsRetval || insn.OpCode == asm.ArSh.Op(asm.ImmSource) && insn.Constant == 32
+			signedComparison = signedComparison || insn.OpCode.JumpOp() == asm.JSGE
+		}
+		if !loadsReal || !loadsRetval {
+			t.Fatalf("expected distinct real and synthetic argument loads, got %v", insns)
+		}
+		if !signExtendsRetval || !signedComparison {
+			t.Fatalf("expected signed retval extension and comparison, got %v", insns)
+		}
+	})
+
+	t.Run("boolean pointer and dereference", func(t *testing.T) {
+		_, err := CompileFilterExpr(CompileExprOptions{
+			Expr:       "(struct sk_buff *)$retval != NULL && ((struct sk_buff *)$retval)->len > 0",
+			RetvalType: &btf.Pointer{Target: skbType},
+			Spec:       testBtf,
+			Kernel:     testBtf,
+			LabelExit:  "exit",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("eval preserves scalar type", func(t *testing.T) {
+		res, err := CompileEvalExpr(CompileExprOptions{
+			Expr:       "(int)$retval",
+			RetvalType: &btf.Const{Type: intType},
+			Spec:       testBtf,
+			Kernel:     testBtf,
+			LabelExit:  "exit",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		intResult, ok := mybtf.UnderlyingType(res.Btf).(*btf.Int)
+		if !ok {
+			t.Fatalf("result BTF = %v, want int", res.Btf)
+		}
+		if intResult.Encoding != btf.Signed {
+			t.Fatalf("result BTF encoding = %v, want signed", intResult.Encoding)
+		}
+		if len(res.Insns) == 0 || res.Insns[0].Offset != 0 {
+			t.Fatalf("expected retval load from only slot, got %v", res.Insns)
+		}
+	})
+
+	t.Run("eval preserves pointer type", func(t *testing.T) {
+		res, err := CompileEvalExpr(CompileExprOptions{
+			Expr:       "(struct sk_buff *)$retval",
+			RetvalType: &btf.Pointer{Target: skbType},
+			Spec:       testBtf,
+			Kernel:     testBtf,
+			LabelExit:  "exit",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := mybtf.UnderlyingType(res.Btf).(*btf.Pointer); !ok {
+			t.Fatalf("result BTF = %v, want pointer", res.Btf)
+		}
+	})
+
+	t.Run("reject mismatched return", func(t *testing.T) {
+		_, err := CompileEvalExpr(CompileExprOptions{
+			Expr:       "(unsigned int)$retval",
+			RetvalType: intType,
+			Spec:       testBtf,
+			Kernel:     testBtf,
+			LabelExit:  "exit",
+		})
+		if err == nil || !strings.Contains(err.Error(), "does not match") {
+			t.Fatalf("got error %v, want type mismatch", err)
+		}
+	})
 }

--- a/internal/cc/variable.go
+++ b/internal/cc/variable.go
@@ -10,6 +10,18 @@ import (
 	"rsc.io/c2go/cc"
 )
 
+var builtinVars = map[string]int64{
+	"NULL":  0,
+	"null":  0,
+	"false": 0,
+	"true":  1,
+}
+
+func isBuiltinVar(name string) bool {
+	_, ok := builtinVars[name]
+	return ok
+}
+
 func ExtractVarNames(expr string) ([]string, error) {
 	e, err := cc.ParseExpr(expr)
 	if err != nil {
@@ -24,7 +36,9 @@ func ExtractVarNames(expr string) ([]string, error) {
 	cc.Walk(e, func(node cc.Syntax) {
 		if v, ok := node.(*cc.Expr); ok {
 			if v.Op == cc.Name {
-				names = append(names, v.Text)
+				if !isBuiltinVar(v.Text) {
+					names = append(names, v.Text)
+				}
 			}
 		}
 	}, func(node cc.Syntax) {})

--- a/internal/cc/variable.go
+++ b/internal/cc/variable.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"slices"
 
-	"rsc.io/c2go/cc"
+	c2go "rsc.io/c2go/cc"
 )
 
 var builtinVars = map[string]int64{
@@ -22,28 +22,102 @@ func isBuiltinVar(name string) bool {
 	return ok
 }
 
-func ExtractVarNames(expr string) ([]string, error) {
-	e, err := cc.ParseExpr(expr)
+// ExprAnalysis contains the parser-facing form and variable metadata for an
+// expression. RetvalCast is empty when the expression doesn't use $retval.
+type ExprAnalysis struct {
+	CompilerExpr string
+	Vars         []string
+	RetvalCast   string
+	retvalExpr   *c2go.Expr
+}
+
+func AnalyzeExpr(expr string) (ExprAnalysis, error) {
+	newExpr := rewriteRetval(expr)
+	hasRetval := newExpr != expr
+
+	var analysis ExprAnalysis
+	analysis.CompilerExpr = newExpr
+
+	e, err := c2go.ParseExpr(newExpr)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse expression: %w", err)
+		return analysis, fmt.Errorf("failed to parse expression: %w", err)
 	}
 
-	if e.Op == cc.Call {
-		e = e.List[0]
+	// A top-level helper call's name is not a variable.
+	varsExpr := e
+	if e.Op == c2go.Call && len(e.List) != 0 {
+		varsExpr = e.List[0]
+	}
+
+	var stack []*c2go.Expr
+	uses, castUses := 0, 0
+	var castErr error
+	c2go.Walk(e, func(node c2go.Syntax) {
+		v, ok := node.(*c2go.Expr)
+		if !ok {
+			return
+		}
+		stack = append(stack, v)
+		if v.Op != c2go.Name || v.Text != retvalCompilerName {
+			return
+		}
+		uses++
+
+		for i := len(stack) - 2; i >= 0; i-- {
+			parent := stack[i]
+			if parent.Op == c2go.Paren {
+				continue
+			}
+			if parent.Op != c2go.Cast || !enclosesThroughParens(parent.Left, v) {
+				break
+			}
+			if !validRetvalCast(parent.Type) {
+				castErr = fmt.Errorf("%s has invalid non-scalar cast %q", RetvalName, parent.Type.String())
+				break
+			}
+			castUses++
+			cast := parent.Type.String()
+			if analysis.retvalExpr == nil {
+				analysis.retvalExpr = parent
+				analysis.RetvalCast = cast
+			} else if analysis.RetvalCast != cast {
+				castErr = fmt.Errorf("%s has conflicting casts %q and %q", RetvalName, analysis.RetvalCast, cast)
+			}
+			break
+		}
+	}, func(node c2go.Syntax) {
+		if _, ok := node.(*c2go.Expr); ok {
+			stack = stack[:len(stack)-1]
+		}
+	})
+
+	if hasRetval {
+		if castErr != nil {
+			return analysis, castErr
+		}
+		if analysis.retvalExpr == nil || castUses != uses {
+			return analysis, fmt.Errorf("%s requires an explicit concrete cast", RetvalName)
+		}
 	}
 
 	var names []string
-	cc.Walk(e, func(node cc.Syntax) {
-		if v, ok := node.(*cc.Expr); ok {
-			if v.Op == cc.Name {
-				if !isBuiltinVar(v.Text) {
-					names = append(names, v.Text)
-				}
+	c2go.Walk(varsExpr, func(node c2go.Syntax) {
+		if v, ok := node.(*c2go.Expr); ok && v.Op == c2go.Name {
+			name := v.Text
+			if name == retvalCompilerName {
+				name = RetvalName
+			}
+			if !isBuiltinVar(name) {
+				names = append(names, name)
 			}
 		}
-	}, func(node cc.Syntax) {})
-
+	}, func(c2go.Syntax) {})
 	slices.Sort(names)
-	names = slices.Compact(names)
-	return names, nil
+	analysis.Vars = slices.Compact(names)
+	return analysis, nil
+}
+
+func ExtractVarNames(expr string) ([]string, error) {
+	analysis, err := AnalyzeExpr(expr)
+	return analysis.Vars, err
 }

--- a/t/retval.txt
+++ b/t/retval.txt
@@ -1,0 +1,62 @@
+# Copyright 2026 Leon Hwang.
+# SPDX-License-Identifier: Apache-2.0
+
+# These tests are for typed $retval expressions and packet return values.
+
+# signed scalar filter and output in exit mode
+name: retval::arg:exit
+tag: retval,cc,fnarg,kfuncs
+test: -k __sys_connect -m exit --filter-arg '(int)$retval < 0' --output-arg '(int)$retval' --limit-events 1
+match: (int)'(int)$retval'=-
+trigger: curl --max-time 1 -sS http://127.0.0.1:1/ &>/dev/null || true
+timeout: 10s
+
+---
+
+# deferred filtering releases the buffered function graph after exit
+name: retval::arg:fgraph
+tag: retval,cc,fnarg,kfuncs,fngraph
+test: -k __sys_connect -m entry,exit --filter-arg '(int)$retval < 0' --output-fgraph --fgraph-max-depth 1 --limit-events 1
+match: → __sys_connect
+trigger: curl --max-time 1 -sS http://127.0.0.1:1/ &>/dev/null || true
+timeout: 10s
+
+---
+
+# deferred filtering releases buffered instruction events after exit
+name: retval::arg:insns
+tag: retval,cc,fnarg,kfuncs,fninsn
+test: -k __sys_connect -m entry,exit --filter-arg '(int)$retval < 0' --output-insns --trace-insn-debug-cnt 10 --limit-events 1
+match: insn=
+trigger: curl --max-time 1 -sS http://127.0.0.1:1/ &>/dev/null || true
+timeout: 10s
+
+---
+
+# pointer return output
+name: retval::arg:pointer
+tag: retval,cc,fnarg,kfuncs,pkt
+test: -k skb_recv_datagram -m exit --filter-arg '(struct sk_buff *)$retval != NULL' --output-arg '(struct sk_buff *)$retval' --limit-events 1
+match: (struct sk_buff *)'(struct sk_buff *)$retval'=0xffff
+trigger: ping -c 1 -s 64 127.0.0.1
+timeout: 10s
+
+---
+
+# filters and outputs may use a parameter together with $retval
+name: retval::arg:mixed
+tag: retval,cc,fnarg,kfuncs,pkt
+test: -k skb_recv_datagram -m exit --filter-arg 'sk != NULL && (struct sk_buff *)$retval != NULL' --output-arg 'sk' --output-arg '(struct sk_buff *)$retval' --limit-events 1
+match: (struct sock *)'sk'=0xffff
+trigger: ping -c 1 -s 64 127.0.0.1
+timeout: 10s
+
+---
+
+# packet filtering and output explicitly select a packet-typed return value
+name: retval::pkt
+tag: retval,kfuncs,pkt
+test: -k skb_recv_datagram -m entry,exit --filter-pkt '(r) icmp' --output-pkt '(r)' --limit-events 1
+match: Pkt tuple: 127.0.0.1 -> 127.0.0.1 (ICMP)
+trigger: ping -c 1 -s 64 127.0.0.1
+timeout: 10s


### PR DESCRIPTION
Add retval support for `--filter-arg`, `--output-arg`, `--filter-pkt`, and `--output-pkt`.

For `--filter-arg` and `--output-arg`, '$retval' in the expr indicates the return value. e.g. `(struct sk_buff *)$retval`, a concrete type is required to match the function's return value.

For `--filter-pkt` and `--output-pkt`, '(r)' prefix indicates using the return value. e.g. `--filter-kt '(r) icmp and host 1.1.1.1'` filters the packet of return value, `--output-pkt '(r)'` outputs the packet of return value.

Closes #106 