### PR TITLE
bpfsnoop: Fix showing type info

### DIFF
--- a/internal/bpfsnoop/type_proto.go
+++ b/internal/bpfsnoop/type_proto.go
@@ -39,7 +39,7 @@ func findStructUnionType(typeName string) (btf.Type, error) {
 
 		for _, t := range types {
 			switch t.(type) {
-			case *btf.Struct, *btf.Union:
+			case *btf.Struct, *btf.Union, *btf.Func, *btf.Enum:
 				typ = t
 				return true
 			}
@@ -203,6 +203,8 @@ func showFnProto(fn *btf.Func) {
 
 func showTypeProto(structs []string) {
 	var sb strings.Builder
+
+	assert.NoErr(PrepareKernelBTF(), "Failed to prepare kernel BTF spec: %v")
 
 	for i, s := range structs {
 		if i != 0 {

--- a/t/types.txt
+++ b/t/types.txt
@@ -1,0 +1,29 @@
+# Copyright 2026 Leon Hwang.
+# SPDX-License-Identifier: Apache-2.0
+
+# These tests are for showing types in the kernel.
+
+# icmp_rcv
+name: type::func:icmp_rcv
+tag: type
+test: -C icmp_rcv
+match: int icmp_rcv(struct sk_buff *skb)
+timeout: 5s
+
+---
+
+# bpf_attach_type
+name: type::enum:bpf_attach_type
+tag: type
+test: -C bpf_attach_type
+match: enum bpf_attach_type
+timeout: 5s
+
+---
+
+# bpf_attr
+name: type::union,bpf_attr
+tag: type
+test: -C bpf_attr
+match: union bpf_attr {
+timeout: 5s


### PR DESCRIPTION
Fix the panic:

```bash
$ s ./bpfsnoop -C bpf_attach_type
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x5882b7]
```

And, fix showing type info for function and enum.
